### PR TITLE
Add initial support for testing BCP-003-01 TLS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ ENV/
 
 # Other
 cache/
+testssl/
+!testssl/README.md
+tls-report.json

--- a/BCP00301Test.py
+++ b/BCP00301Test.py
@@ -42,8 +42,8 @@ class BCP00301Test(GenericTest):
             ret = subprocess.run(["testssl/testssl.sh", "--jsonfile", TMPFILE, "--warnings", "off"] + args +
                                  ["{}:{}".format(self.apis[BCP_API_KEY]["hostname"], self.apis[BCP_API_KEY]["port"])])
         except Exception as e:
-            raise NMOSTestException(test.DISABLED("Unable to execute testssl.sh. Please see the README for installation"
-                                                  " instructions: {}".format(e)))
+            raise NMOSTestException(test.DISABLED("Unable to execute testssl.sh. Please see the README for "
+                                                  "installation instructions: {}".format(e)))
         return ret.returncode
 
     def test_01(self):

--- a/BCP00301Test.py
+++ b/BCP00301Test.py
@@ -55,7 +55,7 @@ class BCP00301Test(GenericTest):
             with open(TMPFILE) as tls_data:
                 tls_data = json.load(tls_data)
                 for report in tls_data:
-                    if report["id"] in ["SSLv2", "SSLv3", "TLS1", "TLS1_1"] and report["finding"] != "not offered":
+                    if report["id"] in ["SSLv2", "SSLv3", "TLS1", "TLS1_1"] and "not offered" not in report["finding"]:
                         return test.FAIL("Protocol {} must not be offered".format(report["id"].replace("_", ".")))
                     elif report["id"] in ["TLS1_2"] and report["finding"] != "offered":
                         return test.FAIL("Protocol {} must be offered".format(report["id"].replace("_", ".")))

--- a/BCP00301Test.py
+++ b/BCP00301Test.py
@@ -1,0 +1,108 @@
+# Copyright (C) 2018 British Broadcasting Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import json
+
+from GenericTest import GenericTest
+from TestResult import Test
+
+BCP_API_KEY = "bcp-003-01"
+TMPFILE = "tls-report.json"
+
+
+class BCP00301Test(GenericTest):
+    """
+    Runs BCP-003-01-Test
+    """
+    def __init__(self, apis):
+        GenericTest.__init__(self, apis)
+
+    def test_01(self):
+        if os.path.exists(TMPFILE):
+            os.remove(TMPFILE)
+        test = Test("TLS Protocols")
+        ret = subprocess.run(["testssl/testssl.sh", "--jsonfile", TMPFILE, "--warnings", "off", "-p",
+                              "{}:{}".format(self.apis[BCP_API_KEY]["hostname"], self.apis[BCP_API_KEY]["port"])])
+        if ret.returncode != 0:
+            return test.FAIL("Unable to test. See the console for further information.")
+        else:
+            with open(TMPFILE) as tls_data:
+                tls_data = json.load(tls_data)
+                for report in tls_data:
+                    if report["id"] in ["SSLv2", "SSLv3", "TLS1", "TLS1_1"] and report["finding"] != "not offered":
+                        return test.FAIL("Protocol {} must not be offered".format(report["id"].replace("_", ".")))
+                    elif report["id"] in ["TLS1_2"] and report["finding"] != "offered":
+                        return test.FAIL("Protocol {} must be offered".format(report["id"].replace("_", ".")))
+                    elif report["id"] in ["TLS1_3"] and report["finding"] != "offered":
+                        return test.WARNING("Protocol {} should be offered".format(report["id"].replace("_", ".")))
+            return test.PASS()
+
+    def test_02(self):
+        if os.path.exists(TMPFILE):
+            os.remove(TMPFILE)
+        test = Test("TLS Ciphers")
+        ret = subprocess.run(["testssl/testssl.sh", "--jsonfile", TMPFILE, "--warnings", "off", "-E",
+                              "{}:{}".format(self.apis[BCP_API_KEY]["hostname"], self.apis[BCP_API_KEY]["port"])])
+        if ret.returncode != 0:
+            return test.FAIL("Unable to test. See the console for further information.")
+        else:
+            with open(TMPFILE) as tls_data:
+                tls_data = json.load(tls_data)
+                tls1_3_supported = False
+                for report in tls_data:
+                    tls1_2_shall = ["TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8"]
+                    tls1_2_should = ["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+                                     "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+                                     "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+                                     "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+                                     "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                                     "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                                     "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+                                     "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+                                     "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+                                     "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+                                     "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
+                                     "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256"]
+                    tls1_3_shall = ["TLS_AES_128_GCM_SHA256"]
+                    tls1_3_should = ["TLS_AES_256_GCM_SHA384",
+                                     "TLS_CHACHA20_POLY1305_SHA256"]
+                    if report["finding"].startswith("TLS 1.2"):
+                        cipher = report["finding"].split("\t")[-1]
+                        if cipher in tls1_2_shall:
+                            tls1_2_shall.remove(cipher)
+                        elif cipher in tls1_2_should:
+                            tls1_2_should.remove(cipher)
+                    elif report["finding"].startswith("TLS 1.3"):
+                        tls1_3_supported = True
+                        cipher = report["finding"].split("\t")[-1]
+                        if cipher in tls1_3_shall:
+                            tls1_3_shall.remove(cipher)
+                        elif cipher in tls1_3_should:
+                            tls1_3_should.remove(cipher)
+            if len(tls1_2_shall) > 0:
+                return test.FAIL("Implementation the following TLS 1.2 ciphers is required: {}"
+                                 .format(",".join(tls1_2_shall)))
+            elif tls1_3_supported and len(tls1_3_shall) > 0:
+                return test.FAIL("Implementation the following TLS 1.3 ciphers is required: {}"
+                                 .format(",".join(tls1_3_shall)))
+            elif len(tls1_2_should) > 0:
+                return test.WARNING("Implementation the following TLS 1.2 ciphers is recommended: {}"
+                                    .format(",".join(tls1_2_should)))
+            elif tls1_3_supported and len(tls1_3_should) > 0:
+                return test.WARNING("Implementation the following TLS 1.3 ciphers is recommended: {}"
+                                    .format(",".join(tls1_3_should)))
+            else:
+                return test.PASS()

