### PR TITLE
Add further BCP003-01 testing

### DIFF
--- a/BCP00301Test.py
+++ b/BCP00301Test.py
@@ -132,14 +132,14 @@ class BCP00301Test(GenericTest):
             with open(TMPFILE) as tls_data:
                 tls_data = json.load(tls_data)
                 for report in tls_data:
-                    if report["id"] == "cert_commonName":
+                    if report["id"].startswith("cert_commonName") and "_wo_SNI" not in report["id"]:
                         common_name = report["finding"]
                         try:
                             ipaddress.ip_address(report["finding"])
                             return test.WARNING("CN is an IP address: {}".format(report["finding"]))
                         except ValueError:
                             pass
-                    elif report["id"] == "cert_subjectAltName":
+                    elif report["id"].startswith("cert_subjectAltName"):
                         if report["finding"].startswith("No SAN"):
                             return test.WARNING("No SAN was found in the certificate")
                         else:

--- a/BCP00301Test.py
+++ b/BCP00301Test.py
@@ -183,10 +183,10 @@ class BCP00301Test(GenericTest):
             with open(TMPFILE) as tls_data:
                 tls_data = json.load(tls_data)
                 for report in tls_data:
-                    if report["id"] == "HSTS":
+                    if report["id"] == "HSTS_time":
                         if report["severity"] == "OK":
                             hsts_supported = True
-                        elif report["finding"] != "not offered":
+                        else:
                             hsts_supported = report["finding"]
             if hsts_supported is True:
                 return test.PASS()

--- a/BCP00301Test.py
+++ b/BCP00301Test.py
@@ -60,9 +60,9 @@ class BCP00301Test(GenericTest):
                 for report in tls_data:
                     if report["id"] in ["SSLv2", "SSLv3", "TLS1", "TLS1_1"] and "not offered" not in report["finding"]:
                         return test.FAIL("Protocol {} must not be offered".format(report["id"].replace("_", ".")))
-                    elif report["id"] in ["TLS1_2"] and report["finding"] != "offered":
+                    elif report["id"] in ["TLS1_2"] and not report["finding"].startswith("offered"):
                         return test.FAIL("Protocol {} must be offered".format(report["id"].replace("_", ".")))
-                    elif report["id"] in ["TLS1_3"] and report["finding"] != "offered":
+                    elif report["id"] in ["TLS1_3"] and not report["finding"].startswith("offered"):
                         return test.WARNING("Protocol {} should be offered".format(report["id"].replace("_", ".")))
             return test.PASS()
 

--- a/BCP00301Test.py
+++ b/BCP00301Test.py
@@ -53,7 +53,7 @@ class BCP00301Test(GenericTest):
 
         ret = self.perform_test_ssl(test, ["-p"])
         if ret != 0:
-            return test.FAIL("Unable to test. See the console for further information.")
+            return test.DISABLED("Unable to test. See the console for further information.")
         else:
             with open(TMPFILE) as tls_data:
                 tls_data = json.load(tls_data)
@@ -63,7 +63,9 @@ class BCP00301Test(GenericTest):
                     elif report["id"] in ["TLS1_2"] and not report["finding"].startswith("offered"):
                         return test.FAIL("Protocol {} must be offered".format(report["id"].replace("_", ".")))
                     elif report["id"] in ["TLS1_3"] and not report["finding"].startswith("offered"):
-                        return test.WARNING("Protocol {} should be offered".format(report["id"].replace("_", ".")))
+                        return test.OPTIONAL("Protocol {} should be offered".format(report["id"].replace("_", ".")),
+                                             "https://amwa-tv.github.io/nmos-api-security/best-practice-secure-comms."
+                                             "html#tls-versions")
             return test.PASS()
 
     def test_02_tls_ciphers(self, test):
@@ -71,7 +73,7 @@ class BCP00301Test(GenericTest):
 
         ret = self.perform_test_ssl(test, ["-E"])
         if ret != 0:
-            return test.FAIL("Unable to test. See the console for further information.")
+            return test.DISABLED("Unable to test. See the console for further information.")
         else:
             tls1_3_supported = False
             tls1_2_shall = ["TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8"]
@@ -113,11 +115,13 @@ class BCP00301Test(GenericTest):
                 return test.FAIL("Implementation of the following TLS 1.3 ciphers is required: {}"
                                  .format(",".join(tls1_3_shall)))
             elif len(tls1_2_should) > 0:
-                return test.WARNING("Implementation of the following TLS 1.2 ciphers is recommended: {}"
-                                    .format(",".join(tls1_2_should)))
+                return test.OPTIONAL("Implementation of the following TLS 1.2 ciphers is recommended: {}"
+                                     .format(",".join(tls1_2_should)), "https://amwa-tv.github.io/nmos-api-security/"
+                                     "best-practice-secure-comms.html#tls-12-cipher-suites")
             elif tls1_3_supported and len(tls1_3_should) > 0:
-                return test.WARNING("Implementation of the following TLS 1.3 ciphers is recommended: {}"
-                                    .format(",".join(tls1_3_should)))
+                return test.OPTIONAL("Implementation of the following TLS 1.3 ciphers is recommended: {}"
+                                     .format(",".join(tls1_3_should)), "https://amwa-tv.github.io/nmos-api-security/"
+                                     "best-practice-secure-comms.html#tls-13-cipher-suites")
             else:
                 return test.PASS()
 
@@ -128,7 +132,7 @@ class BCP00301Test(GenericTest):
         # Known issue: If the OCSP URL is unreachable testssl generates invalid JSON and exits with a non-zero code
         # This is fixed in testssl master, but not yet in a release
         if ret != 0:
-            return test.FAIL("Unable to test. See the console for further information.")
+            return test.DISABLED("Unable to test. See the console for further information.")
         else:
             common_name = None
             with open(TMPFILE) as tls_data:
@@ -138,20 +142,28 @@ class BCP00301Test(GenericTest):
                         common_name = report["finding"]
                         try:
                             ipaddress.ip_address(report["finding"])
-                            return test.WARNING("CN is an IP address: {}".format(report["finding"]))
+                            return test.WARNING("CN is an IP address: {}".format(report["finding"]), "https://amwa-tv"
+                                                ".github.io/nmos-api-security/best-practice-secure-comms.html#x509-"
+                                                "certificates-and-certificate-authority")
                         except ValueError:
                             pass
                     elif report["id"].split()[0] == "cert_subjectAltName":
                         if report["finding"].startswith("No SAN"):
-                            return test.WARNING("No SAN was found in the certificate")
+                            return test.OPTIONAL("No SAN was found in the certificate", "https://amwa-tv.github.io/"
+                                                 "nmos-api-security/best-practice-secure-comms.html#x509-certificates-"
+                                                 "and-certificate-authority")
                         else:
                             alt_names = report["finding"].split()
                             if common_name not in alt_names:
-                                return test.WARNING("CN {} was not found in the SANs".format(common_name))
+                                return test.OPTIONAL("CN {} was not found in the SANs".format(common_name), "https://"
+                                                     "amwa-tv.github.io/nmos-api-security/best-practice-secure-comms."
+                                                     "html#x509-certificates-and-certificate-authority")
                             for name in alt_names:
                                 try:
                                     ipaddress.ip_address(name)
-                                    return test.WARNING("SAN is an IP address: {}".format(name))
+                                    return test.WARNING("SAN is an IP address: {}".format(name), "https://amwa-tv"
+                                                        ".github.io/nmos-api-security/best-practice-secure-comms.html"
+                                                        "#x509-certificates-and-certificate-authority")
                                 except ValueError:
                                     pass
 
