### PR TITLE
Add ability to disable mDNS advertisements via config parameter

### DIFF
--- a/Config.py
+++ b/Config.py
@@ -15,6 +15,9 @@
 # Enable or disable mDNS advertisements. Browsing is always permitted.
 ENABLE_MDNS = True
 
+# Number of seconds to wait after an mDNS advert is created for a client to notice and perform an action
+MDNS_ADVERT_TIMEOUT = 5
+
 # Set a Query API hostname/IP and port for use when operating without mDNS
 QUERY_API_HOST = "127.0.0.1"
 QUERY_API_PORT = 80

--- a/Config.py
+++ b/Config.py
@@ -15,6 +15,10 @@
 # Enable or disable mDNS advertisements. Browsing is always permitted.
 ENABLE_MDNS = True
 
+# Set a Query API hostname/IP and port for use when operating without mDNS
+QUERY_API_HOST = "127.0.0.1"
+QUERY_API_PORT = 80
+
 # Path to store the specification file cache in. Relative to the base of the testing repository.
 CACHE_PATH = 'cache'
 

--- a/Config.py
+++ b/Config.py
@@ -1,0 +1,86 @@
+# Copyright 2018 British Broadcasting Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enable or disable mDNS advertisements. Browsing is always permitted.
+ENABLE_MDNS = True
+
+# Path to store the specification file cache in. Relative to the base of the testing repository.
+CACHE_PATH = 'cache'
+
+# Definition of each API specification and its versions.
+SPECIFICATIONS = {
+    "is-04": {
+        "repo": "nmos-discovery-registration",
+        "versions": ["v1.0", "v1.1", "v1.2", "v1.3"],
+        "default_version": "v1.2",
+        "apis": {
+            "node": {
+                "name": "Node API",
+                "raml": "NodeAPI.raml"
+            },
+            "query": {
+                "name": "Query API",
+                "raml": "QueryAPI.raml"
+            },
+            "registration": {
+                "name": "Registration API",
+                "raml": "RegistrationAPI.raml"
+            }
+        }
+    },
+    "is-05": {
+        "repo": "nmos-device-connection-management",
+        "versions": ["v1.0", "v1.1"],
+        "default_version": "v1.0",
+        "apis": {
+            "connection": {
+                "name": "Connection API",
+                "raml": "ConnectionAPI.raml"
+            }
+        }
+    },
+    "is-06": {
+        "repo": "nmos-network-control",
+        "versions": ["v1.0"],
+        "default_version": "v1.0",
+        "apis": {
+            "netctrl": {
+                "name": "Network API",
+                "raml": "NetworkControlAPI.raml"
+            }
+        }
+    },
+    "is-07": {
+        "repo": "nmos-event-tally",
+        "versions": ["v1.0"],
+        "default_version": "v1.0",
+        "apis": {
+            "events": {
+                "name": "Events API",
+                "raml": "EventsAPI.raml"
+            }
+        }
+    },
+    "is-08": {
+        "repo": "nmos-audio-channel-mapping",
+        "versions": ["v1.0"],
+        "default_version": "v1.0",
+        "apis": {
+            "channelmapping": {
+                "name": "Channel Mapping API",
+                "raml": "ChannelMappingAPI.raml"
+            }
+        }
+    }
+}

--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -24,7 +24,7 @@ from zeroconf_monkey import ServiceBrowser, ServiceInfo, Zeroconf
 from MdnsListener import MdnsListener
 from TestResult import Test
 from GenericTest import GenericTest
-from Config import ENABLE_MDNS, QUERY_API_HOST, QUERY_API_PORT
+from Config import ENABLE_MDNS, QUERY_API_HOST, QUERY_API_PORT, MDNS_ADVERT_TIMEOUT
 
 NODE_API_KEY = "node"
 
@@ -71,7 +71,12 @@ class IS0401Test(GenericTest):
 
         self.zc.register_service(info)
 
-        while (time.time() - self.registry.last_time) < 5:  # Ensure we allow 5 seconds to get at least one heartbeat
+        # Wait for n seconds after advertising the service for the first POST from a Node
+        time.sleep(MDNS_ADVERT_TIMEOUT)
+
+        # Now wait for at least 5 seconds to pass after the last registration was recorded by the mock registry
+        # This ensures we've captured every POST which the Node wants to make, and at least one heartbeat
+        while (time.time() - self.registry.last_time) < 5:
             time.sleep(1)
 
         self.zc.unregister_service(info)

--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -24,6 +24,7 @@ from zeroconf_monkey import ServiceBrowser, ServiceInfo, Zeroconf
 from MdnsListener import MdnsListener
 from TestResult import Test
 from GenericTest import GenericTest
+from Config import ENABLE_MDNS
 
 NODE_API_KEY = "node"
 
@@ -82,6 +83,9 @@ class IS0401Test(GenericTest):
 
         test = Test("Node can discover network registration service via mDNS")
 
+        if not ENABLE_MDNS:
+            return test.MANUAL("This test cannot be performed when ENABLE_MDNS is False")
+
         self.do_registry_basics_prereqs()
 
         if len(self.registry.get_data()) > 0:
@@ -100,6 +104,9 @@ class IS0401Test(GenericTest):
         """Registration API interactions use the correct Content-Type"""
 
         test = Test("Registration API interactions use the correct Content-Type")
+
+        if not ENABLE_MDNS:
+            return test.MANUAL("This test cannot be performed when ENABLE_MDNS is False")
 
         self.do_registry_basics_prereqs()
 
@@ -186,6 +193,9 @@ class IS0401Test(GenericTest):
         test = Test("Node can register a valid Node resource with the network registration service, "
                     "matching its Node API self resource")
 
