### PR TITLE
Tests of Query API cursor-based pagination

### DIFF
--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -316,7 +316,7 @@ class IS0402Test(GenericTest):
     @test_depends
     def test_15(self):
         """Updating Node resource results in 200"""
-        test = Test("Registration API responds with 200 HTTP code on updating an registered Node")
+        test = Test("Registration API responds with 200 HTTP code on updating a registered Node")
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -333,7 +333,7 @@ class IS0402Test(GenericTest):
     @test_depends
     def test_16(self):
         """Updating Device resource results in 200"""
-        test = Test("Registration API responds with 200 HTTP code on updating an registered Device")
+        test = Test("Registration API responds with 200 HTTP code on updating a registered Device")
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -351,7 +351,7 @@ class IS0402Test(GenericTest):
     @test_depends
     def test_17(self):
         """Updating Source resource results in 200"""
-        test = Test("Registration API responds with 200 HTTP code on updating an registered Source")
+        test = Test("Registration API responds with 200 HTTP code on updating a registered Source")
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -368,7 +368,7 @@ class IS0402Test(GenericTest):
     @test_depends
     def test_18(self):
         """Updating Flow resource results in 200"""
-        test = Test("Registration API responds with 200 HTTP code on updating an registered Flow")
+        test = Test("Registration API responds with 200 HTTP code on updating a registered Flow")
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -386,7 +386,7 @@ class IS0402Test(GenericTest):
     @test_depends
     def test_19(self):
         """Updating Sender resource results in 200"""
-        test = Test("Registration API responds with 200 HTTP code on updating an registered Sender")
+        test = Test("Registration API responds with 200 HTTP code on updating a registered Sender")
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -403,7 +403,7 @@ class IS0402Test(GenericTest):
     @test_depends
     def test_20(self):
         """Updating Receiver resource results in 200"""
-        test = Test("Registration API responds with 200 HTTP code on updating an registered Receiver")
+        test = Test("Registration API responds with 200 HTTP code on updating a registered Receiver")
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:

--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -1031,6 +1031,9 @@ class IS0402Test(GenericTest):
         elif self.is04_query_utils.compare_api_version(api["version"], "v1.3") >= 0 and r.status_code == 501:
             return test.OPTIONAL("Query API signalled that it does not support basic queries. This may be important for"
                                  " scalability.", "https://github.com/AMWA-TV/nmos/wiki/IS-04#registries-basic-queries")
+        elif r.status_code != 200:
+            raise NMOSTestException(test.FAIL("Query API returned an unexpected response: "
+                                              "{} {}".format(r.status_code, r.text)))
         elif len(r.json()) > 0:
             return test.FAIL("Query API returned more records than expected for query: {}".format(query_string))
 
@@ -1062,6 +1065,13 @@ class IS0402Test(GenericTest):
             return test.OPTIONAL("Query API signalled that it does not support RQL queries. This may be important for "
                                  "scalability.",
                                  "https://github.com/AMWA-TV/nmos/wiki/IS-04#registries-resource-query-language-rql")
+        elif r.status_code == 400:
+            return test.OPTIONAL("Query API signalled that it refused to support this RQL query: "
+                                 "{}".format(query_string),
+                                 "https://github.com/AMWA-TV/nmos/wiki/IS-04#registries-resource-query-language-rql")
+        elif r.status_code != 200:
+            raise NMOSTestException(test.FAIL("Query API returned an unexpected response: "
+                                              "{} {}".format(r.status_code, r.text)))
         elif len(r.json()) > 0:
             return test.FAIL("Query API returned more records than expected for query: {}".format(query_string))
 
@@ -1092,6 +1102,13 @@ class IS0402Test(GenericTest):
         elif r.status_code == 501:
             return test.OPTIONAL("Query API signalled that it does not support ancestry queries.",
                                  "https://github.com/AMWA-TV/nmos/wiki/IS-04#registries-ancestry-queries")
+        elif r.status_code == 400:
+            return test.OPTIONAL("Query API signalled that it refused to support this ancestry query: "
+                                 "{}".format(query_string),
+                                 "https://github.com/AMWA-TV/nmos/wiki/IS-04#registries-ancestry-queries")
+        elif r.status_code != 200:
+            raise NMOSTestException(test.FAIL("Query API returned an unexpected response: "
+                                              "{} {}".format(r.status_code, r.text)))
         elif len(r.json()) > 0:
             return test.FAIL("Query API returned more records than expected for query: {}".format(query_string))
 