@@ -165,7 +177,7 @@ class BCP00301Test(GenericTest):
 
         ret = self.perform_test_ssl(test, ["-h"])
         if ret != 0:
-            return test.FAIL("Unable to test. See the console for further information.")
+            return test.DISABLED("Unable to test. See the console for further information.")
         else:
             hsts_supported = False
             with open(TMPFILE) as tls_data:
@@ -179,7 +191,8 @@ class BCP00301Test(GenericTest):
             if hsts_supported is True:
                 return test.PASS()
             elif hsts_supported is False:
-                return test.WARNING("Strict Transport Security (HSTS) should be supported")
+                return test.OPTIONAL("Strict Transport Security (HSTS) should be supported", "https://amwa-tv.github.io"
+                                     "/nmos-api-security/best-practice-secure-comms.html#http-server")
             else:
                 return test.FAIL("Error in HSTS header: {}".format(hsts_supported))
 
@@ -190,7 +203,7 @@ class BCP00301Test(GenericTest):
         # Known issue: If the OCSP URL is unreachable testssl generates invalid JSON and exits with a non-zero code
         # This is fixed in testssl master, but not yet in a release
         if ret != 0:
-            return test.FAIL("Unable to test. See the console for further information.")
+            return test.DISABLED("Unable to test. See the console for further information.")
         else:
             with open(TMPFILE) as tls_data:
                 tls_data = json.load(tls_data)
@@ -208,7 +221,7 @@ class BCP00301Test(GenericTest):
         # Known issue: If the OCSP URL is unreachable testssl generates invalid JSON and exits with a non-zero code
         # This is fixed in testssl master, but not yet in a release
         if ret != 0:
-            return test.FAIL("Unable to test. See the console for further information.")
+            return test.DISABLED("Unable to test. See the console for further information.")
         else:
             ocsp_found = False
             with open(TMPFILE) as tls_data:
@@ -216,7 +229,9 @@ class BCP00301Test(GenericTest):
                 for report in tls_data:
                     if report["id"].split()[0] == "OCSP_stapling":
                         if report["finding"] == "not offered":
-                            return test.WARNING("OCSP stapling is not offered by this server")
+                            return test.OPTIONAL("OCSP stapling is not offered by this server", "https://amwa-tv.github"
+                                                 ".io/nmos-api-security/best-practice-secure-comms.html#x509-"
+                                                 "certificates-and-certificate-authority")
                     elif report["id"].split()[0] == "crtl_ocspURL":
                         if report["finding"].startswith("http"):
                             ocsp_found = True
@@ -231,7 +246,7 @@ class BCP00301Test(GenericTest):
 
         ret = self.perform_test_ssl(test, ["-U"])
         if ret != 0:
-            return test.FAIL("Unable to test. See the console for further information.")
+            return test.DISABLED("Unable to test. See the console for further information.")
         else:
             vulnerabilities = {}
             with open(TMPFILE) as tls_data:

--- a/BCP00301Test.py
+++ b/BCP00301Test.py
@@ -241,25 +241,7 @@ class BCP00301Test(GenericTest):
 
             return test.PASS()
 
-    def test_07_vulnerabilities(self, test):
-        """TLS Vulnerabilities"""
-
-        ret = self.perform_test_ssl(test, ["-U"])
-        if ret != 0:
-            return test.DISABLED("Unable to test. See the console for further information.")
-        else:
-            vulnerabilities = {}
-            with open(TMPFILE) as tls_data:
-                tls_data = json.load(tls_data)
-                for report in tls_data:
-                    if report["severity"] not in ["OK", "INFO"]:
-                        vulnerabilities[report["id"]] = report["finding"]
-            if len(vulnerabilities) == 0:
-                return test.PASS()
-            else:
-                return test.WARNING("Server may be vulnerable to the following: {}".format(vulnerabilities))
-
-    def test_08_verify_host(self, test):
+    def test_07_verify_host(self, test):
         """Certificate is valid and matches the host under test"""
 
         try:

