### PR TITLE
Adding test for posting resource without parent

### DIFF
--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -458,27 +458,42 @@ class IS0402Test(GenericTest):
         test = Test("Registration API responds with 400 HTTP code on posting a resource without parent")
 
         api = self.apis[REG_API_KEY]
+
+        resources = ["device", "source", "flow", "sender", "receiver"]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") <= 0:
-            with open("test_data/IS0402/v1.2_device.json") as device_data:
-                device_json = json.load(device_data)
-                if self.is04_reg_utils.compare_api_version(api["version"], "v1.2") < 0:
-                    device_json = self.downgrade_resource("device", device_json, self.apis[REG_API_KEY]["version"])
+            for curr_resource in resources:
+                with open("test_data/IS0402/v1.2_{}.json".format(curr_resource)) as resource_data:
+                    resource_json = json.load(resource_data)
+                    if self.is04_reg_utils.compare_api_version(api["version"], "v1.2") < 0:
+                        resource_json = self.downgrade_resource(curr_resource, resource_json,
+                                                                self.apis[REG_API_KEY]["version"])
 
-                device_json["id"] = str(uuid.uuid4())
-                device_json["node_id"] = str(uuid.uuid4())
+                    resource_json["id"] = str(uuid.uuid4())
 
-                valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": "device",
-                                                                                    "data": device_json})
+                    # Set random uuid for parent (depending on resource type and version)
+                    if curr_resource == "device":
+                        resource_json["node_id"] = str(uuid.uuid4())
+                    elif curr_resource == "flow":
+                        if self.is04_reg_utils.compare_api_version(api["version"], "v1.0") > 0:
+                            resource_json["device_id"] = str(uuid.uuid4())
+                        resource_json["source_id"] = str(uuid.uuid4())
+                    else:
+                        resource_json["device_id"] = str(uuid.uuid4())
 
-                if not valid:
-                    return test.FAIL("Registration API did not respond as expected")
-                elif r.status_code == 200 or r.status_code == 201:
-                    return test.FAIL("Registration API returned wrong HTTP code.")
-                elif r.status_code == 400:
-                    return test.PASS()
-                else:
-                    return test.FAIL(
-                        "Registration API returned an unexpected response: {} {}".format(r.status_code, r.text))
+                    valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": curr_resource,
+                                                                                        "data": resource_json})
+
+                    if not valid:
+                        return test.FAIL("Registration API did not respond as expected")
+                    elif r.status_code == 200 or r.status_code == 201:
+                        return test.FAIL("Registration API returned wrong HTTP code.")
+                    elif r.status_code == 400:
+                        pass
+                    else:
+                        return test.FAIL(
+                            "Registration API returned an unexpected response: {} {}".format(r.status_code, r.text))
+
+            return test.PASS()
 
         return test.FAIL("An unknown error occurred")
 

--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -452,8 +452,7 @@ class IS0402Test(GenericTest):
 
         return test.PASS()
 
-    @test_depends
-    def test_27(self):
+    def test_26(self):
         """Posting resource without parent results in 400"""
         test = Test("Registration API responds with 400 HTTP code on posting a resource without parent")
 


### PR DESCRIPTION
Posting a resource without the parent resource should result in a 400.

Currently only a Device without parent Node is tested. 
Question: Do we want to test all other possible resources additionally?