--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -158,15 +158,9 @@ class IS0402Test(GenericTest):
             if self.is04_reg_utils.compare_api_version(api["version"], "v1.2") < 0:
                 node_json = self.downgrade_resource("node", node_json, self.apis[REG_API_KEY]["version"])
 
-            valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": "node", "data": node_json})
+            self.post_resource(test, "node", node_json, 201)
 
-            if not valid:
-                return test.FAIL("Registration API did not respond as expected")
-            elif r.status_code == 201:
-                return test.PASS()
-            else:
-                return test.FAIL("Registration API returned an unexpected response: {} {}"
-                                 .format(r.status_code, r.text))
+            return test.PASS()
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
@@ -191,16 +185,9 @@ class IS0402Test(GenericTest):
             if self.is04_reg_utils.compare_api_version(api["version"], "v1.2") < 0:
                 device_json = self.downgrade_resource("device", device_json, self.apis[REG_API_KEY]["version"])
 
-            valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": "device",
-                                                                                "data": device_json})
+            self.post_resource(test, "device", device_json, 201)
 
-            if not valid:
-                return test.FAIL("Registration API did not respond as expected")
-            elif r.status_code == 201:
-                return test.PASS()
-            else:
-                return test.FAIL("Registration API returned an unexpected response: {} {}".format(r.status_code,
-                                                                                                  r.text))
+            return test.PASS()
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
@@ -225,16 +212,9 @@ class IS0402Test(GenericTest):
             if self.is04_reg_utils.compare_api_version(api["version"], "v1.2") < 0:
                 source_json = self.downgrade_resource("source", source_json, self.apis[REG_API_KEY]["version"])
 
-            valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": "source",
-                                                                                "data": source_json})
+            self.post_resource(test, "source", source_json, 201)
 
-            if not valid:
-                return test.FAIL("Registration API did not respond as expected")
-            elif r.status_code == 201:
-                return test.PASS()
-            else:
-                return test.FAIL("Registration API returned an unexpected response: {} {}"
-                                 .format(r.status_code, r.text))
+            return test.PASS()
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
@@ -259,16 +239,10 @@ class IS0402Test(GenericTest):
 
             if self.is04_reg_utils.compare_api_version(api["version"], "v1.2") < 0:
                 flow_json = self.downgrade_resource("flow", flow_json, self.apis[REG_API_KEY]["version"])
-            valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": "flow",
-                                                                                "data": flow_json})
 
-            if not valid:
-                return test.FAIL("Registration API did not respond as expected")
-            elif r.status_code == 201:
-                return test.PASS()
-            else:
-                return test.FAIL("Registration API returned an unexpected response: {} {}"
-                                 .format(r.status_code, r.text))
+            self.post_resource(test, "flow", flow_json, 201)
+
+            return test.PASS()
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
@@ -292,16 +266,10 @@ class IS0402Test(GenericTest):
             sender_json = deepcopy(self.test_data["sender"])
             if self.is04_reg_utils.compare_api_version(api["version"], "v1.2") < 0:
                 sender_json = self.downgrade_resource("sender", sender_json, self.apis[REG_API_KEY]["version"])
-            valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": "sender",
-                                                                                "data": sender_json})
 
-            if not valid:
-                return test.FAIL("Registration API did not respond as expected")
-            elif r.status_code == 201:
-                return test.PASS()
-            else:
-                return test.FAIL("Registration API returned an unexpected response: {} {}"
-                                 .format(r.status_code, r.text))
+            self.post_resource(test, "sender", sender_json, 201)
+
+            return test.PASS()
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
@@ -325,16 +293,10 @@ class IS0402Test(GenericTest):
             receiver_json = deepcopy(self.test_data["receiver"])
             if self.is04_reg_utils.compare_api_version(api["version"], "v1.2") < 0:
                 receiver_json = self.downgrade_resource("receiver", receiver_json, self.apis[REG_API_KEY]["version"])
-            valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": "receiver",
-                                                                                "data": receiver_json})
 
-            if not valid:
-                return test.FAIL("Registration API did not respond as expected")
-            elif r.status_code == 201:
-                return test.PASS()
-            else:
-                return test.FAIL("Registration API returned an unexpected response: {} {}"
-                                 .format(r.status_code, r.text))
+            self.post_resource(test, "receiver", receiver_json, 201)
+
+            return test.PASS()
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
@@ -357,20 +319,10 @@ class IS0402Test(GenericTest):
             node_json = deepcopy(self.test_data["node"])
             if self.is04_reg_utils.compare_api_version(api["version"], "v1.2") < 0:
                 node_json = self.downgrade_resource("node", node_json, self.apis[REG_API_KEY]["version"])