--- a/BCP00301Test.py
+++ b/BCP00301Test.py
@@ -42,8 +42,8 @@ class BCP00301Test(GenericTest):
             ret = subprocess.run(["testssl/testssl.sh", "--jsonfile", TMPFILE, "--warnings", "off"] + args +
                                  ["{}:{}".format(self.apis[BCP_API_KEY]["hostname"], self.apis[BCP_API_KEY]["port"])])
         except Exception as e:
-            raise NMOSTestException(test.FAIL("Unable to execute testssl.sh. Please see the README for installation "
-                                              "instructions: {}".format(e)))
+            raise NMOSTestException(test.DISABLED("Unable to execute testssl.sh. Please see the README for installation"
+                                                  " instructions: {}".format(e)))
         return ret.returncode
 
     def test_01(self):

--- a/Config.py
+++ b/Config.py
@@ -114,5 +114,13 @@ SPECIFICATIONS = {
                 "raml": "ChannelMappingAPI.raml"
             }
         }
+    },
+    "bcp-003-01": {
+        "repo": None,
+        "versions": ["v1.0"],
+        "default_version": "v1.0",
+        "apis": {
+            "secure": {}
+        }
     }
 }

--- a/GenericTest.py
+++ b/GenericTest.py
@@ -70,26 +70,28 @@ class GenericTest(object):
         test = Test("Test initialisation")
 
         for api_name, api_data in self.apis.items():
-            if "spec_path" in api_data:
-                repo = git.Repo(api_data["spec_path"])
+            if "spec_path" not in api_data:
+                continue
 
-                # List remote branches and check there is a v#.#.x or v#.#-dev
-                branches = repo.git.branch('-a')
-                spec_branch = None
-                branch_names = [api_data["version"] + ".x", api_data["version"] + "-dev"]
-                for branch in branch_names:
-                    if "remotes/origin/" + branch in branches:
-                        spec_branch = branch
-                        break
+            repo = git.Repo(api_data["spec_path"])
 
-                if not spec_branch:
-                    raise Exception("No branch matching the expected patterns was found in the Git repository")
+            # List remote branches and check there is a v#.#.x or v#.#-dev
+            branches = repo.git.branch('-a')
+            spec_branch = None
+            branch_names = [api_data["version"] + ".x", api_data["version"] + "-dev"]
+            for branch in branch_names:
+                if "remotes/origin/" + branch in branches:
+                    spec_branch = branch
+                    break
 
