### PR TITLE
bcp00301: fix parsing when spaces used in string separation

### DIFF
--- a/BCP00301Test.py
+++ b/BCP00301Test.py
@@ -69,26 +69,26 @@ class BCP00301Test(GenericTest):
         if ret != 0:
             return test.FAIL("Unable to test. See the console for further information.")
         else:
+            tls1_3_supported = False
+            tls1_2_shall = ["TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8"]
+            tls1_2_should = ["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+                             "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+                             "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+                             "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+                             "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                             "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                             "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+                             "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+                             "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+                             "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+                             "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
+                             "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256"]
+            tls1_3_shall = ["TLS_AES_128_GCM_SHA256"]
+            tls1_3_should = ["TLS_AES_256_GCM_SHA384",
+                             "TLS_CHACHA20_POLY1305_SHA256"]
             with open(TMPFILE) as tls_data:
                 tls_data = json.load(tls_data)
-                tls1_3_supported = False
                 for report in tls_data:
-                    tls1_2_shall = ["TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8"]
-                    tls1_2_should = ["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-                                     "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-                                     "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
-                                     "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
-                                     "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-                                     "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-                                     "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
-                                     "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
-                                     "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
-                                     "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
-                                     "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
-                                     "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256"]
-                    tls1_3_shall = ["TLS_AES_128_GCM_SHA256"]
-                    tls1_3_should = ["TLS_AES_256_GCM_SHA384",
-                                     "TLS_CHACHA20_POLY1305_SHA256"]
                     if report["finding"].startswith("TLS 1.2"):
                         cipher = report["finding"].split()[-1]
                         if cipher in tls1_2_shall:
@@ -103,16 +103,16 @@ class BCP00301Test(GenericTest):
                         elif cipher in tls1_3_should:
                             tls1_3_should.remove(cipher)
             if len(tls1_2_shall) > 0:
-                return test.FAIL("Implementation the following TLS 1.2 ciphers is required: {}"
+                return test.FAIL("Implementation of the following TLS 1.2 ciphers is required: {}"
                                  .format(",".join(tls1_2_shall)))
             elif tls1_3_supported and len(tls1_3_shall) > 0:
-                return test.FAIL("Implementation the following TLS 1.3 ciphers is required: {}"
+                return test.FAIL("Implementation of the following TLS 1.3 ciphers is required: {}"
                                  .format(",".join(tls1_3_shall)))
             elif len(tls1_2_should) > 0:
-                return test.WARNING("Implementation the following TLS 1.2 ciphers is recommended: {}"
+                return test.WARNING("Implementation of the following TLS 1.2 ciphers is recommended: {}"
                                     .format(",".join(tls1_2_should)))
             elif tls1_3_supported and len(tls1_3_should) > 0:
-                return test.WARNING("Implementation the following TLS 1.3 ciphers is recommended: {}"
+                return test.WARNING("Implementation of the following TLS 1.3 ciphers is recommended: {}"
                                     .format(",".join(tls1_3_should)))
             else:
                 return test.PASS()

--- a/BCP00301Test.py
+++ b/BCP00301Test.py
@@ -90,14 +90,14 @@ class BCP00301Test(GenericTest):
                     tls1_3_should = ["TLS_AES_256_GCM_SHA384",
                                      "TLS_CHACHA20_POLY1305_SHA256"]
                     if report["finding"].startswith("TLS 1.2"):
-                        cipher = report["finding"].split("\t")[-1]
+                        cipher = report["finding"].split()[-1]
                         if cipher in tls1_2_shall:
                             tls1_2_shall.remove(cipher)
                         elif cipher in tls1_2_should:
                             tls1_2_should.remove(cipher)
                     elif report["finding"].startswith("TLS 1.3"):
                         tls1_3_supported = True
-                        cipher = report["finding"].split("\t")[-1]
+                        cipher = report["finding"].split()[-1]
                         if cipher in tls1_3_shall:
                             tls1_3_shall.remove(cipher)
                         elif cipher in tls1_3_should:


### PR DESCRIPTION
@garethsb-sony this may work better. I should have just used split()'s defaults in the first place.