### PR TITLE
Add support for testing discovery using unicast DNS

### DIFF
--- a/Config.py
+++ b/Config.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 # Enable or disable mDNS advertisements. Browsing is always permitted.
+# The IS-04 Node tests create a mock registry on the network unless the `ENABLE_MDNS` parameter is set to `False`.
+# If set to `False`, make sure to update the Query API hostname/IP and port via `QUERY_API_HOST` and `QUERY_API_PORT`.
 ENABLE_MDNS = True
 
 # Number of seconds to wait after an mDNS advert is created for a client to notice and perform an action

--- a/Config.py
+++ b/Config.py
@@ -18,7 +18,7 @@
 ENABLE_DNS_SD = True
 
 # Set the DNS-SD mode to either 'multicast' or 'unicast'
-DNS_SD_MODE = 'unicast'
+DNS_SD_MODE = 'multicast'
 
 # Number of seconds to wait after a DNS-SD advert is created for a client to notice and perform an action
 DNS_SD_ADVERT_TIMEOUT = 5

--- a/Config.py
+++ b/Config.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Enable or disable mDNS advertisements. Browsing is always permitted.
-# The IS-04 Node tests create a mock registry on the network unless the `ENABLE_MDNS` parameter is set to `False`.
+# Enable or disable DNS-SD advertisements. Browsing is always permitted.
+# The IS-04 Node tests create a mock registry on the network unless the `ENABLE_DNS_SD` parameter is set to `False`.
 # If set to `False`, make sure to update the Query API hostname/IP and port via `QUERY_API_HOST` and `QUERY_API_PORT`.
-ENABLE_MDNS = True
+ENABLE_DNS_SD = True
 
-# Number of seconds to wait after an mDNS advert is created for a client to notice and perform an action
-MDNS_ADVERT_TIMEOUT = 5
+# Set the DNS-SD mode to either 'multicast' or 'unicast'
+DNS_SD_MODE = 'unicast'
+
+# Number of seconds to wait after a DNS-SD advert is created for a client to notice and perform an action
+DNS_SD_ADVERT_TIMEOUT = 5
 
 # Number of seconds expected between heartbeats
 HEARTBEAT_INTERVAL = 5
@@ -26,7 +29,7 @@ HEARTBEAT_INTERVAL = 5
 # Number of seconds to wait for the garbage collection
 GARBAGE_COLLECTION_TIMEOUT = 12
 
-# Set a Query API hostname/IP and port for use when operating without mDNS
+# Set a Query API hostname/IP and port for use when operating without DNS-SD
 QUERY_API_HOST = "127.0.0.1"
 QUERY_API_PORT = 80
 

--- a/DNS.py
+++ b/DNS.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2018 British Broadcasting Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dnslib.server import DNSServer
+from dnslib.zoneresolver import ZoneResolver
+from jinja2 import Template
+
+import netifaces
+
+
+class DNS(object):
+    def __init__(self):
+        default_gw_interface = netifaces.gateways()['default'][netifaces.AF_INET][1]
+        default_ip = netifaces.ifaddresses(default_gw_interface)[netifaces.AF_INET][0]['addr']
+        self.default_ip = default_ip
+        self.resolver = None
+        self.server = None
+        self.base_zone_data = None
+        self.reset()
+
+    def load_zone(self, api_version):
+        zone_file = open("test_data/IS0401/dns_records.zone").read()
+        template = Template(zone_file)
+        zone_data = template.render(ip_address=self.default_ip, api_ver=api_version)
+        self.resolver = ZoneResolver(self.base_zone_data + zone_data)
+        self.stop()
+        self.start()
+
+    def reset(self):
+        zone_file = open("test_data/IS0401/dns_base.zone").read()
+        template = Template(zone_file)
+        self.base_zone_data = template.render(ip_address=self.default_ip)
+        self.resolver = ZoneResolver(self.base_zone_data)
+        self.stop()
+        self.start()
+
+    def start(self):
+        if not self.server:
+            print(" * Starting DNS server on {}:53".format(self.default_ip))
+            try:
+                self.server = DNSServer(self.resolver, port=53, address=self.default_ip)
+                self.server.start_thread()
+            except Exception as e:
+                print(" * ERROR: Unable to bind to port 53. DNS server could not start: {}".format(e))
+
+    def stop(self):
+        if self.server:
+            self.server.stop()
+            self.server = None

--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -33,10 +33,11 @@ class IS0401Test(GenericTest):
     """
     Runs IS-04-01-Test
     """