-            self.bump_resource_version(node_json)
 
-            valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": "node", "data": node_json})
+            self.post_resource(test, "node", node_json, 200)
 
-            if not valid:
-                return test.FAIL("Registration API did not respond as expected")
-            elif r.status_code == 201:
-                return test.FAIL("Registration API returned wrong HTTP code.")
-            elif r.status_code == 200:
-                return test.PASS()
-            else:
-                return test.FAIL("Registration API returned an unexpected response: {} {}"
-                                 .format(r.status_code, r.text))
-
+            return test.PASS()
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
@@ -386,21 +338,9 @@ class IS0402Test(GenericTest):
             if self.is04_reg_utils.compare_api_version(api["version"], "v1.2") < 0:
                 device_json = self.downgrade_resource("device", device_json, self.apis[REG_API_KEY]["version"])
 
-            self.bump_resource_version(device_json)
+            self.post_resource(test, "device", device_json, 200)
 
-            valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": "device",
-                                                                                "data": device_json})
-
-            if not valid:
-                return test.FAIL("Registration API did not respond as expected")
-            elif r.status_code == 201:
-                return test.FAIL("Registration API returned wrong HTTP code.")
-            elif r.status_code == 200:
-                return test.PASS()
-            else:
-                return test.FAIL("Registration API returned an unexpected response: {} {}".format(r.status_code,
-                                                                                                  r.text))
-
+            return test.PASS()
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
@@ -415,21 +355,9 @@ class IS0402Test(GenericTest):
             if self.is04_reg_utils.compare_api_version(api["version"], "v1.2") < 0:
                 source_json = self.downgrade_resource("source", source_json, self.apis[REG_API_KEY]["version"])
 
-            self.bump_resource_version(source_json)
+            self.post_resource(test, "source", source_json, 200)
 
-            valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": "source",
-                                                                                "data": source_json})
-
-            if not valid:
-                return test.FAIL("Registration API did not respond as expected")
-            elif r.status_code == 201:
-                return test.FAIL("Registration API returned wrong HTTP code.")
-            elif r.status_code == 200:
-                return test.PASS()
-            else:
-                return test.FAIL("Registration API returned an unexpected response: {} {}"
-                                 .format(r.status_code, r.text))
-
+            return test.PASS()
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
@@ -445,21 +373,9 @@ class IS0402Test(GenericTest):
             if self.is04_reg_utils.compare_api_version(api["version"], "v1.2") < 0:
                 flow_json = self.downgrade_resource("flow", flow_json, self.apis[REG_API_KEY]["version"])
 
-            self.bump_resource_version(flow_json)
+            self.post_resource(test, "flow", flow_json, 200)
 
-            valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": "flow",
-                                                                                "data": flow_json})
-
-            if not valid:
-                return test.FAIL("Registration API did not respond as expected")
-            elif r.status_code == 201:
-                return test.FAIL("Registration API returned wrong HTTP code.")
-            elif r.status_code == 200:
-                return test.PASS()
-            else:
-                return test.FAIL("Registration API returned an unexpected response: {} {}"
-                                 .format(r.status_code, r.text))
-
+            return test.PASS()
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
@@ -474,21 +390,9 @@ class IS0402Test(GenericTest):
             if self.is04_reg_utils.compare_api_version(api["version"], "v1.2") < 0:
                 sender_json = self.downgrade_resource("sender", sender_json, self.apis[REG_API_KEY]["version"])
 
-            self.bump_resource_version(sender_json)
+            self.post_resource(test, "sender", sender_json, 200)
 
-            valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": "sender",
-                                                                                "data": sender_json})
-
-            if not valid:
-                return test.FAIL("Registration API did not respond as expected")
-            elif r.status_code == 201:
-                return test.FAIL("Registration API returned wrong HTTP code.")
-            elif r.status_code == 200:
-                return test.PASS()
-            else:
-                return test.FAIL("Registration API returned an unexpected response: {} {}"
-                                 .format(r.status_code, r.text))
-
+            return test.PASS()
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
@@ -504,19 +408,9 @@ class IS0402Test(GenericTest):
                 receiver_json = self.downgrade_resource("receiver", receiver_json,
                                                         self.apis[REG_API_KEY]["version"])
 
