### PR TITLE
Strip trailing slash when testing API base resources

### DIFF
--- a/GenericTest.py
+++ b/GenericTest.py
@@ -292,7 +292,7 @@ class GenericTest(object):
 
         # Test general URLs with no parameters
         elif not resource[1]['params']:
-            url = "{}{}".format(self.apis[api]["url"].rstrip("/"), resource[0])
+            url = "{}{}".format(self.apis[api]["url"].rstrip("/"), resource[0].rstrip("/"))
             test = Test("{} /x-nmos/{}/{}{}".format(resource[1]['method'].upper(),
                                                     api,
                                                     self.apis[api]["version"],


### PR DESCRIPTION
I'd consider this to be a bug according to the trailing slash policy. Unfortunately as an artefact of the way RAML is specified the top level resource is defined by a slash, which was causing the likes of GET /x-nmos/node/version to be tested with a slash at the end. This corrects that behaviour in order to bring it into line with the general policy.