-    def __init__(self, apis, registries, node):
+    def __init__(self, apis, registries, node, dns_server):
         GenericTest.__init__(self, apis)
         self.registries = registries
         self.node = node
+        self.dns_server = dns_server
         self.node_url = self.apis[NODE_API_KEY]["url"]
         self.registry_basics_done = False
         self.is04_utils = IS04Utils(self.node_url)
@@ -46,11 +47,15 @@ class IS0401Test(GenericTest):
     def set_up_tests(self):
         self.zc = Zeroconf()
         self.zc_listener = MdnsListener(self.zc)
+        if self.dns_server:
+            self.dns_server.load_zone(self.apis[NODE_API_KEY]["version"])
 
     def tear_down_tests(self):
         if self.zc:
             self.zc.close()
             self.zc = None
+        if self.dns_server:
+            self.dns_server.reset()
 
     def _registry_mdns_info(self, port, priority=0):
         """Get an mDNS ServiceInfo object in order to create an advertisement"""

--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -375,7 +375,7 @@ class IS0401Test(GenericTest):
         for node in node_list:
             address = socket.inet_ntoa(node.address)
             port = node.port
-            if address in self.node_url and ":{}".format(port) in self.node_url:
+            if "/{}:{}/".format(address, port) in self.node_url:
                 properties = self.convert_bytes(node.properties)
                 for prop in properties:
                     if "ver_" in prop:

--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -57,8 +57,13 @@ class IS0401Test(GenericTest):
 
         # TODO: Add another test which checks support for parsing CSV string in api_ver
         txt = {'api_ver': self.apis[NODE_API_KEY]["version"], 'api_proto': 'http', 'pri': str(priority)}