-            valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": "receiver",
-                                                                                "data": receiver_json})
-            self.bump_resource_version(receiver_json)
+            self.post_resource(test, "receiver", receiver_json, 200)
 
-            if not valid:
-                return test.FAIL("Registration API did not respond as expected")
-            elif r.status_code == 201:
-                return test.FAIL("Registration API returned wrong HTTP code.")
-            elif r.status_code == 200:
-                return test.PASS()
-            else:
-                return test.FAIL("Registration API returned an unexpected response: {} {}"
-                                 .format(r.status_code, r.text))
+            return test.PASS()
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
@@ -550,13 +444,7 @@ class IS0402Test(GenericTest):
             # For debugging
             node_data["tags"]["index"] = [str(_)]
 
-            valid_post, r = self.do_request("POST", self.reg_url + "resource",
-                                            data = {"type": "node", "data": node_data})
-            if not valid_post:
-                raise NMOSTestException(test.FAIL("Cannot POST sample data. Cannot execute test: {}".format(r)))
-            elif r.status_code != 201:
-                raise NMOSTestException(test.FAIL("Cannot POST sample data. Cannot execute test: "
-                                                  "{} {}".format(r.status_code, r.text)))
+            self.post_resource(test, "node", node_data, 201)
 
             # Perform a Query API request to get the update timestamp of the most recently POSTed node
             # Wish there was a better way, as this puts the cart before the horse!
@@ -1135,18 +1023,7 @@ class IS0402Test(GenericTest):
                 else:
                     resource_json["device_id"] = str(uuid.uuid4())
 
-                valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": curr_resource,
-                                                                                    "data": resource_json})
-
-                if not valid:
-                    return test.FAIL("Registration API did not respond as expected")
-                elif r.status_code == 200 or r.status_code == 201:
-                    return test.FAIL("Registration API returned wrong HTTP code.")
-                elif r.status_code == 400:
-                    pass
-                else:
-                    return test.FAIL(
-                        "Registration API returned an unexpected response: {} {}".format(r.status_code, r.text))
+                self.post_resource(test, curr_resource, resource_json, 400)
 
             return test.PASS()
 
@@ -1209,15 +1086,7 @@ class IS0402Test(GenericTest):
                     resource_json = self.downgrade_resource(resource, resource_json,
                                                             self.apis[REG_API_KEY]["version"])
 
-                valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": resource,
-                                                                                    "data": resource_json})
-                if not valid:
-                    return test.FAIL("Registration API did not respond as expected")
-                elif r.status_code == 200 or r.status_code == 201:
-                    pass
-                else:
-                    return test.FAIL(
-                        "Registration API returned an unexpected response: {} {}".format(r.status_code, r.text))
+                self.post_resource(test, resource, resource_json)
 
             # Remove Node
             valid, r = self.do_request("DELETE", self.reg_url + "resource/nodes/{}"
@@ -1284,15 +1153,7 @@ class IS0402Test(GenericTest):
                 node_json = self.downgrade_resource("node", node_json, self.apis[REG_API_KEY]["version"])
 
             # Post Node
-            valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": "node", "data": node_json})
-
-            if not valid:
-                return test.FAIL("Registration API did not respond as expected")
-            elif r.status_code == 200 or r.status_code == 201:
-                pass
-            else:
-                return test.FAIL("Registration API returned an unexpected response: {} {}"
-                                 .format(r.status_code, r.text))
+            self.post_resource(test, "node", node_json)
 
             # Post heartbeat
             valid, r = self.do_request("POST", "{}health/nodes/{}".format(self.reg_url, node_json["id"]))
@@ -1374,13 +1235,7 @@ class IS0402Test(GenericTest):
 
             # Post sample data
             for resource in resources_to_post:
-                valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": resource,
-                                                                                    "data": test_data[resource]})
-                if not valid:
-                    return test.FAIL("Cannot POST sample data. Cannot execute test: {}".format(r))
-                elif r.status_code != 201:
-                    return test.FAIL("Cannot POST sample data. Cannot execute test: {} {}"
-                                     .format(r.status_code, r.text))
+                self.post_resource(test, resource, test_data[resource], 201)
 
             # Verify if corresponding message received via websocket: UNCHANGED (SYNC)
 
