### PR TITLE
Enable non-interactive testing

### DIFF
--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -1372,7 +1372,7 @@ class IS0402Test(GenericTest):
                         return test.FAIL("Query API returned not 404 on a resource which should have been "
                                          "removed because parent resource was deleted")
                 else:
-                    return test.FAIL("Query API returned an unexpected response: {} {}".format(r.status_code, r.text))
+                    return test.FAIL("Query API did not respond as expected")
             return test.PASS()
         else:
             return test.FAIL("Version > 1 not supported yet.")

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -20,7 +20,11 @@ When testing any of the above APIs it is important that they contain representat
 
 ## Usage
 
-Install the dependencies with `pip3 install -r requirements.txt` and start the service with `python3 nmos-test.py`.
+Install the dependencies with `pip3 install -r requirements.txt` and start the service as follows:
+
+```shell
+python3 nmos-test.py
+```
 
 This tool provides a simple web service which is available on `http://localhost:5000`.
 Provide the URL of the relevant API under test (see the detailed description on the webpage) and select a test from the checklist. The result of the test will be shown after a few seconds.
@@ -28,6 +32,18 @@ Provide the URL of the relevant API under test (see the detailed description on 
 ### Testing Unicast discovery
 
 In order to test unicast discovery, ensure the `DNS_SD_MODE` is set to `'unicast'`. Additionally, ensure that the unit under test has its search domain set to 'testsuite.nmos.tv' and the DNS server IP to the IP address of the server which is running the test suite instance.
+
+### Non-Interative Mode
+
+The test suite supports non-interactive operation in order use it within continuous integration systems. An example of this usage can be seen below:
+
+```shell
+# List the available tests for a given test definition
+python3 nmos-test.py --suite IS-04-02 --list
+
+# Run a test set, saving the output as a JUnit XML file
+python3 nmos-test.py --suite IS-04-02 --selection auto --ip 128.66.12.5 128.66.12.6 --port 80 80 --version v1.2 v1.2 --ignore auto_5 auto_6 --output results.xml
+```
 
 ## External Dependencies
 

--- a/TestResult.py
+++ b/TestResult.py
@@ -16,6 +16,47 @@ import inspect
 import datetime
 import time
 
+from enum import Enum
+
+
+class TestStates(Enum):
+    PASS = 0
+    WARNING = 1
+    FAIL = 2
+    MANUAL = 3
+    NA = 4
+    OPTIONAL = 5
+    DISABLED = 6
+    UNCLEAR = 7
+
+    def __init__(self, *args):
+        self.names = ["Pass", "Warning", "Fail", "Manual", "Not Applicable", "Not Implemented", "Test Disabled",
+                      "Could Not Test"]
+        self.classes = ["bg-success", "bg-warning", "bg-danger", "bg-primary", "bg-secondary", "bg-warning",
+                        "bg-warning", "bg-warning"]
+
+    def __str__(self):
+        return self.names[self.value]
+
+    @property
+    def css_class(self):
+        return self.classes[self.value]
+
+
+class TestResult(object):
+    def __init__(self, name, state, description, detail, link, timestamp, elapsed_time):
+        self.name = name
+        self.state = state
+        self.description = description
+        self.detail = detail
+        self.link = link
+        self.timestamp = timestamp
+        self.elapsed_time = elapsed_time
+
+    def output(self):
+        return [self.name, str(self.state), self.state.css_class, self.description, self.detail, self.link,
+                self.timestamp, "{0:.3f}s".format(self.elapsed_time)]
+
 
 class Test(object):
     def __init__(self, description, name=None):
@@ -30,46 +71,46 @@ class Test(object):
         return datetime.datetime.now().strftime("%H:%M:%S.%f")[:-3]
 
     def _time_elapsed(self):
-        return "{0:.3f}s".format(time.time() - self.timer)
+        return time.time() - self.timer
 
     # Pass: Successful test case
     def PASS(self, detail="", link=None):
-        return [self.name, "Pass", "bg-success", self.description, detail, link, self._current_time(),
-                self._time_elapsed()]
+        return TestResult(self.name, TestStates.PASS, self.description, detail, link, self._current_time(),
+                          self._time_elapsed())
 
     # Warning: Not a failure, but the API being tested is responding or configured in a way which is
     # not recommended in most cases
     def WARNING(self, detail="", link=None):
-        return [self.name, "Warning", "bg-warning", self.description, detail, link, self._current_time(),
-                self._time_elapsed()]
+        return TestResult(self.name, TestStates.WARNING, self.description, detail, link, self._current_time(),
+                          self._time_elapsed())
 
     # Manual: Test suite does not currently test this feature, so it must be tested manually
     def MANUAL(self, detail="", link=None):
-        return [self.name, "Manual", "bg-primary", self.description, detail, link, self._current_time(),
-                self._time_elapsed()]
+        return TestResult(self.name, TestStates.MANUAL, self.description, detail, link, self._current_time(),
+                          self._time_elapsed())
 
     # Not Applicable: Test is not applicable, e.g. due to the version of the specification being tested
     def NA(self, detail, link=None):
-        return [self.name, "Not Applicable", "bg-secondary", self.description, detail, link, self._current_time(),
-                self._time_elapsed()]
+        return TestResult(self.name, TestStates.NA, self.description, detail, link, self._current_time(),
+                          self._time_elapsed())
 
     # Fail: Required feature of the specification has been found to be implemented incorrectly
     def FAIL(self, detail, link=None):
-        return [self.name, "Fail", "bg-danger", self.description, detail, link, self._current_time(),
-                self._time_elapsed()]
+        return TestResult(self.name, TestStates.FAIL, self.description, detail, link, self._current_time(),
+                          self._time_elapsed())
 
     # Optional: Recommended/optional feature of the specifications has been found to be not implemented
     # Detail message should explain the effect of this feature being unimplemented
     def OPTIONAL(self, detail, link=None):
-        return [self.name, "Not Implemented", "bg-warning", self.description, detail, link, self._current_time(),
-                self._time_elapsed()]
+        return TestResult(self.name, TestStates.OPTIONAL, self.description, detail, link, self._current_time(),
+                          self._time_elapsed())
 
     # Disabled: Test is disabled due to test suite configuration; change the config or test manually
     def DISABLED(self, detail="", link=None):
-        return [self.name, "Test Disabled", "bg-warning", self.description, detail, link, self._current_time(),
-                self._time_elapsed()]
+        return TestResult(self.name, TestStates.DISABLED, self.description, detail, link, self._current_time(),
+                          self._time_elapsed())
 
     # Unclear: Test was not run due to prior responses from the API, which may be OK, or indicate a fault
     def UNCLEAR(self, detail="", link=None):
-        return [self.name, "Could Not Test", "bg-warning", self.description, detail, link, self._current_time(),
-                self._time_elapsed()]
+        return TestResult(self.name, TestStates.UNCLEAR, self.description, detail, link, self._current_time(),
+                          self._time_elapsed())

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -412,11 +412,15 @@ def run_noninteractive_tests(args):
     endpoints = []
     for i in range(len(args.ip)):
         endpoints.append({"ip": args.ip[i], "port": args.port[i], "version": args.version[i]})
-    results = run_test(args.suite, endpoints, args.selection)
-    if args.output:
-        exit_code = write_test_results(results, args)
-    else:
-        exit_code = print_test_results(results, args)
+    try:
+        results = run_test(args.suite, endpoints, args.selection)
+        if args.output:
+            exit_code = write_test_results(results, args)
+        else:
+            exit_code = print_test_results(results, args)
+    except Exception as e:
+        print(" * ERROR: {}".format(str(e)))
+        exit_code = ExitCodes.ERROR
     return exit_code
 
 

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -223,7 +223,7 @@ def index_page():
                     r.headers['Cache-Control'] = 'no-cache, no-store'
                     return r
                 else:
-                    raise flash("Error: This test definition does not exist")
+                    flash("Error: This test definition does not exist")
             except Exception as e:
                 flash("Error: {}".format(e))
         else:

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -325,13 +325,13 @@ def write_test_results(results, args):
             test_case.is_enabled = False
         elif test_result.state in [TestStates.MANUAL, TestStates.NA, TestStates.OPTIONAL]:
             test_case.add_skipped_info(test_result.detail)
-        elif test_result.state is TestStates.FAIL:
+        elif test_result.state == TestStates.FAIL:
             test_case.add_failure_info(test_result.detail, failure_type=str(test_result.state))
             exit_code = max(exit_code, ExitCodes.FAIL)
-        elif test_result.state is TestStates.WARNING:
+        elif test_result.state == TestStates.WARNING:
             test_case.add_error_info(test_result.detail, error_type=str(test_result.state))
             exit_code = max(exit_code, ExitCodes.WARNING)
-        elif test_result.state is not TestStates.PASS:
+        elif test_result.state != TestStates.PASS:
             test_case.add_error_info(test_result.detail, error_type=str(test_result.state))
         test_cases.append(test_case)
 
@@ -348,9 +348,9 @@ def print_test_results(results, args):
     print("----------------------------")
     total_time = 0
     for test_result in results["result"]:
-        if test_result.state is TestStates.FAIL:
+        if test_result.state == TestStates.FAIL:
             exit_code = max(exit_code, ExitCodes.FAIL)
-        elif test_result.state is TestStates.WARNING:
+        elif test_result.state == TestStates.WARNING:
             exit_code = max(exit_code, ExitCodes.WARNING)
         result_str = "{} ... {}".format(test_result.name, str(test_result.state))
         print(result_str)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ websocket-client
 jsonref
 dnslib
 jinja2
+junit-xml


### PR DESCRIPTION
Will resolve #43 

This is just a bit of refactoring with the aim to permit command line operation triggered by automated testing jobs.

I'd appreciate thoughts on whether the unit under test should be passed in via command line argument or use of the existing Config file. Equally, if passing things in via the command line should it be possible to override Config.py values via this method?

Also, what format would the test results be most useful in? I'm intending that the exit code reflects the worst test result encountered in the pass, but the detail of failures could be formatted however is most useful.