--- a/BCP00301Test.py
+++ b/BCP00301Test.py
@@ -191,7 +191,7 @@ class BCP00301Test(GenericTest):
             with open(TMPFILE) as tls_data:
                 tls_data = json.load(tls_data)
                 for report in tls_data:
-                    if report["id"] == "cert_revocation":
+                    if report["id"].split()[0] == "cert_revocation":
                         if report["severity"] == "HIGH":
                             return test.FAIL("No certificate revocation method was provided by the server")
 
@@ -208,7 +208,7 @@ class BCP00301Test(GenericTest):
             with open(TMPFILE) as tls_data:
                 tls_data = json.load(tls_data)
                 for report in tls_data:
-                    if report["id"] == "OCSP_stapling":
+                    if report["id"].split()[0] == "OCSP_stapling":
                         ocsp_found = True
                         if report["finding"] == "not offered":
                             return test.WARNING("OCSP stapling is not offered by this server")

--- a/BCP00301Test.py
+++ b/BCP00301Test.py
@@ -125,6 +125,7 @@ class BCP00301Test(GenericTest):
         """Certificate does not use IP addresses in CN/SANs"""
 
         ret = self.perform_test_ssl(test, ["-S"])
+        # Known issue: If the OCSP URL is unreachable testssl generates invalid JSON and exits with a non-zero code
         if ret != 0:
             return test.FAIL("Unable to test. See the console for further information.")
         else:
@@ -132,14 +133,14 @@ class BCP00301Test(GenericTest):
             with open(TMPFILE) as tls_data:
                 tls_data = json.load(tls_data)
                 for report in tls_data:
-                    if report["id"].startswith("cert_commonName") and "_wo_SNI" not in report["id"]:
+                    if report["id"].split()[0] == "cert_commonName":
                         common_name = report["finding"]
                         try:
                             ipaddress.ip_address(report["finding"])
                             return test.WARNING("CN is an IP address: {}".format(report["finding"]))
                         except ValueError:
                             pass
-                    elif report["id"].startswith("cert_subjectAltName"):
+                    elif report["id"].split()[0] == "cert_subjectAltName":
                         if report["finding"].startswith("No SAN"):
                             return test.WARNING("No SAN was found in the certificate")
                         else:
@@ -185,6 +186,7 @@ class BCP00301Test(GenericTest):
         """Certificate revocation method is available"""
 
         ret = self.perform_test_ssl(test, ["-S"])
+        # Known issue: If the OCSP URL is unreachable testssl generates invalid JSON and exits with a non-zero code
         if ret != 0:
             return test.FAIL("Unable to test. See the console for further information.")
         else:
@@ -201,6 +203,7 @@ class BCP00301Test(GenericTest):
         """OCSP Stapling"""
 
         ret = self.perform_test_ssl(test, ["-S"])
+        # Known issue: If the OCSP URL is unreachable testssl generates invalid JSON and exits with a non-zero code
         if ret != 0:
             return test.FAIL("Unable to test. See the console for further information.")
         else:
@@ -209,9 +212,11 @@ class BCP00301Test(GenericTest):
                 tls_data = json.load(tls_data)
                 for report in tls_data:
                     if report["id"].split()[0] == "OCSP_stapling":
-                        ocsp_found = True
                         if report["finding"] == "not offered":
                             return test.WARNING("OCSP stapling is not offered by this server")
+                    elif report["id"].split()[0] == "crtl_ocspURL":
+                        if report["finding"].startswith("http"):
+                            ocsp_found = True
 
             if not ocsp_found:
                 return test.UNCLEAR("Unable to find OCSP stapling results in the testssl report")

--- a/BCP00301Test.py
+++ b/BCP00301Test.py
@@ -183,23 +183,18 @@ class BCP00301Test(GenericTest):
                 return test.FAIL("Error in HSTS header: {}".format(hsts_supported))
 
     def test_05_revocation(self, test):