-        info = ServiceInfo("_nmos-registration._tcp.local.",
-                           "NMOS Test Suite {}._nmos-registration._tcp.local.".format(port),
+
+        service_type = "_nmos-registration._tcp.local."
+        if self.is04_utils.compare_api_version(self.apis[NODE_API_KEY]["version"], "v1.3") >= 0:
+            service_type = "_nmos-register._tcp.local."
+
+        info = ServiceInfo(service_type,
+                           "NMOSTestSuite{}.{}".format(port, service_type),
                            socket.inet_aton(default_ip), port, 0, 0,
                            txt, "nmos-test.local.")
         return info

--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -65,7 +65,11 @@ class IS0402Test(GenericTest):
 
         test = Test("Registration API advertises correctly via mDNS")
 
-        browser = ServiceBrowser(self.zc, "_nmos-registration._tcp.local.", self.zc_listener)
+        service_type = "_nmos-registration._tcp.local."
+        if self.is04_reg_utils.compare_api_version(self.apis[REG_API_KEY]["version"], "v1.3") >= 0:
+            service_type = "_nmos-register._tcp.local."
+
+        browser = ServiceBrowser(self.zc, service_type, self.zc_listener)
         sleep(2)
         serv_list = self.zc_listener.get_service_list()
         for api in serv_list:

--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -46,6 +46,7 @@ class IS0402Test(GenericTest):
         self.reg_url = self.apis[REG_API_KEY]["url"]
         self.query_url = self.apis[QUERY_API_KEY]["url"]
         self.zc = None
+        self.zc_listener = None
         self.is04_reg_utils = IS04Utils(self.reg_url)
         self.is04_query_utils = IS04Utils(self.query_url)
         self.test_data = self.load_resource_data()

--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -560,8 +560,12 @@ class IS0402Test(GenericTest):
         random_label = uuid.uuid4()
         query_string = "?label=" + str(random_label)
         valid, r = self.do_request("GET", self.query_url + "nodes" + query_string)
+        api = self.apis[QUERY_API_KEY]
         if not valid:
             return test.FAIL("Query API failed to respond to query")
+        elif self.is04_query_utils.compare_api_version(api["version"], "v1.3") >= 0 and r.status_code == 501:
+            return test.OPTIONAL("Query API signalled that it does not support basic queries. This may be important for"
+                                 " scalability.", "https://github.com/AMWA-TV/nmos/wiki/IS-04#registries-basic-queries")
         elif len(r.json()) > 0:
             return test.FAIL("Query API returned more records than expected for query: {}".format(query_string))
 

--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -71,7 +71,7 @@ class IS0402Test(GenericTest):
         for api in serv_list:
             address = socket.inet_ntoa(api.address)
             port = api.port
-            if address in self.reg_url and ":{}".format(port) in self.reg_url:
+            if "/{}:{}/".format(address, port) in self.reg_url:
                 properties = self.convert_bytes(api.properties)
                 if "pri" not in properties:
                     return test.FAIL("No 'pri' TXT record found in Registration API advertisement.")
@@ -114,7 +114,7 @@ class IS0402Test(GenericTest):
         for api in serv_list:
             address = socket.inet_ntoa(api.address)
             port = api.port
-            if address in self.query_url and ":{}".format(port) in self.query_url:
+            if "/{}:{}/".format(address, port) in self.query_url:
                 properties = self.convert_bytes(api.properties)
                 if "pri" not in properties:
                     return test.FAIL("No 'pri' TXT record found in Query API advertisement.")

--- a/IS0403Test.py
+++ b/IS0403Test.py
@@ -53,7 +53,7 @@ class IS0403Test(GenericTest):
         for node in node_list:
             address = socket.inet_ntoa(node.address)
             port = node.port
-            if address in self.node_url and ":{}".format(port) in self.node_url:
+            if "/{}:{}/".format(address, port) in self.node_url:
                 properties = self.convert_bytes(node.properties)
                 for ver_txt in ["ver_slf", "ver_src", "ver_flw", "ver_dvc", "ver_snd", "ver_rcv"]:
                     if ver_txt not in properties:

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -20,9 +20,7 @@ When testing any of the above APIs it is important that they contain representat
 
 ## Usage
 
-```
-$ python3 nmos-test.py
-```
+Install the dependencies with `pip3 install -r requirements.txt` and start the service with `python3 nmos-test.py`.
 
 This tool provides a simple web service which is available on `http://localhost:5000`.
 Provide the URL of the relevant API under test (see the detailed description on the webpage) and select a test from the checklist. The result of the test will be shown after a few seconds.
@@ -30,17 +28,8 @@ Provide the URL of the relevant API under test (see the detailed description on 
 ## External Dependencies
 
 *   Python 3
-
-Python packages:
-*   flask
-*   wtforms
-*   jsonschema
-*   zeroconf-monkey
-*   requests
-*   netifaces
-*   gitpython
-*   ramlfications
-*   jsonref
+*   Git
+*   See [requirements.txt](requirements.txt) for additional packages
 
 ## Known Issues
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -15,7 +15,7 @@ The following test sets are currently supported:
 When testing any of the above APIs it is important that they contain representative data. The test results will generate 'N/A' results if no testable entities can be located. In addition, if device support many modes of operation (including multiple video/audio formats) it is strongly recommended to re-test them in multiple modes.
 
 **Attention:**
-*   The IS-04 Node tests create mock registry mDNS announcements on the network unless the Config.py `ENABLE_DNS_SD` parameter is set to `False`, or the `DNS_SD_MODE` parameter is set to `'unicast'`. It is critical that these tests are only run in isolated network segments away from production Nodes and registries. Only one Node can be tested at a single time.
+*   The IS-04 Node tests create mock registry mDNS announcements on the network unless the `Config.py` `ENABLE_DNS_SD` parameter is set to `False`, or the `DNS_SD_MODE` parameter is set to `'unicast'`. It is critical that these tests are only run in isolated network segments away from production Nodes and registries. Only one Node can be tested at a single time. If `ENABLE_DNS_SD` is set to `False`, make sure to update the Query API hostname/IP and port via `QUERY_API_HOST` and `QUERY_API_PORT` in the `Config.py`.
 *   For IS-05 tests #29 and #30 (absolute activation), make sure the time of the test device and the time of the device hosting the tests is synchronized.
 
 ## Usage

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -15,7 +15,7 @@ The following test sets are currently supported:
 When testing any of the above APIs it is important that they contain representative data. The test results will generate 'N/A' results if no testable entities can be located. In addition, if device support many modes of operation (including multiple video/audio formats) it is strongly recommended to re-test them in multiple modes.
 
 **Attention:**
-*   The IS-04 Node tests create a mock registry on the network unless the Config.py ENABLE_MDNS parameter is set to False. It is critical that these tests are only run in isolated network segments away from production Nodes and registries. Only one Node can be tested at a single time.
+*   The IS-04 Node tests create a mock registry on the network unless the `Config.py` `ENABLE_MDNS` parameter is set to `False`. It is critical that these tests are only run in isolated network segments away from production Nodes and registries. Only one Node can be tested at a single time. If `ENABLE_MDNS` is set to `False`, make sure to update the Query API hostname/IP and port via `QUERY_API_HOST` and `QUERY_API_PORT` in the `Config.py`.
 *   For IS-05 tests #29 and #30 (absolute activation), make sure the time of the test device and the time of the device hosting the tests is synchronized.
 
 ## Usage

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -15,7 +15,7 @@ The following test sets are currently supported:
 When testing any of the above APIs it is important that they contain representative data. The test results will generate 'N/A' results if no testable entities can be located. In addition, if device support many modes of operation (including multiple video/audio formats) it is strongly recommended to re-test them in multiple modes.
 
 **Attention:**
-*   The IS-04 Node tests create a mock registry on the network unless the `Config.py` `ENABLE_MDNS` parameter is set to `False`. It is critical that these tests are only run in isolated network segments away from production Nodes and registries. Only one Node can be tested at a single time. If `ENABLE_MDNS` is set to `False`, make sure to update the Query API hostname/IP and port via `QUERY_API_HOST` and `QUERY_API_PORT` in the `Config.py`.
+*   The IS-04 Node tests create mock registry mDNS announcements on the network unless the Config.py `ENABLE_DNS_SD` parameter is set to `False`, or the `DNS_SD_MODE` parameter is set to `'unicast'`. It is critical that these tests are only run in isolated network segments away from production Nodes and registries. Only one Node can be tested at a single time.
 *   For IS-05 tests #29 and #30 (absolute activation), make sure the time of the test device and the time of the device hosting the tests is synchronized.
 
 ## Usage
@@ -24,6 +24,10 @@ Install the dependencies with `pip3 install -r requirements.txt` and start the s
 
 This tool provides a simple web service which is available on `http://localhost:5000`.
 Provide the URL of the relevant API under test (see the detailed description on the webpage) and select a test from the checklist. The result of the test will be shown after a few seconds.
+
+### Testing Unicast discovery
+
+In order to test unicast discovery, ensure the `DNS_SD_MODE` is set to `'unicast'`. Additionally, ensure that the unit under test has its search domain set to 'testsuite.nmos.tv' and the DNS server IP to the IP address of the server which is running the test suite instance.
 
 ## External Dependencies
 

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -31,6 +31,7 @@ import pickle
 import threading
 import sys
 import netifaces
+import platform
 
 import IS0401Test
 import IS0402Test
@@ -251,9 +252,17 @@ def index_page():
 
 
 if __name__ == '__main__':
-    if ENABLE_DNS_SD and DNS_SD_MODE == "unicast" and os.geteuid() != 0:
-        print(" * ERROR: In order to test DNS-SD in unicast mode, the test suite must be run with elevated permissions")
-        sys.exit(1)
+    if ENABLE_DNS_SD and DNS_SD_MODE == "unicast":
+        is_admin = False
+        if platform.system() == "Windows":
+            from ctypes import windll
+            if windll.shell32.IsUserAnAdmin():
+                is_admin = True
+        elif os.geteuid() == 0:
+            is_admin = True
+        if not is_admin:
+            print(" * ERROR: In order to test DNS-SD in unicast mode, the test suite must be run with elevated permissions")
+            sys.exit(1)
 
     print(" * Initialising specification repositories...")
 

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -18,8 +18,10 @@ from flask import Flask, render_template, flash, request
 from wtforms import Form, validators, StringField, SelectField, IntegerField, HiddenField, FormField, FieldList
 from Registry import NUM_REGISTRIES, REGISTRIES, REGISTRY_API
 from Node import NODE, NODE_API
-from Config import CACHE_PATH, SPECIFICATIONS
+from Config import CACHE_PATH, SPECIFICATIONS, ENABLE_DNS_SD, DNS_SD_MODE
 from datetime import datetime, timedelta
+from dnslib.server import DNSServer
+from dnslib.zoneresolver import ZoneResolver
 
 import git
 import os
@@ -27,6 +29,8 @@ import json
 import copy
 import pickle
 import threading
+import sys
+import netifaces
 
 import IS0401Test
 import IS0402Test
@@ -247,6 +251,10 @@ def index_page():
 
 
 if __name__ == '__main__':
+    if ENABLE_DNS_SD and DNS_SD_MODE == "unicast" and os.geteuid() != 0:
+        print(" * ERROR: In order to test DNS-SD in unicast mode, the test suite must be run with elevated permissions")
+        sys.exit(1)
+
     print(" * Initialising specification repositories...")
 
     if not os.path.exists(CACHE_PATH):
@@ -299,4 +307,23 @@ if __name__ == '__main__':
         t.start()
         port += 1
 
+    dns_server = None
+    if ENABLE_DNS_SD and DNS_SD_MODE == "unicast":
+        default_gw_interface = netifaces.gateways()['default'][netifaces.AF_INET][1]
+        default_ip = netifaces.ifaddresses(default_gw_interface)[netifaces.AF_INET][0]['addr']
+        print(" * Starting DNS server on {}:53".format(default_ip))
+        zone_file = open("test_data/IS0401/dns.zone").read()
+        zone_file.replace("127.0.0.1", default_ip)
+        resolver = ZoneResolver(zone_file)
+        try:
+            dns_server = DNSServer(resolver, port=53, address=default_ip)
+            dns_server.start_thread()
+        except Exception as e:
+            print(" * ERROR: Unable to bind to port 53. DNS server could not start: {}".format(e))
+
+    # This call will block until interrupted
     core_app.run(host='0.0.0.0', port=5000, threaded=True)
+
+    print(" * Exiting")
+    if dns_server:
+        dns_server.stop()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ gitpython
 ramlfications
 websocket-client
 jsonref
-
+dnslib

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ ramlfications
 websocket-client
 jsonref
 dnslib
+jinja2

--- a/setup.py
+++ b/setup.py
@@ -72,18 +72,8 @@ def find_packages(path, base=""):
 packages = find_packages(".")
 package_names = packages.keys()
 
-packages_required = [
-    "flask",
-    "wtforms",
-    "jsonschema",
-    "zeroconf-monkey",
-    "requests",
-    "netifaces",
-    "gitpython",
-    "ramlfications",
-    "websocket-client",
-    "jsonref"
-]
+with open("requirements.txt") as requirements_file:
+    packages_required = requirements_file.read().splitlines()
 
 deps_required = []
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,6 +28,11 @@
 <body>
     <div id="page">
         <h1>NMOS Test</h1>
+        <noscript>
+          <div class="alert alert-danger top_alert" role="alert">
+              This test suite requires JavaScript. Please enable it to ensure accurate results.
+          </div>
+        </noscript>
         <div class="alert alert-primary top_alert" role="alert">
             This test suite is under active development and does not yet provide 100% coverage of specifications.<br />
             We recommend regularly re-testing implementations as new tests are developed.

--- a/test_data/IS0401/dns.zone
+++ b/test_data/IS0401/dns.zone
@@ -27,34 +27,44 @@ query5005.testsuite.nmos.tv.	IN	A	127.0.0.1
 
 ; There should be one PTR record for each instance of the service you wish to advertise.
 _nmos-registration._tcp	PTR	reg-api-5001._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5001._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5001._nmos-register._tcp
 _nmos-query._tcp	PTR	qry-api-5001._nmos-query._tcp
 _nmos-registration._tcp	PTR	reg-api-5002._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5002._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5002._nmos-register._tcp
 _nmos-query._tcp	PTR	qry-api-5002._nmos-query._tcp
 _nmos-registration._tcp	PTR	reg-api-5003._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5003._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5003._nmos-register._tcp
 _nmos-query._tcp	PTR	qry-api-5003._nmos-query._tcp
 _nmos-registration._tcp	PTR	reg-api-5004._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5004._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5004._nmos-register._tcp
 _nmos-query._tcp	PTR	qry-api-5004._nmos-query._tcp
 _nmos-registration._tcp	PTR	reg-api-5005._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5005._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5005._nmos-register._tcp
 _nmos-query._tcp	PTR	qry-api-5005._nmos-query._tcp
 
 ; Next we have a SRV and a TXT record corresponding to each PTR above, first the Registration API
 ; The SRV links the PTR name to a resolvable DNS name (see the A records above) and identify the port which the API runs on
 ; The TXT records indicate additional metadata relevant to the IS-04 spec
 reg-api-5001._nmos-registration._tcp	SRV	0 0 5001 registration5001.testsuite.nmos.tv.
+reg-api-5001._nmos-register._tcp	SRV	0 0 5001 registration5001.testsuite.nmos.tv.
 reg-api-5001._nmos-registration._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=0"
+reg-api-5001._nmos-register._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=0"
 reg-api-5002._nmos-registration._tcp	SRV	0 0 5002 registration5002.testsuite.nmos.tv.
+reg-api-5002._nmos-register._tcp	SRV	0 0 5002 registration5002.testsuite.nmos.tv.
 reg-api-5002._nmos-registration._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=10"
+reg-api-5002._nmos-register._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=10"
 reg-api-5003._nmos-registration._tcp	SRV	0 0 5003 registration5003.testsuite.nmos.tv.
+reg-api-5003._nmos-register._tcp	SRV	0 0 5003 registration5003.testsuite.nmos.tv.
 reg-api-5003._nmos-registration._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=20"
+reg-api-5003._nmos-register._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=20"
 reg-api-5004._nmos-registration._tcp	SRV	0 0 5004 registration5004.testsuite.nmos.tv.
+reg-api-5004._nmos-register._tcp	SRV	0 0 5004 registration5004.testsuite.nmos.tv.
 reg-api-5004._nmos-registration._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=30"
+reg-api-5004._nmos-register._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=30"
 reg-api-5005._nmos-registration._tcp	SRV	0 0 5005 registration5005.testsuite.nmos.tv.
+reg-api-5005._nmos-register._tcp	SRV	0 0 5005 registration5005.testsuite.nmos.tv.
 reg-api-5005._nmos-registration._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=40"
+reg-api-5005._nmos-register._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=40"
 
 ; Finally, the SRV and TXT for the Query API
 qry-api-5001._nmos-query._tcp	SRV	0 0 5001 query5001.testsuite.nmos.tv.

--- a/test_data/IS0401/dns.zone
+++ b/test_data/IS0401/dns.zone
@@ -1,0 +1,69 @@
+$ORIGIN testsuite.nmos.tv.
+$TTL 60s
+
+testsuite.nmos.tv.  IN  SOA   ns.testsuite.nmos.tv. postmaster.testsuite.nmos.tv. ( 2007120710 1d 2h 4w 1h )
+testsuite           IN  A     127.0.0.1
+
+; These lines indicate to clients that this server supports DNS Service Discovery
+b._dns-sd._udp	IN	PTR	@
+lb._dns-sd._udp	IN	PTR	@
+
+; These lines indicate to clients which service types this server may advertise
+_services._dns-sd._udp	PTR	_nmos-registration._tcp
+_services._dns-sd._udp	PTR	_nmos-register._tcp
+_services._dns-sd._udp	PTR	_nmos-query._tcp
+
+; These lines give the fully qualified DNS names to the IP addresses of the hosts which we'd like to discover
+registration5001.testsuite.nmos.tv.	IN	A	127.0.0.1
+query5001.testsuite.nmos.tv.	IN	A	127.0.0.1
+registration5002.testsuite.nmos.tv.	IN	A	127.0.0.1
+query5002.testsuite.nmos.tv.	IN	A	127.0.0.1
+registration5003.testsuite.nmos.tv.	IN	A	127.0.0.1
+query5003.testsuite.nmos.tv.	IN	A	127.0.0.1
+registration5004.testsuite.nmos.tv.	IN	A	127.0.0.1
+query5004.testsuite.nmos.tv.	IN	A	127.0.0.1
+registration5005.testsuite.nmos.tv.	IN	A	127.0.0.1
+query5005.testsuite.nmos.tv.	IN	A	127.0.0.1
+
+; There should be one PTR record for each instance of the service you wish to advertise.
+_nmos-registration._tcp	PTR	reg-api-5001._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5001._nmos-registration._tcp
+_nmos-query._tcp	PTR	qry-api-5001._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-5002._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5002._nmos-registration._tcp
+_nmos-query._tcp	PTR	qry-api-5002._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-5003._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5003._nmos-registration._tcp
+_nmos-query._tcp	PTR	qry-api-5003._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-5004._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5004._nmos-registration._tcp
+_nmos-query._tcp	PTR	qry-api-5004._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-5005._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5005._nmos-registration._tcp
+_nmos-query._tcp	PTR	qry-api-5005._nmos-query._tcp
+
+; Next we have a SRV and a TXT record corresponding to each PTR above, first the Registration API
+; The SRV links the PTR name to a resolvable DNS name (see the A records above) and identify the port which the API runs on
+; The TXT records indicate additional metadata relevant to the IS-04 spec
+reg-api-5001._nmos-registration._tcp	SRV	0 0 5001 registration5001.testsuite.nmos.tv.
+reg-api-5001._nmos-registration._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=0"
+reg-api-5002._nmos-registration._tcp	SRV	0 0 5002 registration5002.testsuite.nmos.tv.
+reg-api-5002._nmos-registration._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=10"
+reg-api-5003._nmos-registration._tcp	SRV	0 0 5003 registration5003.testsuite.nmos.tv.
+reg-api-5003._nmos-registration._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=20"
+reg-api-5004._nmos-registration._tcp	SRV	0 0 5004 registration5004.testsuite.nmos.tv.
+reg-api-5004._nmos-registration._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=30"
+reg-api-5005._nmos-registration._tcp	SRV	0 0 5005 registration5005.testsuite.nmos.tv.
+reg-api-5005._nmos-registration._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=40"
+
+; Finally, the SRV and TXT for the Query API
+qry-api-5001._nmos-query._tcp	SRV	0 0 5001 query5001.testsuite.nmos.tv.
+qry-api-5001._nmos-query._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=0"
+qry-api-5002._nmos-query._tcp	SRV	0 0 5002 query5002.testsuite.nmos.tv.
+qry-api-5002._nmos-query._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=10"
+qry-api-5003._nmos-query._tcp	SRV	0 0 5003 query5003.testsuite.nmos.tv.
+qry-api-5003._nmos-query._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=20"
+qry-api-5004._nmos-query._tcp	SRV	0 0 5004 query5004.testsuite.nmos.tv.
+qry-api-5004._nmos-query._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=30"
+qry-api-5005._nmos-query._tcp	SRV	0 0 5005 query5005.testsuite.nmos.tv.
+qry-api-5005._nmos-query._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=40"

--- a/test_data/IS0401/dns_base.zone
+++ b/test_data/IS0401/dns_base.zone
@@ -1,0 +1,14 @@
+$ORIGIN testsuite.nmos.tv.
+$TTL 60s
+
+testsuite.nmos.tv.  IN  SOA   ns.testsuite.nmos.tv. postmaster.testsuite.nmos.tv. ( 2007120710 1d 2h 4w 1h )
+testsuite           IN  A     {{ ip_address }}
+
+; These lines indicate to clients that this server supports DNS Service Discovery
+b._dns-sd._udp	IN	PTR	@
+lb._dns-sd._udp	IN	PTR	@
+
+; These lines indicate to clients which service types this server may advertise
+_services._dns-sd._udp	PTR	_nmos-registration._tcp
+_services._dns-sd._udp	PTR	_nmos-register._tcp
+_services._dns-sd._udp	PTR	_nmos-query._tcp

--- a/test_data/IS0401/dns_records.zone
+++ b/test_data/IS0401/dns_records.zone
@@ -1,29 +1,14 @@
-$ORIGIN testsuite.nmos.tv.
-$TTL 60s
-
-testsuite.nmos.tv.  IN  SOA   ns.testsuite.nmos.tv. postmaster.testsuite.nmos.tv. ( 2007120710 1d 2h 4w 1h )
-testsuite           IN  A     127.0.0.1
-
-; These lines indicate to clients that this server supports DNS Service Discovery
-b._dns-sd._udp	IN	PTR	@
-lb._dns-sd._udp	IN	PTR	@
-
-; These lines indicate to clients which service types this server may advertise
-_services._dns-sd._udp	PTR	_nmos-registration._tcp
-_services._dns-sd._udp	PTR	_nmos-register._tcp
-_services._dns-sd._udp	PTR	_nmos-query._tcp
-
 ; These lines give the fully qualified DNS names to the IP addresses of the hosts which we'd like to discover
-registration5001.testsuite.nmos.tv.	IN	A	127.0.0.1
-query5001.testsuite.nmos.tv.	IN	A	127.0.0.1
-registration5002.testsuite.nmos.tv.	IN	A	127.0.0.1
-query5002.testsuite.nmos.tv.	IN	A	127.0.0.1
-registration5003.testsuite.nmos.tv.	IN	A	127.0.0.1
-query5003.testsuite.nmos.tv.	IN	A	127.0.0.1
-registration5004.testsuite.nmos.tv.	IN	A	127.0.0.1
-query5004.testsuite.nmos.tv.	IN	A	127.0.0.1
-registration5005.testsuite.nmos.tv.	IN	A	127.0.0.1
-query5005.testsuite.nmos.tv.	IN	A	127.0.0.1
+registration5001.testsuite.nmos.tv.	IN	A	{{ ip_address }}
+query5001.testsuite.nmos.tv.	IN	A	{{ ip_address }}
+registration5002.testsuite.nmos.tv.	IN	A	{{ ip_address }}
+query5002.testsuite.nmos.tv.	IN	A	{{ ip_address }}
+registration5003.testsuite.nmos.tv.	IN	A	{{ ip_address }}
+query5003.testsuite.nmos.tv.	IN	A	{{ ip_address }}
+registration5004.testsuite.nmos.tv.	IN	A	{{ ip_address }}
+query5004.testsuite.nmos.tv.	IN	A	{{ ip_address }}
+registration5005.testsuite.nmos.tv.	IN	A	{{ ip_address }}
+query5005.testsuite.nmos.tv.	IN	A	{{ ip_address }}
 
 ; There should be one PTR record for each instance of the service you wish to advertise.
 _nmos-registration._tcp	PTR	reg-api-5001._nmos-registration._tcp
@@ -47,33 +32,33 @@ _nmos-query._tcp	PTR	qry-api-5005._nmos-query._tcp
 ; The TXT records indicate additional metadata relevant to the IS-04 spec
 reg-api-5001._nmos-registration._tcp	SRV	0 0 5001 registration5001.testsuite.nmos.tv.
 reg-api-5001._nmos-register._tcp	SRV	0 0 5001 registration5001.testsuite.nmos.tv.
-reg-api-5001._nmos-registration._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=0"
-reg-api-5001._nmos-register._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=0"
+reg-api-5001._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=http" "pri=0"
+reg-api-5001._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=http" "pri=0"
 reg-api-5002._nmos-registration._tcp	SRV	0 0 5002 registration5002.testsuite.nmos.tv.
 reg-api-5002._nmos-register._tcp	SRV	0 0 5002 registration5002.testsuite.nmos.tv.
-reg-api-5002._nmos-registration._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=10"
-reg-api-5002._nmos-register._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=10"
+reg-api-5002._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=http" "pri=10"
+reg-api-5002._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=http" "pri=10"
 reg-api-5003._nmos-registration._tcp	SRV	0 0 5003 registration5003.testsuite.nmos.tv.
 reg-api-5003._nmos-register._tcp	SRV	0 0 5003 registration5003.testsuite.nmos.tv.
-reg-api-5003._nmos-registration._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=20"
-reg-api-5003._nmos-register._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=20"
+reg-api-5003._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=http" "pri=20"
+reg-api-5003._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=http" "pri=20"
 reg-api-5004._nmos-registration._tcp	SRV	0 0 5004 registration5004.testsuite.nmos.tv.
 reg-api-5004._nmos-register._tcp	SRV	0 0 5004 registration5004.testsuite.nmos.tv.
-reg-api-5004._nmos-registration._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=30"
-reg-api-5004._nmos-register._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=30"
+reg-api-5004._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=http" "pri=30"
+reg-api-5004._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=http" "pri=30"
 reg-api-5005._nmos-registration._tcp	SRV	0 0 5005 registration5005.testsuite.nmos.tv.
 reg-api-5005._nmos-register._tcp	SRV	0 0 5005 registration5005.testsuite.nmos.tv.
-reg-api-5005._nmos-registration._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=40"
-reg-api-5005._nmos-register._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=40"
+reg-api-5005._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=http" "pri=40"
+reg-api-5005._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=http" "pri=40"
 
 ; Finally, the SRV and TXT for the Query API
 qry-api-5001._nmos-query._tcp	SRV	0 0 5001 query5001.testsuite.nmos.tv.
-qry-api-5001._nmos-query._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=0"
+qry-api-5001._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=http" "pri=0"
 qry-api-5002._nmos-query._tcp	SRV	0 0 5002 query5002.testsuite.nmos.tv.
-qry-api-5002._nmos-query._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=10"
+qry-api-5002._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=http" "pri=10"
 qry-api-5003._nmos-query._tcp	SRV	0 0 5003 query5003.testsuite.nmos.tv.
-qry-api-5003._nmos-query._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=20"
+qry-api-5003._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=http" "pri=20"
 qry-api-5004._nmos-query._tcp	SRV	0 0 5004 query5004.testsuite.nmos.tv.
-qry-api-5004._nmos-query._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=30"
+qry-api-5004._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=http" "pri=30"
 qry-api-5005._nmos-query._tcp	SRV	0 0 5005 query5005.testsuite.nmos.tv.
-qry-api-5005._nmos-query._tcp	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=40"
+qry-api-5005._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=http" "pri=40"


### PR DESCRIPTION
Work in progress. This is intended to add support for unicast discovery testing. At present I'm unable to test it fully on Linux as the default port is already in use. Assuming it can be made to work it would provide a much better testing method for shared networks.

Note that the DNS server implementation itself has been tested and found to work when running on a non-standard port.