+        if not ENABLE_MDNS:
+            return test.MANUAL("This test cannot be performed when ENABLE_MDNS is False")
+
         self.do_registry_basics_prereqs()
 
         return self.check_matching_resource(test, "node")
@@ -194,6 +204,9 @@ class IS0401Test(GenericTest):
         """Node maintains itself in the registry via periodic calls to the health resource"""
 
         test = Test("Node maintains itself in the registry via periodic calls to the health resource")
+
+        if not ENABLE_MDNS:
+            return test.MANUAL("This test cannot be performed when ENABLE_MDNS is False")
 
         self.do_registry_basics_prereqs()
 
@@ -242,6 +255,9 @@ class IS0401Test(GenericTest):
         test = Test("Node can register a valid Device resource with the network registration service, "
                     "matching its Node API Device resource")
 
+        if not ENABLE_MDNS:
+            return test.MANUAL("This test cannot currently be performed when ENABLE_MDNS is False")
+
         self.do_registry_basics_prereqs()
 
         return self.check_matching_resource(test, "device")
@@ -252,6 +268,9 @@ class IS0401Test(GenericTest):
 
         test = Test("Node can register a valid Source resource with the network registration service, "
                     "matching its Node API Source resource")
+
+        if not ENABLE_MDNS:
+            return test.MANUAL("This test cannot currently be performed when ENABLE_MDNS is False")
 
         self.do_registry_basics_prereqs()
 
@@ -264,6 +283,9 @@ class IS0401Test(GenericTest):
         test = Test("Node can register a valid Flow resource with the network registration service, "
                     "matching its Node API Flow resource")
 
+        if not ENABLE_MDNS:
+            return test.MANUAL("This test cannot currently be performed when ENABLE_MDNS is False")
+
         self.do_registry_basics_prereqs()
 
         return self.check_matching_resource(test, "flow")
@@ -275,6 +297,9 @@ class IS0401Test(GenericTest):
         test = Test("Node can register a valid Sender resource with the network registration service, "
                     "matching its Node API Sender resource")
 
+        if not ENABLE_MDNS:
+            return test.MANUAL("This test cannot currently be performed when ENABLE_MDNS is False")
+
         self.do_registry_basics_prereqs()
 
         return self.check_matching_resource(test, "sender")
@@ -285,6 +310,9 @@ class IS0401Test(GenericTest):
 
         test = Test("Node can register a valid Receiver resource with the network registration service, "
                     "matching its Node API Receiver resource")
+
+        if not ENABLE_MDNS:
+            return test.MANUAL("This test cannot currently be performed when ENABLE_MDNS is False")
 
         self.do_registry_basics_prereqs()
 

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -18,6 +18,7 @@ from flask import Flask, render_template, flash, request
 from wtforms import Form, validators, StringField, SelectField, IntegerField, HiddenField, FormField, FieldList
 from Registry import REGISTRY, REGISTRY_API
 from Node import NODE, NODE_API
+from Config import CACHE_PATH, SPECIFICATIONS
 from datetime import datetime, timedelta
 
 import git
@@ -34,6 +35,7 @@ import IS0601Test
 import IS0701Test
 import IS0801Test
 
+
 app = Flask(__name__)
 app.debug = True  # Ensures we can debug exceptions more easily
 app.config['SECRET_KEY'] = 'nmos-interop-testing-jtnm'
@@ -41,72 +43,8 @@ app.config['TEST_ACTIVE'] = False
 app.register_blueprint(REGISTRY_API)  # Dependency for IS0401Test
 app.register_blueprint(NODE_API)  # Dependency for IS0401Test
 
-CACHE_PATH = 'cache'
-SPECIFICATIONS = {
-    "is-04": {
-        "repo": "nmos-discovery-registration",
-        "versions": ["v1.0", "v1.1", "v1.2", "v1.3"],
-        "default_version": "v1.2",
-        "apis": {
-            "node": {
-                "name": "Node API",
-                "raml": "NodeAPI.raml"
-            },
-            "query": {
-                "name": "Query API",
-                "raml": "QueryAPI.raml"
-            },
-            "registration": {
-                "name": "Registration API",
-                "raml": "RegistrationAPI.raml"
-            }
-        }
-    },
-    "is-05": {
-        "repo": "nmos-device-connection-management",
-        "versions": ["v1.0", "v1.1"],
-        "default_version": "v1.0",
-        "apis": {
-            "connection": {
-                "name": "Connection API",
-                "raml": "ConnectionAPI.raml"
-            }
-        }
-    },
-    "is-06": {
-        "repo": "nmos-network-control",
-        "versions": ["v1.0"],
-        "default_version": "v1.0",
-        "apis": {
-            "netctrl": {
-                "name": "Network API",
-                "raml": "NetworkControlAPI.raml"
-            }
-        }
-    },
-    "is-07": {
-        "repo": "nmos-event-tally",
-        "versions": ["v1.0"],
-        "default_version": "v1.0",
-        "apis": {
-            "events": {
-                "name": "Events API",
-                "raml": "EventsAPI.raml"
-            }
-        }
-    },
-    "is-08": {
-        "repo": "nmos-audio-channel-mapping",
-        "versions": ["v1.0"],
-        "default_version": "v1.0",
-        "apis": {
-            "channelmapping": {
-                "name": "Channel Mapping API",
-                "raml": "ChannelMappingAPI.raml"
-            }
-        }
-    }
-}
+
+# Definitions of each set of tests made available from the dropdowns
 TEST_DEFINITIONS = {
     "IS-04-01": {
         "name": "IS-04 Node API",


### PR DESCRIPTION
This is a work in progress. Currently it adds a way to disable mDNS advertisements and marks the related tests as manual. Eventually it will include the ability to keep performing some of the tests by using a Query API configured in Config.py and making GET requests to it in the same way that the Riedel test suite used to.