### PR TITLE
Show the human-friendly name like "IS-04 Node API" in results page

### DIFF
--- a/nmos-test.py
+++ b/nmos-test.py
@@ -218,7 +218,7 @@ def index_page():
                     raise ex
                 finally:
                     app.config['TEST_ACTIVE'] = False
-                return render_template("result.html", url=base_url, test=test, result=result)
+                return render_template("result.html", url=base_url, test=test_def["name"], result=result)
             else:
                 flash("Error: This test definition does not exist")
         else:


### PR DESCRIPTION
Since the index page doesn't show the test suite id like "IS-04-01" to the user, only the human-friendly name like "IS-04 Node API", shall we do the same in the results page?