@@ -1432,14 +1287,7 @@ class IS0402Test(GenericTest):
             old_resource_data = deepcopy(test_data)  # Backup old resource data for later comparison
             for resource, resource_data in test_data.items():
                 # Update resource
-                self.bump_resource_version(resource_data)
-                valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": resource,
-                                                                                    "data": resource_data})
-                if not valid:
-                    return test.FAIL("Cannot update sample data. Cannot execute test: {}".format(r))
-                elif r.status_code != 200:
-                    return test.FAIL("Cannot update sample data. Cannot execute test: {} {}"
-                                     .format(r.status_code, r.text))
+                self.post_resource(test, resource, resource_data, 200)
 
             sleep(1)
 
@@ -1522,15 +1370,9 @@ class IS0402Test(GenericTest):
             # Verify if corresponding message received via Websocket: ADDED
             # Post sample data again
             for resource in resources_to_post:
-                # Update resource
+                # Recreate resource with updated version
                 self.bump_resource_version(test_data[resource])
-                valid, r = self.do_request("POST", self.reg_url + "resource", data={"type": resource,
-                                                                                    "data": test_data[resource]})
-                if not valid:
-                    return test.FAIL("Cannot POST sample data. Cannot execute test: {}".format(r))
-                elif r.status_code != 201:
-                    return test.FAIL("Cannot POST sample data. Cannot execute test: {} {}"
-                                     .format(r.status_code, r.text))
+                self.post_resource(test, resource, test_data[resource], 201)
 
             sleep(1)
             for resource, resource_data in test_data.items():
@@ -1736,3 +1578,24 @@ class IS0402Test(GenericTest):
             v[0] += 1
             v[1] = 0
         resource["version"] = str(v[0]) + ':' + str(v[1])
+
+    def post_resource(self, test, type, data, code = None):
+        """Perform a POST request on the Registration API to create or update a resource registration"""
+
+        # As a convenience, bump the version if this is expected to be an update
+        if code == 200:
+            self.bump_resource_version(data)
+
+        valid, r = self.do_request("POST", self.reg_url + "resource",
+                                   data = {"type": type, "data": data})
+        if not valid:
+            raise NMOSTestException(test.FAIL("Registration API did not respond as expected"))
+
+        expected_codes = [200, 201] if code is None else [code]
+        wrong_codes = [_ for _ in [200, 201] if _ not in expected_codes]
+
+        if r.status_code in wrong_codes:
+            raise NMOSTestException(test.FAIL("Registration API returned wrong HTTP code"))
+        elif r.status_code not in expected_codes:
+            raise NMOSTestException(test.FAIL("Registration API returned an unexpected response: "
+                                              "{} {}".format(r.status_code, r.text)))

--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -1007,13 +1007,28 @@ class IS0402Test(GenericTest):
 
         return test.PASS()
 
+    def test_21_8(self):
+        """Query API implements pagination (correct encoding of URLs in Link header)"""
+
+        test = Test("Query API implements pagination (correct encoding of URLs in Link header)")
+        self.check_paged_trait(test)
+        description = "test_21_8"
+
+        # check '&' is returned encoded
+        response = self.do_paged_request(label = "foo%26bar")
+        self.check_paged_response(test, response,
+                                  expected_ids = None,
+                                  expected_since = None, expected_until = None) 
+        
+        return test.PASS()
+
     # TODO
-    def _test_21_8(self):
+    def _test_21_x(self):
         """Query API implements pagination (paging.order=create)"""
 
         test = Test("Query API implements pagination (paging.order=create)")
         self.check_paged_trait(test)
-        description = "test_21_8"
+        description = "test_21_x"
 
         return test.MANUAL()
 

--- a/NMOSUtils.py
+++ b/NMOSUtils.py
@@ -71,7 +71,7 @@ class NMOSUtils(object):
         return secs + leap_sec + is_leap, nanos
 
     def get_TAI_time(self, offset=0.0):
-        """Get the current TAI time as a colon seperated string"""
+        """Get the current TAI time as a colon-separated string"""
         myTime = time.time() + offset
         secs = int(myTime)
         nanos = int((myTime - secs) * 1e9)


### PR DESCRIPTION
We're attempting to convert an internal unit test suite into API-based tests for the 'paged' trait.

This is the beginning:

1. Check all required response headers are present
2. Check the most recently POSTed resource is at the top of the initial page of results
3. Check paging.limit restricts the response to the specified number of results

More to come...
