### PR TITLE
Abort testing if the selected configuration is invalid

### DIFF
--- a/GenericTest.py
+++ b/GenericTest.py
@@ -33,8 +33,17 @@ def test_depends(func):
             return func(self)
     return invalid
 
+
 class NMOSTestException(Exception):
+    """ Provides a way to exit a single test, by providing the TestResult return statement as the first exception
+        parameter"""
     pass
+
+
+class NMOSInitException(Exception):
+    """ The test set was run in an invalid mode. Causes all tests to abort"""
+    pass
+
 
 class GenericTest(object):
     """

--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -25,7 +25,7 @@ import re
 from zeroconf_monkey import ServiceBrowser, Zeroconf
 from MdnsListener import MdnsListener
 from TestResult import Test
-from GenericTest import GenericTest, NMOSTestException, test_depends
+from GenericTest import GenericTest, NMOSTestException, NMOSInitException, test_depends
 from IS04Utils import IS04Utils
 from Config import GARBAGE_COLLECTION_TIMEOUT
 from TestHelper import WebsocketWorker, load_resolved_schema
@@ -46,6 +46,8 @@ class IS0402Test(GenericTest):
         GenericTest.__init__(self, apis, omit_paths)
         self.reg_url = self.apis[REG_API_KEY]["url"]
         self.query_url = self.apis[QUERY_API_KEY]["url"]
+        if self.apis[REG_API_KEY]["version"] != self.apis[QUERY_API_KEY]["version"]:
+            raise NMOSInitException("The Registration and Query API versions under test must be identical")
         self.zc = None
         self.zc_listener = None
         self.is04_reg_utils = IS04Utils(self.reg_url)


### PR DESCRIPTION
This PR provides a new exception type which can be thrown during a given test set's `__init__` call. In its first usage it checks that the Registration and Query API versions under test match, and the tests are very heavily dependent on this being the case.