### PR TITLE
Clearer flagging of tests that don't proceed

### DIFF
--- a/GenericTest.py
+++ b/GenericTest.py
@@ -273,7 +273,7 @@ class GenericTest(object):
                                                         api,
                                                         self.apis[api]["version"],
                                                         resource[0].rstrip("/")), self.auto_test_name())
-                return test.NA("No resources found to perform this test")
+                return test.UNCLEAR("No resources found to perform this test")
 
         # Test general URLs with no parameters
         elif not resource[1]['params']:

--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -133,7 +133,7 @@ class IS0401Test(GenericTest):
         test = Test("Node can discover network registration service via mDNS")
 
         if not ENABLE_MDNS:
-            return test.MANUAL("This test cannot be performed when ENABLE_MDNS is False")
+            return test.DISABLED("This test cannot be performed when ENABLE_MDNS is False")
 
         self.do_registry_basics_prereqs()
 
@@ -156,7 +156,7 @@ class IS0401Test(GenericTest):
         test = Test("Registration API interactions use the correct Content-Type")
 
         if not ENABLE_MDNS:
-            return test.MANUAL("This test cannot be performed when ENABLE_MDNS is False")
+            return test.DISABLED("This test cannot be performed when ENABLE_MDNS is False")
 
         self.do_registry_basics_prereqs()
 
@@ -231,7 +231,7 @@ class IS0401Test(GenericTest):
                     node_resources = self.get_node_resources(r.json())
 
                     if len(node_resources) == 0:
-                        return test.NA("No {} resources were found on the Node.".format(res_type.title()))
+                        return test.UNCLEAR("No {} resources were found on the Node.".format(res_type.title()))
 
                     for res_id in node_resources:
                         reg_resource = self.get_registry_resource(res_type, res_id)
@@ -266,7 +266,7 @@ class IS0401Test(GenericTest):
         test = Test("Node maintains itself in the registry via periodic calls to the health resource")
 
         if not ENABLE_MDNS:
-            return test.MANUAL("This test cannot be performed when ENABLE_MDNS is False")
+            return test.DISABLED("This test cannot be performed when ENABLE_MDNS is False")
 
         self.do_registry_basics_prereqs()
 
@@ -439,7 +439,7 @@ class IS0401Test(GenericTest):
         except json.decoder.JSONDecodeError:
             return test.FAIL("Non-JSON response returned from Node API")
 
