### PR TITLE
Check for empty request bodies on POST /health/nodes/{nodeId}

### DIFF
--- a/GenericTest.py
+++ b/GenericTest.py
@@ -78,6 +78,8 @@ class GenericTest(object):
             if not spec_branch:
                 raise Exception("No branch matching the expected patterns was found in the Git repository")
 
+            api_data["spec_branch"] = spec_branch
+
             repo.git.reset('--hard')
             repo.git.checkout(spec_branch)
             repo.git.rebase("origin/" + spec_branch)

--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -320,8 +320,10 @@ class IS0401Test(GenericTest):
                     return test.FAIL("First heartbeat occurred too long after initial Node registration.")
 
             # Ensure the heartbeat request body is empty
-            if heartbeat[1]["payload"] is not None:
-                return test.FAIL("Heartbeat POST contained a payload body.")
+            if heartbeat[1]["payload"] is not bytes():
+                return test.WARNING("Heartbeat POST contained a payload body.", "https://amwa-tv.github.io/nmos-discovery-registration/tags/v1.2.1/docs/2.2._APIs_-_Client_Side_Implementation_Notes.html#empty-request-bodies")
+            if "Content-Type" in heartbeat[1]["headers"]:
+                return test.WARNING("Heartbeat POST contained a Content-Type header.", "https://amwa-tv.github.io/nmos-discovery-registration/tags/v1.2.1/docs/2.2._APIs_-_Client_Side_Implementation_Notes.html#empty-request-bodies")
 
             last_hb = heartbeat
 

--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -293,6 +293,8 @@ class IS0401Test(GenericTest):
         if not ENABLE_DNS_SD:
             return test.DISABLED("This test cannot be performed when ENABLE_DNS_SD is False")
 
+        api = self.apis[NODE_API_KEY]
+
         self.do_registry_basics_prereqs()
 
         registry = self.registries[0]
@@ -321,9 +323,9 @@ class IS0401Test(GenericTest):
 
             # Ensure the heartbeat request body is empty
             if heartbeat[1]["payload"] is not bytes():
-                return test.WARNING("Heartbeat POST contained a payload body.", "https://amwa-tv.github.io/nmos-discovery-registration/tags/v1.2.1/docs/2.2._APIs_-_Client_Side_Implementation_Notes.html#empty-request-bodies")
+                return test.WARNING("Heartbeat POST contained a payload body.", "https://amwa-tv.github.io/nmos-discovery-registration/branches/{}/docs/2.2._APIs_-_Client_Side_Implementation_Notes.html#empty-request-bodies".format(api["spec_branch"]))
             if "Content-Type" in heartbeat[1]["headers"]:
-                return test.WARNING("Heartbeat POST contained a Content-Type header.", "https://amwa-tv.github.io/nmos-discovery-registration/tags/v1.2.1/docs/2.2._APIs_-_Client_Side_Implementation_Notes.html#empty-request-bodies")
+                return test.WARNING("Heartbeat POST contained a Content-Type header.", "https://amwa-tv.github.io/nmos-discovery-registration/branches/{}/docs/2.2._APIs_-_Client_Side_Implementation_Notes.html#empty-request-bodies".format(api["spec_branch"]))
 
             last_hb = heartbeat
 

--- a/Registry.py
+++ b/Registry.py
@@ -103,7 +103,8 @@ def heartbeat(version, node_id):
     registry = REGISTRIES[flask.current_app.config["REGISTRY_INSTANCE"]]
     if not registry.enabled:
         abort(500)
-    registry.heartbeat(request.headers, request.json, node_id)
+    # store raw request payload, in order to check for empty request bodies later
+    registry.heartbeat(request.headers, request.data, node_id)
     if node_id in registry.get_resources()["node"]:
         return jsonify({"health": int(time.time())})
     else:


### PR DESCRIPTION
Replaces #168.

Implements https://github.com/amwa-tv/nmos-discovery-registration/blob/v1.2.1/docs/2.2.%20APIs%20-%20Client%20Side%20Implementation%20Notes.md#empty-request-bodies