-        """Certificate revocation method"""
+        """Certificate revocation method is available"""
 
         ret = self.perform_test_ssl(test, ["-S"])
         if ret != 0:
             return test.FAIL("Unable to test. See the console for further information.")
         else:
-            revocation_found = False
             with open(TMPFILE) as tls_data:
                 tls_data = json.load(tls_data)
                 for report in tls_data:
                     if report["id"] == "cert_revocation":
-                        revocation_found = True
                         if report["severity"] == "HIGH":
                             return test.FAIL("No certificate revocation method was provided by the server")
-
-            if not revocation_found:
-                return test.UNCLEAR("Unable to find certificate revocation results in the testssl report")
 
             return test.PASS()
 
@@ -244,7 +239,7 @@ class BCP00301Test(GenericTest):
 
     def test_08_verify_host(self, test):
         """Certificate is valid and matches the host under test"""
-        
+
         try:
             context = ssl.create_default_context()
             hostname = self.apis[BCP_API_KEY]["hostname"]

--- a/BCP00301Test.py
+++ b/BCP00301Test.py
@@ -126,6 +126,7 @@ class BCP00301Test(GenericTest):
 
         ret = self.perform_test_ssl(test, ["-S"])
         # Known issue: If the OCSP URL is unreachable testssl generates invalid JSON and exits with a non-zero code
+        # This is fixed in testssl master, but not yet in a release
         if ret != 0:
             return test.FAIL("Unable to test. See the console for further information.")
         else:
@@ -146,7 +147,7 @@ class BCP00301Test(GenericTest):
                         else:
                             alt_names = report["finding"].split()
                             if common_name not in alt_names:
-                                return test.FAIL("CN {} was not found in the SANs".format(common_name))
+                                return test.WARNING("CN {} was not found in the SANs".format(common_name))
                             for name in alt_names:
                                 try:
                                     ipaddress.ip_address(name)
@@ -187,6 +188,7 @@ class BCP00301Test(GenericTest):
 
         ret = self.perform_test_ssl(test, ["-S"])
         # Known issue: If the OCSP URL is unreachable testssl generates invalid JSON and exits with a non-zero code
+        # This is fixed in testssl master, but not yet in a release
         if ret != 0:
             return test.FAIL("Unable to test. See the console for further information.")
         else:
@@ -204,6 +206,7 @@ class BCP00301Test(GenericTest):
 
         ret = self.perform_test_ssl(test, ["-S"])
         # Known issue: If the OCSP URL is unreachable testssl generates invalid JSON and exits with a non-zero code
+        # This is fixed in testssl master, but not yet in a release
         if ret != 0:
             return test.FAIL("Unable to test. See the console for further information.")
         else:

--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -383,13 +383,13 @@ class IS0401Test(GenericTest):
         for node in node_list:
             address = socket.inet_ntoa(node.address)
             port = node.port
-            if "/{}:{}/".format(address, port) in self.node_url:
+            api = self.apis[NODE_API_KEY]
+            if address == api["ip"] and port == api["port"]:
                 properties = self.convert_bytes(node.properties)
                 for prop in properties:
                     if "ver_" in prop:
                         return test.FAIL("Found 'ver_' TXT record while Node is registered.")
 
-                api = self.apis[NODE_API_KEY]
                 if self.is04_utils.compare_api_version(api["version"], "v1.1") >= 0:
                     if "api_ver" not in properties:
                         return test.FAIL("No 'api_ver' TXT record found in Node API advertisement.")
@@ -403,8 +403,9 @@ class IS0401Test(GenericTest):
 
                 return test.PASS()
 