-                api_data["spec_branch"] = spec_branch
+            if not spec_branch:
+                raise Exception("No branch matching the expected patterns was found in the Git repository")
 
-                repo.git.reset('--hard')
-                repo.git.checkout(spec_branch)
-                repo.git.rebase("origin/" + spec_branch)
+            api_data["spec_branch"] = spec_branch
+
+            repo.git.reset('--hard')
+            repo.git.checkout(spec_branch)
+            repo.git.rebase("origin/" + spec_branch)
 
         self.parse_RAML()
 
@@ -98,9 +100,10 @@ class GenericTest(object):
     def parse_RAML(self):
         """Create a Specification object for each API defined in this object"""
         for api in self.apis:
-            if "spec_path" in self.apis[api]:
-                self.apis[api]["spec"] = Specification(os.path.join(self.apis[api]["spec_path"] + '/APIs/' +
-                                                                    self.apis[api]["raml"]))
+            if "spec_path" not in self.apis[api]:
+                continue
+            self.apis[api]["spec"] = Specification(os.path.join(self.apis[api]["spec_path"] + '/APIs/' +
+                                                                self.apis[api]["raml"]))
 
     def execute_tests(self, test_names):
         """Perform tests defined within this class"""
@@ -261,19 +264,22 @@ class GenericTest(object):
         results = []
 
         for api in self.apis:
-            if "spec_path" in self.apis[api]:
-                results.append(self.check_base_path(self.apis[api]["base_url"], "/x-nmos", api + "/"))
-                results.append(self.check_base_path(self.apis[api]["base_url"], "/x-nmos/{}".format(api),
-                                                    self.apis[api]["version"] + "/"))
+            if "spec_path" not in self.apis[api]:
+                continue
 
-                for resource in self.apis[api]["spec"].get_reads():
-                    for response_code in resource[1]['responses']:
-                        if response_code == 200 and resource[0] not in self.omit_paths:
-                            # TODO: Test for each of these if the trailing slash version also works and if redirects are
-                            # used on either.
-                            result = self.check_api_resource(resource, response_code, api)
-                            if result is not None:
-                                results.append(result)
+            # We don't check the very base of the URL (before x-nmos) as it may be used for other things
+            results.append(self.check_base_path(self.apis[api]["base_url"], "/x-nmos", api + "/"))
+            results.append(self.check_base_path(self.apis[api]["base_url"], "/x-nmos/{}".format(api),
+                                                self.apis[api]["version"] + "/"))
+
+            for resource in self.apis[api]["spec"].get_reads():
+                for response_code in resource[1]['responses']:
+                    if response_code == 200 and resource[0] not in self.omit_paths:
+                        # TODO: Test for each of these if the trailing slash version also works and if redirects are
+                        # used on either.
+                        result = self.check_api_resource(resource, response_code, api)
+                        if result is not None:
+                            results.append(result)
 
         return results
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -11,6 +11,7 @@ The following test sets are currently supported:
 *   IS-06 Network Control API
 *   IS-07 Event & Tally API
 *   IS-08 Channel Mapping API
+*   BCP-003-01 Secure API Communications
 
 When testing any of the above APIs it is important that they contain representative data. The test results will generate 'Could Not Test' results if no testable entities can be located. In addition, if device support many modes of operation (including multiple video/audio formats) it is strongly recommended to re-test them in multiple modes.
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -47,6 +47,10 @@ The result of each test case will be one of the following:
 
 In order to test unicast discovery, ensure the `DNS_SD_MODE` is set to `'unicast'`. Additionally, ensure that the unit under test has its search domain set to 'testsuite.nmos.tv' and the DNS server IP to the IP address of the server which is running the test suite instance.
 
+### Testing BCP-003-01 TLS
+
+Testing of certain aspects of BCP-003-01 makes use of an external tool 'testssl.sh'. Please see [testssl/README.md](testssl/README.md) for installation instructions.
+
 ### Non-Interative Mode
 
 The test suite supports non-interactive operation in order use it within continuous integration systems. An example of this usage can be seen below:
@@ -63,6 +67,7 @@ python3 nmos-test.py --suite IS-04-02 --selection auto --ip 128.66.12.5 128.66.1
 
 *   Python 3
 *   Git
