### PR TITLE
Add JsonValidation for event messages

### DIFF
--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -894,7 +894,7 @@ class IS0402Test(GenericTest):
 
             # Load schema
             if self.is04_reg_utils.compare_api_version(api["version"], "v1.0") == 0:
-                schema = load_resolved_schema(self.apis["query"]["spec_path"],
+                schema = load_resolved_schema(self.apis[QUERY_API_KEY]["spec_path"],
                                               "queryapi-v1.0-subscriptions-websocket.json")
             else:
                 schema = load_resolved_schema(self.apis["query"]["spec_path"],

--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -897,7 +897,7 @@ class IS0402Test(GenericTest):
                 schema = load_resolved_schema(self.apis[QUERY_API_KEY]["spec_path"],
                                               "queryapi-v1.0-subscriptions-websocket.json")
             else:
-                schema = load_resolved_schema(self.apis["query"]["spec_path"],
+                schema = load_resolved_schema(self.apis[QUERY_API_KEY]["spec_path"],
                                               "queryapi-subscriptions-websocket.json")
 
             for resource, resource_data in test_data.items():


### PR DESCRIPTION
Adding the last missing schema validation for the Event messages received via the websocket subscriptions.

As the schema for the event messages is a slightly different case (not reachable via the `QueryAPI.raml`) in comparison to the other schemas, I have to load the schema and validate manually at the moment.

Currently only SYNC messages are validated, but as they have both (`pre` and `post`) messages filled, I think this might be enough and there is no need to validate the messages for MODIFIED, ADD and DELETED as well. Thoughts?