### PR TITLE
in Registry.py, request.json throws 400 Exception

### DIFF
--- a/Registry.py
+++ b/Registry.py
@@ -103,7 +103,7 @@ def heartbeat(version, node_id):
     registry = REGISTRIES[flask.current_app.config["REGISTRY_INSTANCE"]]
     if not registry.enabled:
         abort(500)
-    registry.heartbeat(request.headers, request.json, node_id)
+    registry.heartbeat(request.headers, request.get_json(False, True), node_id)
     if node_id in registry.get_resources()["node"]:
         return jsonify({"health": int(time.time())})
     else:


### PR DESCRIPTION
test_05 requires to POST to health/node/<node_id> with no body, but the mock perform a "request.json" which throw an Exception if there's no content (or no valid json).
A request.get_json(False, True) parses the body if any or return None if there's no content.