### PR TITLE
Add IS-04 Node Receiver target tests

### DIFF
--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -345,12 +345,14 @@ class IS0401Test(GenericTest):
 
                 receiver = response.json()
                 if receiver["subscription"]["sender_id"] != request_data["id"]:
-                    return test.FAIL("Node API Receiver subscription does not reflect the subscribed Sender ID")
+                    return test.FAIL("Node API Receiver subscription {} does not reflect the subscribed \
+                                      Sender ID", receiver["id"])
 
                 api = self.apis[NODE_API_KEY]
                 if api["major_version"] > 1 or (api["major_version"] == 1 and api["minor_version"] >= 2):
                     if not receiver["subscription"]["active"]:
-                        return test.FAIL("Node API Receiver subscription does not indicate an active subscription")
+                        return test.FAIL("Node API Receiver subscription {} does not indicate an active \
+                                          subscription", receiver["id"])
 
                 formats_tested.append(stream_type)
 
@@ -388,12 +390,14 @@ class IS0401Test(GenericTest):
 
                 receiver = response.json()
                 if receiver["subscription"]["sender_id"] is not None:
-                    return test.FAIL("Node API Receiver subscription does not reflect the subscribed Sender ID")
+                    return test.FAIL("Node API Receiver subscription {} does not reflect the subscribed \
+                                      Sender ID", receiver["id"])
 
                 api = self.apis[NODE_API_KEY]
                 if api["major_version"] > 1 or (api["major_version"] == 1 and api["minor_version"] >= 2):
                     if receiver["subscription"]["active"]:
-                        return test.FAIL("Node API Receiver subscription does not indicate an inactive subscription")
+                        return test.FAIL("Node API Receiver subscription {} does not indicate an inactive \
+                                          subscription", receiver["id"])
 
                 return test.PASS()
         except json.decoder.JSONDecodeError:

--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -321,9 +321,13 @@ class IS0401Test(GenericTest):
             return test.FAIL("Unexpected response from the Node API: {}".format(receivers))
 
         try:
-            if len(receivers.json()) > 0:
-                receiver = receivers.json()[0]
+            formats_tested = []
+            for receiver in receivers.json():
                 stream_type = receiver["format"].split(":")[-1]
+                # Test each available receiver format once
+                if stream_type in formats_tested:
+                    continue
+
                 if stream_type not in ["video", "audio", "data", "mux"]:
                     return test.FAIL("Unexpected Receiver format: {}".format(receiver["format"]))
 
@@ -348,6 +352,9 @@ class IS0401Test(GenericTest):
                     if not receiver["subscription"]["active"]:
                         return test.FAIL("Node API Receiver subscription does not indicate an active subscription")
 
+                formats_tested.append(stream_type)
+
+            if len(formats_tested) > 0:
                 return test.PASS()
         except json.decoder.JSONDecodeError:
             return test.FAIL("Non-JSON response returned from Node API")

--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -345,14 +345,14 @@ class IS0401Test(GenericTest):
 
                 receiver = response.json()
                 if receiver["subscription"]["sender_id"] != request_data["id"]:
-                    return test.FAIL("Node API Receiver subscription {} does not reflect the subscribed \
-                                      Sender ID", receiver["id"])
+                    return test.FAIL("Node API Receiver {} subscription does not reflect the subscribed " \
+                                     "Sender ID".format(receiver["id"]))
 
                 api = self.apis[NODE_API_KEY]
                 if api["major_version"] > 1 or (api["major_version"] == 1 and api["minor_version"] >= 2):
                     if not receiver["subscription"]["active"]:
-                        return test.FAIL("Node API Receiver subscription {} does not indicate an active \
-                                          subscription", receiver["id"])
+                        return test.FAIL("Node API Receiver {} subscription does not indicate an active " \
+                                         "subscription".format(receiver["id"]))
 
                 formats_tested.append(stream_type)
 
@@ -390,14 +390,14 @@ class IS0401Test(GenericTest):
 
                 receiver = response.json()
                 if receiver["subscription"]["sender_id"] is not None:
-                    return test.FAIL("Node API Receiver subscription {} does not reflect the subscribed \
-                                      Sender ID", receiver["id"])
+                    return test.FAIL("Node API Receiver {} subscription does not reflect the subscribed " \
+                                     "Sender ID".format(receiver["id"]))
 
                 api = self.apis[NODE_API_KEY]
                 if api["major_version"] > 1 or (api["major_version"] == 1 and api["minor_version"] >= 2):
                     if receiver["subscription"]["active"]:
-                        return test.FAIL("Node API Receiver subscription {} does not indicate an inactive \
-                                          subscription", receiver["id"])
+                        return test.FAIL("Node API Receiver {} subscription does not indicate an inactive " \
+                                         "subscription".format(receiver["id"]))
 
                 return test.PASS()
         except json.decoder.JSONDecodeError:

