### PR TITLE
Add boilerplate for BCP003-02 API testing

### DIFF
--- a/Config.py
+++ b/Config.py
@@ -107,5 +107,16 @@ SPECIFICATIONS = {
                 "raml": "ChannelMappingAPI.raml"
             }
         }
+    },
+    "bcp-003": {
+        "repo": "nmos-api-security",
+        "versions": ["v1.0"],
+        "default_version": "v1.0",
+        "apis": {
+            "oauth": {
+                "name": "Authorization API",
+                "raml": "AuthorizationAPI.raml"
+            }
+        }
     }
 }

--- a/Config.py
+++ b/Config.py
@@ -108,12 +108,12 @@ SPECIFICATIONS = {
             }
         }
     },
-    "bcp-003": {
+    "bcp-003-02": {
         "repo": "nmos-api-security",
         "versions": ["v1.0"],
         "default_version": "v1.0",
         "apis": {
-            "oauth": {
+            "auth": {
                 "name": "Authorization API",
                 "raml": "AuthorizationAPI.raml"
             }

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -11,6 +11,7 @@ The following test sets are currently supported:
 *   IS-06 Network Control API
 *   IS-07 Event & Tally API
 *   IS-08 Channel Mapping API
+*   BCP-003-02 Authorization API
 
 When testing any of the above APIs it is important that they contain representative data. The test results will generate 'N/A' results if no testable entities can be located. In addition, if device support many modes of operation (including multiple video/audio formats) it is strongly recommended to re-test them in multiple modes.
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -11,13 +11,9 @@ The following test sets are currently supported:
 *   IS-06 Network Control API
 *   IS-07 Event & Tally API
 *   IS-08 Channel Mapping API
-<<<<<<< HEAD
-*   BCP-003-02 Authorization API
-=======
 *   IS-08 Interaction with IS-04
 *   BCP-003-01 Secure API Communications
 *   BCP-003-02 Authorization API
->>>>>>> origin/master
 
 When testing any of the above APIs it is important that they contain representative data. The test results will generate 'Could Not Test' results if no testable entities can be located. In addition, if device support many modes of operation (including multiple video/audio formats) it is strongly recommended to re-test them in multiple modes.
 

--- a/Specification.py
+++ b/Specification.py
@@ -70,6 +70,7 @@ class Specification(object):
                     if in_schemas and not line.startswith(" "):
                         # Detect that we've reached the first line after the schemas/types section
                         in_schemas = False
+                        type_name = None
 
                     if in_schemas and "!include" not in line:
                         # This is a correct RAML 1.0 type definition
@@ -86,7 +87,7 @@ class Specification(object):
                         # We've hit the global schema/type definition section
                         in_schemas = True
 
-                    if line.startswith("traits:"):
+                    if line.startswith("traits:") or line.startswith("securitySchemes:"):
                         # Remove traits to work around an issue with ramlfications util.py '_remove_duplicates'
                         line = "bugfix:\r\n"
 
@@ -108,7 +109,7 @@ class Specification(object):
             for schema in api_raml.schemas:
                 keys = list(schema.keys())
                 self.global_schemas[keys[0]] = schema[keys[0]]
-        elif "types" in api_raml.raw:
+        elif "types" in api_raml.raw and api_raml.raw["types"] is not None:
             # Handle RAML 1.0 parsing manually as ramlfications doesn't support it
             for schema in api_raml.raw["types"]:
                 keys = list(schema.keys())

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -134,8 +134,8 @@ TEST_DEFINITIONS = {
     "BCP-003-02": {
         "name": "BCP-003-02 Authorization API",
         "specs": [{
-            "spec_key": 'bcp-003',
-            "api_key": "oauth"
+            "spec_key": 'bcp-003-02',
+            "api_key": "auth"
         }],
         "class": BCP00302Test.BCP00302Test
     }

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -40,6 +40,7 @@ import IS0502Test
 import IS0601Test
 import IS0701Test
 import IS0801Test
+import BCP00302Test
 
 FLASK_APPS = []
 DNS_SERVER = None
@@ -129,6 +130,14 @@ TEST_DEFINITIONS = {
             "api_key": "channelmapping"
         }],
         "class": IS0801Test.IS0801Test
+    },
+    "BCP-003-02": {
+        "name": "BCP-003-02 Authorization API",
+        "specs": [{
+            "spec_key": 'bcp-003',
+            "api_key": "oauth"
+        }],
+        "class": BCP00302Test.BCP00302Test
     }
 }
 


### PR DESCRIPTION
This doesn't work yet, but in looking at BCP003-02 RAML I added this test set, so thought I'd leave it here until it's ready to merge.