### PR TITLE
Add config option to restrict number of iterations for some tests

### DIFF
--- a/Config.py
+++ b/Config.py
@@ -34,6 +34,10 @@ CACHE_PATH = 'cache'
 # Timeout for any HTTP requests
 HTTP_TIMEOUT = 1
 
+# Restrict the maximum number of resources that time consuming tests run against.
+# 0 = unlimited for a really thorough test!
+MAX_TEST_ITERATIONS = 0
+
 # Definition of each API specification and its versions.
 SPECIFICATIONS = {
     "is-04": {

--- a/IS0501Test.py
+++ b/IS0501Test.py
@@ -548,7 +548,7 @@ class IS0501Test(GenericTest):
         """Immediate activation of a sender is possible"""
         test = Test("Immediate activation of a sender is possible")
         if len(self.senders) > 0:
-            for sender in self.senders:
+            for sender in self.is05_utils.sampled_list(self.senders):
                 valid, response = self.is05_utils.check_activation("sender", sender,
                                                                    self.is05_utils.check_perform_immediate_activation)
                 if valid:
@@ -563,13 +563,14 @@ class IS0501Test(GenericTest):
         """Immediate activation of a receiver is possible"""
         test = Test("Immediate activation of a receiver is possible")
         if len(self.receivers) > 0:
-            for receiver in self.receivers:
+            for receiver in self.is05_utils.sampled_list(self.receivers):
                 valid, response = self.is05_utils.check_activation("receiver", receiver,
                                                                    self.is05_utils.check_perform_immediate_activation)
                 if valid:
                     pass
                 else:
                     return test.FAIL(response)
+
             return test.PASS()
         else:
             return test.NA("Not tested. No resources found.")
@@ -578,7 +579,7 @@ class IS0501Test(GenericTest):
         """Relative activation of a sender is possible"""
         test = Test("Relative activation of a sender is possible")
         if len(self.senders) > 0:
-            for sender in self.senders:
+            for sender in self.is05_utils.sampled_list(self.senders):
                 valid, response = self.is05_utils.check_activation("sender", sender,
                                                                    self.is05_utils.check_perform_relative_activation)
                 if valid:
@@ -593,7 +594,7 @@ class IS0501Test(GenericTest):
         """Relative activation of a receiver is possible"""
         test = Test("Relative activation of a receiver is possible")
         if len(self.receivers) > 0:
-            for receiver in self.receivers:
+            for receiver in self.is05_utils.sampled_list(self.receivers):
                 valid, response = self.is05_utils.check_activation("receiver", receiver,
                                                                    self.is05_utils.check_perform_relative_activation)
                 if valid:
@@ -608,7 +609,7 @@ class IS0501Test(GenericTest):
         """Absolute activation of a sender is possible"""
         test = Test("Absolute activation of a sender is possible")
         if len(self.senders) > 0:
-            for sender in self.senders:
+            for sender in self.is05_utils.sampled_list(self.senders):
                 valid, response = self.is05_utils.check_activation("sender", sender,
                                                                    self.is05_utils.check_perform_absolute_activation)
                 if valid:
@@ -623,7 +624,7 @@ class IS0501Test(GenericTest):
         """Absolute activation of a receiver is possible"""
         test = Test("Absolute activation of a receiver is possible")
         if len(self.receivers) > 0:
-            for receiver in self.receivers:
+            for receiver in self.is05_utils.sampled_list(self.receivers):
                 valid, response = self.is05_utils.check_activation("receiver", receiver,
                                                                    self.is05_utils.check_perform_absolute_activation)
                 if valid:
@@ -804,7 +805,6 @@ class IS0501Test(GenericTest):
                 return test.PASS()
             else:
                 return test.NA("Not tested. No resources found.")
-
 
     def check_bulk_stage(self, port, portList):
         """Test changing staged parameters on the bulk interface"""

--- a/NMOSUtils.py
+++ b/NMOSUtils.py
@@ -14,6 +14,9 @@
 
 import time
 from urllib.parse import urlparse
+from random import sample
+
+from Config import MAX_TEST_ITERATIONS
 
 # The UTC leap seconds table below was extracted from the information provided at
 # http://www.ietf.org/timezones/data/leap-seconds.list
@@ -137,3 +140,9 @@ class NMOSUtils(object):
             return False
 
         return True
+
+    def sampled_list(self, resource_list):
+        if MAX_TEST_ITERATIONS > 0:
+            return sample(resource_list, min(MAX_TEST_ITERATIONS, len(resource_list)))
+        else:
+            return resource_list


### PR DESCRIPTION
Resolves #84 

@billt-hlit could you see if this resolves your issue? You'll need to configure an appropriate limit in Config.py.

I've applied the limit to the obvious slow tests in IS0501, but I'm sure there are others elsewhere. If you're immediately aware of any others that cause a pain point please let me know and I'll include them here, otherwise we'll catch them later.