--- a/Node.py
+++ b/Node.py
@@ -1,0 +1,72 @@
+# Copyright (C) 2018 British Broadcasting Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+import netifaces
+
+from flask import Blueprint, make_response, abort
+
+
+class Node(object):
+    def __init__(self):
+        pass
+
+    def get_sender(self, stream_type="video"):
+        default_gw_interface = netifaces.gateways()['default'][netifaces.AF_INET][1]
+        default_ip = netifaces.ifaddresses(default_gw_interface)[netifaces.AF_INET][0]['addr']
+        # TODO: Provide the means to downgrade this to a <v1.2 JSON representation
+        sender = {
+            "id": str(uuid.uuid4()),
+            "label": "Dummy Sender",
+            "description": "Dummy Sender",
+            "version": "50:50",
+            "caps": {},
+            "tags": {},
+            "manifest_href": "http://{}:5000/{}.sdp".format(default_ip, stream_type),
+            "flow_id": str(uuid.uuid4()),
+            "transport": "urn:x-nmos:transport:rtp.mcast",
+            "device_id": str(uuid.uuid4()),
+            "interface_bindings": ["eth0"],
+            "subscription": {
+                "receiver_id": None,
+                "active": True
+            }
+        }
+        return sender
+
+
+NODE = Node()
+NODE_API = Blueprint('node_api', __name__)
+
+
+@NODE_API.route('/<stream_type>.sdp', methods=["GET"])
+def node_video_sdp(stream_type):
+    response = None
+    if stream_type == "video":
+        with open("test_data/IS0401/video.sdp") as f:
+            response = make_response(f.read())
+    elif stream_type == "audio":
+        with open("test_data/IS0401/audio.sdp") as f:
+            response = make_response(f.read())
+    elif stream_type == "data":
+        with open("test_data/IS0401/data.sdp") as f:
+            response = make_response(f.read())
+    elif stream_type == "mux":
+        with open("test_data/IS0401/mux.sdp") as f:
+            response = make_response(f.read())
+    else:
+        abort(404)
+
+    response.headers["Content-Type"] = "application/sdp"
+    return response

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -17,6 +17,7 @@
 from flask import Flask, render_template, flash, request
 from wtforms import Form, validators, StringField, SelectField, IntegerField, HiddenField, FormField, FieldList
 from Registry import REGISTRY, REGISTRY_API
+from Node import NODE, NODE_API
 from datetime import datetime, timedelta
 
 import git
@@ -38,6 +39,7 @@ app.debug = True  # Ensures we can debug exceptions more easily
 app.config['SECRET_KEY'] = 'nmos-interop-testing-jtnm'
 app.config['TEST_ACTIVE'] = False
 app.register_blueprint(REGISTRY_API)  # Dependency for IS0401Test
+app.register_blueprint(NODE_API)  # Dependency for IS0401Test
 
 CACHE_PATH = 'cache'
 SPECIFICATIONS = {
@@ -268,7 +270,7 @@ def index_page():
                 test_obj = None
                 if test == "IS-04-01":
                     # This test has an unusual constructor as it requires a registry instance
-                    test_obj = test_def["class"](apis, REGISTRY)
+                    test_obj = test_def["class"](apis, REGISTRY, NODE)
                 else:
                     test_obj = test_def["class"](apis)
 

--- a/test_data/IS0401/audio.sdp
+++ b/test_data/IS0401/audio.sdp
@@ -1,0 +1,12 @@
+v=0
+o=- 1543226711 1543226711 IN IP4 172.29.80.65
+s=Demo Audio Stream
+t=0 0
+m=audio 46848 RTP/AVP 102
+c=IN IP4 232.130.55.188/32
+a=source-filter: incl IN IP4 232.130.55.188 172.29.80.65
+a=ts-refclk:ptp=IEEE1588-2008:ec-46-70-ff-fe-00-ce-de
+a=rtpmap:102 L24/48000/2
+a=mediaclk:direct=0
+a=ptime:1
+a=maxptime:1

--- a/test_data/IS0401/data.sdp
+++ b/test_data/IS0401/data.sdp
@@ -1,0 +1,10 @@
+v=0
+o=- 1543226713 1543226713 IN IP4 172.29.80.65
+s=Demo Data Stream
+t=0 0
+m=video 11437 RTP/AVP 105
+c=IN IP4 232.32.87.86/32
+a=source-filter: incl IN IP4 232.32.87.86 172.29.80.65
+a=ts-refclk:ptp=IEEE1588-2008:ec-46-70-ff-fe-00-ce-de
+a=rtpmap:105 smpte291/90000
+a=mediaclk:direct=0 rate=90000

--- a/test_data/IS0401/mux.sdp
+++ b/test_data/IS0401/mux.sdp
@@ -1,0 +1,8 @@
+v=0
+o=- 198403 11 IN IP4 172.29.80.65
+s=Demo Mux Stream
+t=0 0
+m=video 5000 RTP/AVP 98
+c=IN IP4 232.0.16.1/32
+a=source-filter: incl IN IP4 232.0.16.1 172.29.80.65
+a=rtpmap:98 SMPTE2022-6/27000000

--- a/test_data/IS0401/video.sdp
+++ b/test_data/IS0401/video.sdp
@@ -1,0 +1,11 @@
+v=0
+o=- 1543226715 1543226715 IN IP4 172.29.80.65
+s=Demo Video Stream
+t=0 0
+m=video 27346 RTP/AVP 97
+c=IN IP4 232.80.177.113/32
+a=source-filter: incl IN IP4 232.80.177.113 172.29.80.65
+a=ts-refclk:ptp=IEEE1588-2008:ec-46-70-ff-fe-00-ce-de
+a=rtpmap:97 raw/90000
+a=fmtp:97 sampling=YCbCr-4:2:2; width=1920; height=1080; depth=10; interlace; SSN=ST2110-20:2017; colorimetry=BT709; PM=2110GPM; TP=2110TPW; TCS=SDR; exactframerate=25
+a=mediaclk:direct=0 rate=90000


### PR DESCRIPTION
I've squashed three paper tests into two code tests to make it slightly easier. I'd appreciate this being run against at least one other implementation before it's merged in as there's a good chance some of the SDP file contents will need to be parameterised in order to get them accepted in all cases (for example changing source IPs to something in the range under test).

Resolves https://github.com/bbc/nmos-testing/issues/29