+*   [testssl.sh](https://testssl.sh) (required for BCP-003-01 testing)
 *   See [requirements.txt](requirements.txt) for additional packages
 
 ## Known Issues

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -331,23 +331,24 @@ def init_spec_cache():
 
     for repo_key, repo_data in SPECIFICATIONS.items():
         path = os.path.join(CACHE_PATH + '/' + repo_key)
-        if repo_data["repo"] is not None:
-            if not os.path.exists(path):
-                print(" * Initialising repository '{}'".format(repo_data["repo"]))
-                repo = git.Repo.clone_from('https://github.com/AMWA-TV/' + repo_data["repo"] + '.git', path)
-                update_last_pull = True
-            else:
-                repo = git.Repo(path)
-                repo.git.reset('--hard')
-                # Only pull if we haven't in the last hour
-                if (last_pull_time + timedelta(hours=1)) <= time_now:
-                    print(" * Pulling latest files for repository '{}'".format(repo_data["repo"]))
-                    try:
-                        repo.remotes.origin.pull()
-                        update_last_pull = True
-                    except Exception as e:
-                        print(" * ERROR: Unable to update repository '{}'. If the problem persists, "
-                              "please delete the '{}' directory".format(repo_data["repo"], CACHE_PATH))
+        if repo_data["repo"] is None:
+            continue
+        if not os.path.exists(path):
+            print(" * Initialising repository '{}'".format(repo_data["repo"]))
+            repo = git.Repo.clone_from('https://github.com/AMWA-TV/' + repo_data["repo"] + '.git', path)
+            update_last_pull = True
+        else:
+            repo = git.Repo(path)
+            repo.git.reset('--hard')
+            # Only pull if we haven't in the last hour
+            if (last_pull_time + timedelta(hours=1)) <= time_now:
+                print(" * Pulling latest files for repository '{}'".format(repo_data["repo"]))
+                try:
+                    repo.remotes.origin.pull()
+                    update_last_pull = True
+                except Exception as e:
+                    print(" * ERROR: Unable to update repository '{}'. If the problem persists, "
+                          "please delete the '{}' directory".format(repo_data["repo"], CACHE_PATH))
 
     if update_last_pull:
         try:

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -20,7 +20,11 @@ function updateDropdown() {
           versionDropdown.options[i] = new Option(specData[specKey]["versions"][i], specData[specKey]["versions"][i]);
         }
         versionDropdown.value = specData[specKey]["default_version"];
-        label.innerHTML = specData[specKey]["apis"][apiKey]["name"] + ":";
+        if (apiKey in specData[specKey]["apis"]) {
+          label.innerHTML = specData[specKey]["apis"][apiKey]["name"] + ":";
+        } else {
+          label.innerHTML = "";
+        }
         div.style.display = "block";
       } else {
         div.style.display = "none";

--- a/testssl/README.md
+++ b/testssl/README.md
@@ -1,0 +1,3 @@
+# testssl.sh
+
+Please download the 'testssl.sh' script (v3.0 rc3) into this directory, and the accompanying files into a subdirectory of 'etc/'.

--- a/testssl/README.md
+++ b/testssl/README.md
@@ -1,3 +1,13 @@
 # testssl.sh
 
-Please download the 'testssl.sh' script (v3.0 rc3) into this directory, and the accompanying files into a subdirectory of 'etc/'.
+In order to test BCP-003-01, the 'testssl.sh' script (v3.0 rc4) must be placed in this directory with 'execute' permission enabled. This tool is known to work on Linux and Mac OS, but will not work on Windows.
+
+Please download the required files using the following link, then untar the results into this directory:
+<https://github.com/drwetter/testssl.sh/archive/3.0rc4.tar.gz>
+
+Alternatively, use the following command which can be executed from within this 'testssl' directory.
+
+```shell
+wget https://github.com/drwetter/testssl.sh/archive/3.0rc4.tar.gz
+tar -xvzf 3.0rc4.tar.gz --strip-components=1
+```


### PR DESCRIPTION
A new test set as testssl.sh takes quite a while to run tests, so we won't want to run them all the time. Initially covers TLS versions and cipher suites, but will be expanded. Requires a download of testssl.sh which I'll add further documentation for before review.