-        return test.WARNING("No matching mDNS announcement found for Node. This will not affect operation in registered"
-                            " mode but may indicate a lack of support for peer to peer operation.",
+        return test.WARNING("No matching mDNS announcement found for Node with IP/Port {}:{}. This will not affect "
+                            "operation in registered mode but may indicate a lack of support for peer to peer "
+                            "operation.".format(self.apis[NODE_API_KEY]["ip"], self.apis[NODE_API_KEY]["port"]),
                             "https://github.com/amwa-tv/nmos/wiki/IS-04#nodes-peer-to-peer-mode")
 
     def test_13(self):

--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -76,10 +76,11 @@ class IS0402Test(GenericTest):
         browser = ServiceBrowser(self.zc, service_type, self.zc_listener)
         sleep(2)
         serv_list = self.zc_listener.get_service_list()
-        for api in serv_list:
-            address = socket.inet_ntoa(api.address)
-            port = api.port
-            if "/{}:{}/".format(address, port) in self.reg_url:
+        for service in serv_list:
+            address = socket.inet_ntoa(service.address)
+            port = service.port
+            api = self.apis[REG_API_KEY]
+            if address == api["ip"] and port == api["port"]:
                 properties = self.convert_bytes(api.properties)
                 if "pri" not in properties:
                     return test.FAIL("No 'pri' TXT record found in Registration API advertisement.")
@@ -94,7 +95,6 @@ class IS0402Test(GenericTest):
                     return test.FAIL("Priority ('pri') TXT record is not an integer.")
 
                 # Other TXT records only came in for IS-04 v1.1+
-                api = self.apis[REG_API_KEY]
                 if self.is04_reg_utils.compare_api_version(api["version"], "v1.1") >= 0:
                     if "api_ver" not in properties:
                         return test.FAIL("No 'api_ver' TXT record found in Registration API advertisement.")
@@ -107,7 +107,8 @@ class IS0402Test(GenericTest):
                         return test.FAIL("API protocol ('api_proto') TXT record is not '{}'.".format(self.protocol))
 
                 return test.PASS()
-        return test.FAIL("No matching mDNS announcement found for Registration API.")
+        return test.FAIL("No matching mDNS announcement found for Registration API with IP/Port {}:{}."
+                         .format(self.apis[REG_API_KEY]["ip"], self.apis[REG_API_KEY]["port"]))
 
     def test_02(self):
         """Query API advertises correctly via mDNS"""
@@ -117,10 +118,11 @@ class IS0402Test(GenericTest):
         browser = ServiceBrowser(self.zc, "_nmos-query._tcp.local.", self.zc_listener)
         sleep(2)
         serv_list = self.zc_listener.get_service_list()
-        for api in serv_list:
-            address = socket.inet_ntoa(api.address)
-            port = api.port
-            if "/{}:{}/".format(address, port) in self.query_url:
+        for service in serv_list:
+            address = socket.inet_ntoa(service.address)
+            port = service.port
+            api = self.apis[QUERY_API_KEY]
+            if address == api["ip"] and port == api["port"]:
                 properties = self.convert_bytes(api.properties)
                 if "pri" not in properties:
                     return test.FAIL("No 'pri' TXT record found in Query API advertisement.")
@@ -135,7 +137,6 @@ class IS0402Test(GenericTest):
                     return test.FAIL("Priority ('pri') TXT record is not an integer.")
 
                 # Other TXT records only came in for IS-04 v1.1+
-                api = self.apis[QUERY_API_KEY]
                 if self.is04_query_utils.compare_api_version(api["version"], "v1.1") >= 0:
                     if "api_ver" not in properties:
                         return test.FAIL("No 'api_ver' TXT record found in Query API advertisement.")
@@ -148,7 +149,8 @@ class IS0402Test(GenericTest):
                         return test.FAIL("API protocol ('api_proto') TXT record is not '{}'.".format(self.protocol))
 
                 return test.PASS()
-        return test.FAIL("No matching mDNS announcement found for Query API.")
+        return test.FAIL("No matching mDNS announcement found for Query API with IP/Port {}:{}."
+                         .format(self.apis[QUERY_API_KEY]["ip"], self.apis[QUERY_API_KEY]["port"]))
 
     def test_03(self):
         """Registration API accepts and stores a valid Node resource"""

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -60,7 +60,7 @@ The test suite supports non-interactive operation in order use it within continu
 python3 nmos-test.py --suite IS-04-02 --list
 
 # Run a test set, saving the output as a JUnit XML file
-python3 nmos-test.py --suite IS-04-02 --selection auto --ip 128.66.12.5 128.66.12.6 --port 80 80 --version v1.2 v1.2 --ignore auto_5 auto_6 --output results.xml
+python3 nmos-test.py --suite IS-04-02 --selection auto --host 128.66.12.5 128.66.12.6 --port 80 80 --version v1.2 v1.2 --ignore auto_5 auto_6 --output results.xml
 ```
 
 ## External Dependencies

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -289,7 +289,7 @@ def run_tests(test, endpoints, test_selection=["all"]):
                 "base_url": base_url,
                 "hostname": endpoints[index]["host"],
                 "ip": ip_address,
-                "port": endpoints[index]["port"],
+                "port": int(endpoints[index]["port"]),
                 "url": "{}/x-nmos/{}/{}/".format(base_url, api_key, endpoints[index]["version"]),
                 "version": endpoints[index]["version"],
                 "spec": None  # Used inside GenericTest

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -62,7 +62,7 @@ function loadSettings() {
 
                 var maxOptions = document.getElementById('hidden_options').value;
                 for (var apiNum=0; apiNum<maxOptions; apiNum++) {
-                    document.getElementById("endpoints-" + apiNum.toString() + "-ip").value = sessionStorage.getItem("endpoints-" + apiNum.toString() + "-ip");
+                    document.getElementById("endpoints-" + apiNum.toString() + "-host").value = sessionStorage.getItem("endpoints-" + apiNum.toString() + "-host");
                     document.getElementById("endpoints-" + apiNum.toString() + "-port").value = sessionStorage.getItem("endpoints-" + apiNum.toString() + "-port");
                     document.getElementById("endpoints-" + apiNum.toString() + "-version").value = sessionStorage.getItem("endpoints-" + apiNum.toString() + "-version");
                 }
@@ -92,7 +92,7 @@ function saveSettings() {
 
             var maxOptions = document.getElementById('hidden_options').value;
             for (var apiNum=0; apiNum<maxOptions; apiNum++) {
-                sessionStorage.setItem("endpoints-" + apiNum.toString() + "-ip", document.getElementById("endpoints-" + apiNum.toString() + "-ip",).value);
+                sessionStorage.setItem("endpoints-" + apiNum.toString() + "-host", document.getElementById("endpoints-" + apiNum.toString() + "-host",).value);
                 sessionStorage.setItem("endpoints-" + apiNum.toString() + "-port", document.getElementById("endpoints-" + apiNum.toString() + "-port",).value);
                 sessionStorage.setItem("endpoints-" + apiNum.toString() + "-version", document.getElementById("endpoints-" + apiNum.toString() + "-version",).value);
             }

--- a/templates/index.html
+++ b/templates/index.html
@@ -51,7 +51,7 @@
                             <label id="endpoints-{{ loop.index-1 }}-label"></label>
                         </div>
                         <div class="input text input_data_fld">
-                            {{ endpoint.ip.label }} {{ endpoint.ip(size="15") }}
+                            {{ endpoint.host.label }} {{ endpoint.host(size="15") }}
                         </div>
                         <div class="input text input_data_fld">
                             {{ endpoint.port.label }} {{ endpoint.port(size="5") }}


### PR DESCRIPTION
This adds a check for the HSTS header. It also performs some vulnerability testing via testssl, however as this isn't strictly part of BCP003-01 it's questionable whether it belongs here.

I may add some further checks on certificate verification and OCSP stapling before completing this one.