-        return test.NA("Node API does not expose any Receivers")
+        return test.UNCLEAR("Node API does not expose any Receivers")
 
     def test_14(self):
         """PUTing to a Receiver target resource with an empty JSON object payload is accepted and
@@ -481,7 +481,7 @@ class IS0401Test(GenericTest):
         except json.decoder.JSONDecodeError:
             return test.FAIL("Non-JSON response returned from Node API")
 
-        return test.NA("Node API does not expose any Receivers")
+        return test.UNCLEAR("Node API does not expose any Receivers")
 
     def test_15(self):
         """Node correctly selects a Registration API based on advertised priorities"""
@@ -489,7 +489,7 @@ class IS0401Test(GenericTest):
         test = Test("Node correctly selects a Registration API based on advertised priorities")
 
         if not ENABLE_MDNS:
-            return test.MANUAL("This test cannot be performed when ENABLE_MDNS is False")
+            return test.DISABLED("This test cannot be performed when ENABLE_MDNS is False")
 
         self.do_registry_basics_prereqs()
 
@@ -518,7 +518,7 @@ class IS0401Test(GenericTest):
         test = Test("Node correctly fails over between advertised Registration APIs when one fails")
 
         if not ENABLE_MDNS:
-            return test.MANUAL("This test cannot be performed when ENABLE_MDNS is False")
+            return test.DISABLED("This test cannot be performed when ENABLE_MDNS is False")
 
         self.do_registry_basics_prereqs()
 

--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -544,7 +544,7 @@ class IS0402Test(GenericTest):
             if not valid:
                 return test.FAIL("Query API failed to respond to query")
             elif len(r.json()) == 0:
-                return test.NA("No Nodes found in registry. Test cannot proceed.")
+                return test.MANUAL("No Nodes found in registry. Test cannot proceed.")
         except json.decoder.JSONDecodeError:
             return test.FAIL("Non-JSON response returned")
 
@@ -571,7 +571,7 @@ class IS0402Test(GenericTest):
             if not valid:
                 return test.FAIL("Query API failed to respond to query")
             elif len(r.json()) == 0:
-                return test.NA("No Nodes found in registry. Test cannot proceed.")
+                return test.MANUAL("No Nodes found in registry. Test cannot proceed.")
         except json.decoder.JSONDecodeError:
             return test.FAIL("Non-JSON response returned")
 
@@ -600,7 +600,7 @@ class IS0402Test(GenericTest):
             if not valid:
                 return test.FAIL("Query API failed to respond to query")
             elif len(r.json()) == 0:
-                return test.NA("No Sources found in registry. Test cannot proceed.")
+                return test.MANUAL("No Sources found in registry. Test cannot proceed.")
         except json.decoder.JSONDecodeError:
             return test.FAIL("Non-JSON response returned")
 

--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -79,7 +79,7 @@ class IS0402Test(GenericTest):
                     if priority < 0:
                         return test.FAIL("Priority ('pri') TXT record must be greater than zero.")
                     elif priority >= 100:
-                        return test.FAIL("Priority ('pri') TXT record must be less than 100 for a production instance.")
+                        return test.WARNING("Priority ('pri') TXT record must be less than 100 for a production instance.")
                 except Exception:
                     return test.FAIL("Priority ('pri') TXT record is not an integer.")
 
@@ -93,9 +93,11 @@ class IS0402Test(GenericTest):
 
                     if "api_proto" not in properties:
                         return test.FAIL("No 'api_proto' TXT record found in Registration API advertisement.")
+                    elif properties["api_proto"] == "https":
+                        return test.MANUAL("API protocol is not advertised as 'http'. "
+                                           "This test suite does not currently support 'https'.")
                     elif properties["api_proto"] != "http":
-                        return test.FAIL("API protocol is not advertised as 'http'. "
-                                         "This test suite does not currently support 'https'.")
+                        return test.FAIL("API protocol ('api_proto') TXT record is not 'http' or 'https'.")
 
                 return test.PASS()
         return test.FAIL("No matching mDNS announcement found for Registration API.")
@@ -120,7 +122,7 @@ class IS0402Test(GenericTest):
                     if priority < 0:
                         return test.FAIL("Priority ('pri') TXT record must be greater than zero.")
                     elif priority >= 100:
-                        return test.FAIL("Priority ('pri') TXT record must be less than 100 for a production instance.")
+                        return test.WARNING("Priority ('pri') TXT record must be less than 100 for a production instance.")
                 except Exception:
                     return test.FAIL("Priority ('pri') TXT record is not an integer.")
 
@@ -134,9 +136,11 @@ class IS0402Test(GenericTest):
 
                     if "api_proto" not in properties:
                         return test.FAIL("No 'api_proto' TXT record found in Query API advertisement.")
+                    elif properties["api_proto"] == "https":
+                        return test.MANUAL("API protocol is not advertised as 'http'. "
+                                           "This test suite does not currently support 'https'.")
                     elif properties["api_proto"] != "http":
-                        return test.FAIL("API protocol is not advertised as 'http'. "
-                                         "This test suite does not currently support 'https'.")
+                        return test.FAIL("API protocol ('api_proto') TXT record is not 'http' or 'https'.")
 
                 return test.PASS()
         return test.FAIL("No matching mDNS announcement found for Query API.")
@@ -544,7 +548,7 @@ class IS0402Test(GenericTest):
             if not valid:
                 return test.FAIL("Query API failed to respond to query")
             elif len(r.json()) == 0:
-                return test.MANUAL("No Nodes found in registry. Test cannot proceed.")
+                return test.UNCLEAR("No Nodes found in registry. Test cannot proceed.")
         except json.decoder.JSONDecodeError:
             return test.FAIL("Non-JSON response returned")
 
@@ -571,7 +575,7 @@ class IS0402Test(GenericTest):
             if not valid:
                 return test.FAIL("Query API failed to respond to query")
             elif len(r.json()) == 0:
-                return test.MANUAL("No Nodes found in registry. Test cannot proceed.")
+                return test.UNCLEAR("No Nodes found in registry. Test cannot proceed.")
         except json.decoder.JSONDecodeError:
             return test.FAIL("Non-JSON response returned")
 
@@ -600,7 +604,7 @@ class IS0402Test(GenericTest):
             if not valid:
                 return test.FAIL("Query API failed to respond to query")
             elif len(r.json()) == 0:
-                return test.MANUAL("No Sources found in registry. Test cannot proceed.")
+                return test.UNCLEAR("No Sources found in registry. Test cannot proceed.")
         except json.decoder.JSONDecodeError:
             return test.FAIL("Non-JSON response returned")
 

--- a/IS0501Test.py
+++ b/IS0501Test.py
@@ -106,7 +106,7 @@ class IS0501Test(GenericTest):
                             return test.FAIL(smsg)
                     return test.PASS()
                 else:
-                    return test.NA("Not tested. No resources found.")
+                    return test.UNCLEAR("Not tested. No resources found.")
             else:
                 return test.FAIL(amsg)
         else:
@@ -135,7 +135,7 @@ class IS0501Test(GenericTest):
                             return test.FAIL(smsg)
                     return test.PASS()
                 else:
-                    return test.NA("Not tested. No resources found.")
+                    return test.UNCLEAR("Not tested. No resources found.")
             else:
                 return test.FAIL(amsg)
         else:
@@ -167,7 +167,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(response)
             return test.PASS()
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_06(self):
         """Index of /single/receivers/<uuid>/ matches the spec"""
@@ -194,7 +194,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(response)
             return test.PASS()
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_07(self):
         """Return of /single/senders/<uuid>/constraints/ meets the schema"""
@@ -210,7 +210,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(msg)
             return test.PASS()
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_08(self):
         """Return of /single/receivers/<uuid>/constraints/ meets the schema"""
@@ -226,7 +226,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(msg)
             return test.PASS()
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_09(self):
         """All params listed in /single/senders/<uuid>/constraints/ matches /staged/ and /active/"""
@@ -237,11 +237,11 @@ class IS0501Test(GenericTest):
                 return test.PASS()
             else:
                 if "Not tested. No resources found." in response:
-                    return test.NA(response)
+                    return test.UNCLEAR(response)
                 else:
                     return test.FAIL(response)
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_10(self):
         """All params listed in /single/receivers/<uuid>/constraints/ matches /staged/ and /active/"""
@@ -252,11 +252,11 @@ class IS0501Test(GenericTest):
                 return test.PASS()
             else:
                 if "Not tested. No resources found." in response:
-                    return test.NA(response)
+                    return test.UNCLEAR(response)
                 else:
                     return test.FAIL(response)
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_11(self):
         """Senders are using valid combination of parameters"""
@@ -300,7 +300,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL("Expected constraints array at {} to contain dicts, got {}".format(dest, response))
             return test.PASS()
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_12(self):
         """Receiver are using valid combination of parameters"""
@@ -342,7 +342,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL("Expected constraints array at {} to contain dicts, got {}".format(dest, response))
             return test.PASS()
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_13(self):
         """Return of /single/senders/<uuid>/staged/ meets the schema"""
@@ -358,7 +358,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(msg)
             return test.PASS()
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_14(self):
         """Return of /single/receivers/<uuid>/staged/ meets the schema"""
@@ -374,7 +374,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(msg)
             return test.PASS()
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_15(self):
         """Staged parameters for senders comply with constraints"""
@@ -386,7 +386,7 @@ class IS0501Test(GenericTest):
             else:
                 return test.FAIL(response)
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_16(self):
         """Staged parameters for receivers comply with constraints"""
@@ -398,7 +398,7 @@ class IS0501Test(GenericTest):
             else:
                 return test.FAIL(response)
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_17(self):
         """Sender patch response schema is valid"""
@@ -410,7 +410,7 @@ class IS0501Test(GenericTest):
             else:
                 return test.FAIL(response)
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_18(self):
         """Receiver patch response schema is valid"""
@@ -422,7 +422,7 @@ class IS0501Test(GenericTest):
             else:
                 return test.FAIL(response)
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_19(self):
         """Sender invalid patch is refused"""
@@ -434,7 +434,7 @@ class IS0501Test(GenericTest):
             else:
                 return test.FAIL(response)
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_20(self):
         """Receiver invalid patch is refused"""
@@ -446,7 +446,7 @@ class IS0501Test(GenericTest):
             else:
                 return test.FAIL(response)
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_21(self):
         """Sender id on staged receiver is changeable"""
@@ -475,7 +475,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(response)
             return test.PASS()
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_22(self):
         """Receiver id on staged sender is changeable"""
@@ -504,7 +504,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(response)
             return test.PASS()
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_23(self):
         """Sender transport parameters are changeable"""
@@ -523,7 +523,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(values)
             return test.PASS()
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_24(self):
         """Receiver transport parameters are changeable"""
@@ -543,7 +543,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(values)
             return test.PASS()
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_25(self):
         """Immediate activation of a sender is possible"""
@@ -558,7 +558,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(response)
             return test.PASS()
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_26(self):
         """Immediate activation of a receiver is possible"""
@@ -573,7 +573,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(response)
             return test.PASS()
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_27(self):
         """Relative activation of a sender is possible"""
@@ -588,7 +588,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(response)
             return test.PASS(response)
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_28(self):
         """Relative activation of a receiver is possible"""
@@ -603,7 +603,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(response)
             return test.PASS(response)
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_29(self):
         """Absolute activation of a sender is possible"""
@@ -618,7 +618,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(response)
             return test.PASS(response)
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_30(self):
         """Absolute activation of a receiver is possible"""
@@ -633,7 +633,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(response)
             return test.PASS(response)
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_31(self):
         """Sender active response schema is valid"""
@@ -649,7 +649,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(response)
             return test.PASS()
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_32(self):
         """Receiver active response schema is valid"""
@@ -665,7 +665,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(response)
             return test.PASS()
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_33(self):
         """/bulk/ endpoint returns correct JSON"""
@@ -712,7 +712,7 @@ class IS0501Test(GenericTest):
             else:
                 return test.FAIL(response)
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_37(self):
         """Bulk interface can be used to change destination port on all receivers"""
@@ -724,7 +724,7 @@ class IS0501Test(GenericTest):
             else:
                 return test.FAIL(response)
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_38(self):
         """Number of legs matches on constraints, staged and active endpoint for senders"""
@@ -739,7 +739,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(response)
             return test.PASS()
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_39(self):
         """Number of legs matches on constraints, staged and active endpoint for receivers"""
@@ -754,7 +754,7 @@ class IS0501Test(GenericTest):
                     return test.FAIL(response)
             return test.PASS()
         else:
-            return test.NA("Not tested. No resources found.")
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_40(self):
         """Only valid transport types for a given API version are advertised"""
@@ -781,7 +781,7 @@ class IS0501Test(GenericTest):
                         return test.FAIL("Unexpected response from active resource for Receiver {}".format(receiver))
                 return test.PASS()
             else:
-                return test.NA("Not tested. No resources found.")
+                return test.UNCLEAR("Not tested. No resources found.")
         else:
             if len(self.senders) or len(self.receivers):
                 for sender in self.senders:
@@ -804,7 +804,7 @@ class IS0501Test(GenericTest):
                         return test.FAIL("Unexpected response from transporttype resource for Receiver {}".format(receiver))
                 return test.PASS()
             else:
-                return test.NA("Not tested. No resources found.")
+                return test.UNCLEAR("Not tested. No resources found.")
 
 
     def check_bulk_stage(self, port, portList):

--- a/IS0502Test.py
+++ b/IS0502Test.py
@@ -350,7 +350,7 @@ class IS0502Test(GenericTest):
             return test.FAIL(result)
 
         if len(self.is05_resources[resource_type]) == 0:
-            return test.NA("Could not find any IS-05 Receivers to test")
+            return test.UNCLEAR("Could not find any IS-05 Receivers to test")
 
         valid, response = self.activate_check_version(resource_type)
         if not valid:
@@ -373,7 +373,7 @@ class IS0502Test(GenericTest):
             return test.FAIL(result)
 
         if len(self.is05_resources[resource_type]) == 0:
-            return test.NA("Could not find any IS-05 Senders to test")
+            return test.UNCLEAR("Could not find any IS-05 Senders to test")
 
         valid, response = self.activate_check_version(resource_type)
         if not valid:
@@ -396,7 +396,7 @@ class IS0502Test(GenericTest):
             return test.FAIL(result)
 
         if len(self.is05_resources[resource_type]) == 0:
-            return test.NA("Could not find any IS-05 Receivers to test")
+            return test.UNCLEAR("Could not find any IS-05 Receivers to test")
 
         valid, response = self.activate_check_parked(resource_type)
         if not valid:
@@ -423,7 +423,7 @@ class IS0502Test(GenericTest):
             return test.FAIL(result)
 
         if len(self.is05_resources[resource_type]) == 0:
-            return test.NA("Could not find any IS-05 Receivers to test")
+            return test.UNCLEAR("Could not find any IS-05 Receivers to test")
 
         valid, response = self.activate_check_parked(resource_type)
         if not valid:
@@ -454,7 +454,7 @@ class IS0502Test(GenericTest):
             return test.FAIL(result)
 
         if len(self.is05_resources[resource_type]) == 0:
-            return test.NA("Could not find any IS-05 Senders to test")
+            return test.UNCLEAR("Could not find any IS-05 Senders to test")
 
         valid, response = self.activate_check_parked(resource_type)
         if not valid:
@@ -485,7 +485,7 @@ class IS0502Test(GenericTest):
             return test.FAIL(result)
 
         if len(self.is05_resources[resource_type]) == 0:
-            return test.NA("Could not find any IS-05 Senders to test")
+            return test.UNCLEAR("Could not find any IS-05 Senders to test")
 
         valid, response = self.activate_check_parked(resource_type)
         if not valid:
@@ -516,7 +516,7 @@ class IS0502Test(GenericTest):
             return test.FAIL(result)
 
         if len(self.is05_resources[resource_type]) == 0:
-            return test.NA("Could not find any IS-05 Senders to test")
+            return test.UNCLEAR("Could not find any IS-05 Senders to test")
 
         valid, response = self.activate_check_parked(resource_type)
         if not valid:

--- a/TestResult.py
+++ b/TestResult.py
@@ -27,17 +27,36 @@ class Test(object):
     def _time_elapsed(self):
         return "{0:.3f}s".format(time.time() - self.timer)
 
+    # Pass: Successful test case
     def PASS(self, detail=""):
-        return [self.description, "Pass", detail, self.name, self._time_elapsed()]
+        return [self.description, "Pass", "bg-success", detail, self.name, self._time_elapsed()]
 
+    # Warning: Not a failure, but the API being tested is responding or configured in a way which is
+    # not recommended in most cases
+    def WARNING(self, detail=""):
+        return [self.description, "Warning", "bg-warning", detail, self.name, self._time_elapsed()]
+
+    # Manual: Test suite does not currently test this feature, so it must be tested manually
     def MANUAL(self, detail=""):
-        return [self.description, "Manual", detail, self.name, self._time_elapsed()]
+        return [self.description, "Manual", "bg-primary", detail, self.name, self._time_elapsed()]
 
+    # Not Applicable: Test is not applicable, e.g. due to the version of the specification being tested
     def NA(self, detail):
-        return [self.description, "N/A", detail, self.name, self._time_elapsed()]
+        return [self.description, "Not Applicable", "bg-secondary", detail, self.name, self._time_elapsed()]
 
+    # Fail: Required feature of the specification has been found to be implemented incorrectly
     def FAIL(self, detail):
-        return [self.description, "Fail", detail, self.name, self._time_elapsed()]
+        return [self.description, "Fail", "bg-danger", detail, self.name, self._time_elapsed()]
 
+    # Optional: Recommended/optional feature of the specifications has been found to be not implemented
+    # Detail message should explain the effect of this feature being unimplemented
     def OPTIONAL(self, detail):
-        return [self.description, "Not Implemented", detail, self.name, self._time_elapsed()]
+        return [self.description, "Not Implemented", "bg-warning", detail, self.name, self._time_elapsed()]
+
+    # Disabled: Test is disabled due to test suite configuration; change the config or test manually
+    def DISABLED(self, detail=""):
+        return [self.description, "Test Disabled", "bg-warning", detail, self.name, self._time_elapsed()]
+
+    # Unclear: Test was not run due to prior responses from the API, which may be OK, or indicate a fault
+    def UNCLEAR(self, detail=""):
+        return [self.description, "Could Not Test", "bg-warning", detail, self.name, self._time_elapsed()]

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -63,7 +63,7 @@ th {
     font-weight: bold;
 }
 
-.notavailable {
+.notapplicable {
     text-align: center;
     font-weight: bold;
 }
@@ -92,7 +92,7 @@ th {
         background-color: #17a2b8 !important
     }
 
-    .table td.notavailable {
+    .table td.notapplicable {
         background-color: #6c757d !important
     }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -68,7 +68,7 @@ th {
     font-weight: bold;
 }
 
-.optional {
+.notimplemented {
     text-align: center;
     font-weight: bold;
 }
@@ -100,7 +100,7 @@ th {
       background-color: #dc3545 !important
     }
 
-    .table td.optional {
+    .table td.notimplemented {
       background-color: #ffc107 !important
     }
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -48,27 +48,7 @@ th {
     text-align: center;
 }
 
-.pass {
-    text-align: center;
-    font-weight: bold;
-}
-
-.fail {
-    text-align: center;
-    font-weight: bold;
-}
-
-.manual {
-    text-align: center;
-    font-weight: bold;
-}
-
-.notapplicable {
-    text-align: center;
-    font-weight: bold;
-}
-
-.notimplemented {
+.pass_state {
     text-align: center;
     font-weight: bold;
 }
@@ -84,23 +64,27 @@ th {
 
 /* Override bootstrap print behaviour */
 @media print{
-    .table td.pass {
+    .table td.bg-success {
         background-color: #28a745 !important
     }
 
-    .table td.manual {
+    .table td.bg-info {
         background-color: #17a2b8 !important
     }
 
-    .table td.notapplicable {
+    .table td.bg-primary {
+        background-color: #007bff !important
+    }
+
+    .table td.bg-secondary {
         background-color: #6c757d !important
     }
 
-    .table td.fail {
+    .table td.bg-danger {
       background-color: #dc3545 !important
     }
 
-    .table td.notimplemented {
+    .table td.bg-warning {
       background-color: #ffc107 !important
     }
 }

--- a/templates/result.html
+++ b/templates/result.html
@@ -50,7 +50,7 @@
                         {% elif curr_result[1] == "Manual" %}
                             <td class="bg-info manual">{{ curr_result[1] }}</td>
                         {% elif curr_result[1] == "N/A" %}
-                            <td class="bg-secondary notavailable">{{ curr_result[1] }}</td>
+                            <td class="bg-secondary notapplicable">{{ curr_result[1] }}</td>
                         {% elif curr_result[1] == "Not Implemented" %}
                             <td class="bg-warning notimplemented">{{ curr_result[1] }}</td>
                         {% else %}

--- a/templates/result.html
+++ b/templates/result.html
@@ -52,7 +52,7 @@
                         {% elif curr_result[1] == "N/A" %}
                             <td class="bg-secondary notavailable">{{ curr_result[1] }}</td>
                         {% elif curr_result[1] == "Not Implemented" %}
-                            <td class="bg-warning optional">{{ curr_result[1] }}</td>
+                            <td class="bg-warning notimplemented">{{ curr_result[1] }}</td>
                         {% else %}
                             <td class="bg-danger fail">{{ curr_result[1] }}</td>
                         {% endif %}

--- a/templates/result.html
+++ b/templates/result.html
@@ -44,21 +44,11 @@
             <tbody>
                 {% for curr_result in result %}
                     <tr>
-                        <td>{{ curr_result[3] }}</td>
-                        {% if curr_result[1] == "Pass" %}
-                            <td class="bg-success pass">{{ curr_result[1] }}</td>
-                        {% elif curr_result[1] == "Manual" %}
-                            <td class="bg-info manual">{{ curr_result[1] }}</td>
-                        {% elif curr_result[1] == "N/A" %}
-                            <td class="bg-secondary notapplicable">{{ curr_result[1] }}</td>
-                        {% elif curr_result[1] == "Not Implemented" %}
-                            <td class="bg-warning notimplemented">{{ curr_result[1] }}</td>
-                        {% else %}
-                            <td class="bg-danger fail">{{ curr_result[1] }}</td>
-                        {% endif %}
-                        <td>{{ curr_result[0] }}</td>
-                        <td>{{ curr_result[2] }}</td>
                         <td>{{ curr_result[4] }}</td>
+                        <td class="{{ curr_result[2] }} pass_state">{{ curr_result[1] }}</td>
+                        <td>{{ curr_result[0] }}</td>
+                        <td>{{ curr_result[3] }}</td>
+                        <td>{{ curr_result[5] }}</td>
                     </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION
When a test cannot proceed because of a temporary condition (e.g. no resources of a particular type in a Registry) it seems better to clearly flag that as needing manual intervention (e.g. register a node with the appropriate resources), rather than as N/A.

Maybe there's a confusion in the meaning of "N/A"... "Not Applicable" or "Not Available". The CSS class is "notavailable", but most uses are like ``test.NA("This test does not apply to v1.0")``.

I didn't apply the same to the Node API tests, because a Node could reasonably never have resources of a particular type.

Other initial commit is a simple rename because the "Not Implemented" status wasn't rendering correctly in my web browser.