### PR TITLE
De-duplicate all the test case descriptions

### DIFF
--- a/BCP00301Test.py
+++ b/BCP00301Test.py
@@ -46,8 +46,9 @@ class BCP00301Test(GenericTest):
                                                   "installation instructions: {}".format(e)))
         return ret.returncode
 
-    def test_01(self):
-        test = Test("TLS Protocols")
+    def test_01(self, test):
+        """TLS Protocols"""
+
         ret = self.perform_test_ssl(test, ["-p"])
         if ret != 0:
             return test.FAIL("Unable to test. See the console for further information.")
@@ -63,8 +64,9 @@ class BCP00301Test(GenericTest):
                         return test.WARNING("Protocol {} should be offered".format(report["id"].replace("_", ".")))
             return test.PASS()
 
-    def test_02(self):
-        test = Test("TLS Ciphers")
+    def test_02(self, test):
+        """TLS Ciphers"""
+
         ret = self.perform_test_ssl(test, ["-E"])
         if ret != 0:
             return test.FAIL("Unable to test. See the console for further information.")

--- a/GenericTest.py
+++ b/GenericTest.py
@@ -25,31 +25,33 @@ from Config import ENABLE_HTTPS
 
 
 def test_depends(func):
-    """ Decorator to prevent a test being executed in individual mode"""
+    """Decorator to prevent a test being executed in individual mode"""
     def invalid(self):
         if self.test_individual:
             test = Test("Invalid", func.__name__)
             return test.DISABLED("This test cannot be performed individually")
         else:
             return func(self)
+    invalid.__name__ = func.__name__
+    invalid.__doc__ = func.__doc__
     return invalid
 
 
 class NMOSTestException(Exception):
-    """ Provides a way to exit a single test, by providing the TestResult return statement as the first exception
-        parameter"""
+    """Provides a way to exit a single test, by providing the TestResult return statement as the first exception
+       parameter"""
     pass
 
 
 class NMOSInitException(Exception):
-    """ The test set was run in an invalid mode. Causes all tests to abort"""
+    """The test set was run in an invalid mode. Causes all tests to abort"""
     pass
 
 
 class GenericTest(object):
     """
     Generic testing class.
-    Can be inhereted from in order to perform detailed testing.
+    Can be inherited from in order to perform detailed testing.
     """
     def __init__(self, apis, omit_paths=None):
         self.apis = apis

--- a/GenericTest.py
+++ b/GenericTest.py
@@ -18,6 +18,7 @@ import git
 import jsonschema
 import TestHelper
 import traceback
+import inspect
 
 from Specification import Specification
 from TestResult import Test
@@ -26,12 +27,12 @@ from Config import ENABLE_HTTPS
 
 def test_depends(func):
     """Decorator to prevent a test being executed in individual mode"""
-    def invalid(self):
+    def invalid(self, test):
         if self.test_individual:
-            test = Test("Invalid", func.__name__)
+            test.description = "Invalid"
             return test.DISABLED("This test cannot be performed individually")
         else:
-            return func(self)
+            return func(self, test)
     invalid.__name__ = func.__name__
     invalid.__doc__ = func.__doc__
     return invalid
@@ -129,8 +130,9 @@ class GenericTest(object):
                     method = getattr(self, method_name)
                     if callable(method):
                         print(" * Running " + method_name)
+                        test = Test(inspect.getdoc(method), method_name)
                         try:
-                            self.result.append(method())
+                            self.result.append(method(test))
                         except NMOSTestException as e:
                             self.result.append(e.args[0])
                         except Exception as e:
@@ -141,8 +143,9 @@ class GenericTest(object):
             method = getattr(self, test_name)
             if callable(method):
                 print(" * Running " + test_name)
+                test = Test(inspect.getdoc(method), test_name)
                 try:
-                    self.result.append(method())
+                    self.result.append(method(test))
                 except NMOSTestException as e:
                     self.result.append(e.args[0])
                 except Exception as e:

--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -147,7 +147,7 @@ class IS0401Test(GenericTest):
     def test_01(self):
         """Node can discover network registration service via multicast DNS"""
 
-        test = Test("Node can discover network registration service via multicast DNS")
+        test = Test()
 
         if not ENABLE_DNS_SD or DNS_SD_MODE != "multicast":
             return test.DISABLED("This test cannot be performed when ENABLE_DNS_SD is False or DNS_SD_MODE is not "
@@ -164,7 +164,7 @@ class IS0401Test(GenericTest):
     def test_02(self):
         """Node can discover network registration service via unicast DNS"""
 
-        test = Test("Node can discover network registration service via unicast DNS")
+        test = Test()
 
         if not ENABLE_DNS_SD or DNS_SD_MODE != "unicast":
             return test.DISABLED("This test cannot be performed when ENABLE_DNS_SD is False or DNS_SD_MODE is not "
@@ -181,7 +181,7 @@ class IS0401Test(GenericTest):
     def test_03(self):
         """Registration API interactions use the correct Content-Type"""
 
-        test = Test("Registration API interactions use the correct Content-Type")
+        test = Test()
 
         if not ENABLE_DNS_SD:
             return test.DISABLED("This test cannot be performed when ENABLE_DNS_SD is False")
@@ -264,8 +264,7 @@ class IS0401Test(GenericTest):
         """Node can register a valid Node resource with the network registration service,
         matching its Node API self resource"""
 
-        test = Test("Node can register a valid Node resource with the network registration service, "
-                    "matching its Node API self resource")
+        test = Test()
 
         self.do_registry_basics_prereqs()
 
@@ -274,7 +273,7 @@ class IS0401Test(GenericTest):
     def test_05(self):
         """Node maintains itself in the registry via periodic calls to the health resource"""
 
-        test = Test("Node maintains itself in the registry via periodic calls to the health resource")
+        test = Test()
 
         if not ENABLE_DNS_SD:
             return test.DISABLED("This test cannot be performed when ENABLE_DNS_SD is False")
@@ -309,9 +308,15 @@ class IS0401Test(GenericTest):
 
             # Ensure the heartbeat request body is empty
             if heartbeat[1]["payload"] is not bytes():
-                return test.WARNING("Heartbeat POST contained a payload body.", "https://amwa-tv.github.io/nmos-discovery-registration/branches/{}/docs/2.2._APIs_-_Client_Side_Implementation_Notes.html#empty-request-bodies".format(api["spec_branch"]))
+                return test.WARNING("Heartbeat POST contained a payload body.", 
+                                    "https://amwa-tv.github.io/nmos-discovery-registration/branches/{}"
+                                    "/docs/2.2._APIs_-_Client_Side_Implementation_Notes.html#empty-request-bodies"
+                                    .format(api["spec_branch"]))
             if "Content-Type" in heartbeat[1]["headers"]:
-                return test.WARNING("Heartbeat POST contained a Content-Type header.", "https://amwa-tv.github.io/nmos-discovery-registration/branches/{}/docs/2.2._APIs_-_Client_Side_Implementation_Notes.html#empty-request-bodies".format(api["spec_branch"]))
+                return test.WARNING("Heartbeat POST contained a Content-Type header.", 
+                                    "https://amwa-tv.github.io/nmos-discovery-registration/branches/{}"
+                                    "/docs/2.2._APIs_-_Client_Side_Implementation_Notes.html#empty-request-bodies"
+                                    .format(api["spec_branch"]))
 
             last_hb = heartbeat
 
@@ -321,8 +326,7 @@ class IS0401Test(GenericTest):
         """Node can register a valid Device resource with the network registration service, matching its
         Node API Device resource"""
 
-        test = Test("Node can register a valid Device resource with the network registration service, "
-                    "matching its Node API Device resource")
+        test = Test()
 
         self.do_registry_basics_prereqs()
 
@@ -332,8 +336,7 @@ class IS0401Test(GenericTest):
         """Node can register a valid Source resource with the network
         registration service, matching its Node API Source resource"""
 
-        test = Test("Node can register a valid Source resource with the network registration service, "
-                    "matching its Node API Source resource")
+        test = Test()
 
         self.do_registry_basics_prereqs()
 
@@ -343,8 +346,7 @@ class IS0401Test(GenericTest):
         """Node can register a valid Flow resource with the network
         registration service, matching its Node API Flow resource"""
 
-        test = Test("Node can register a valid Flow resource with the network registration service, "
-                    "matching its Node API Flow resource")
+        test = Test()
 
         self.do_registry_basics_prereqs()
 
@@ -354,8 +356,7 @@ class IS0401Test(GenericTest):
         """Node can register a valid Sender resource with the network
         registration service, matching its Node API Sender resource"""
 
-        test = Test("Node can register a valid Sender resource with the network registration service, "
-                    "matching its Node API Sender resource")
+        test = Test()
 
         self.do_registry_basics_prereqs()
 
@@ -365,8 +366,7 @@ class IS0401Test(GenericTest):
         """Node can register a valid Receiver resource with the network
         registration service, matching its Node API Receiver resource"""
 
-        test = Test("Node can register a valid Receiver resource with the network registration service, "
-                    "matching its Node API Receiver resource")
+        test = Test()
 
         self.do_registry_basics_prereqs()
 
@@ -375,8 +375,9 @@ class IS0401Test(GenericTest):
     def test_12(self):
         """Node advertises a Node type mDNS announcement with no ver_* TXT records
         in the presence of a Registration API"""
-        test = Test("Node advertises a Node type mDNS announcement with no ver_* TXT records in the presence "
-                    "of a Registration API")
+
+        test = Test()
+
         browser = ServiceBrowser(self.zc, "_nmos-node._tcp.local.", self.zc_listener)
         time.sleep(1)
         node_list = self.zc_listener.get_service_list()
@@ -411,8 +412,7 @@ class IS0401Test(GenericTest):
         """PUTing to a Receiver target resource with a Sender resource payload is accepted
         and connects the Receiver to a stream"""
 
-        test = Test("PUTing to a Receiver target resource with a Sender resource payload " \
-                    "is accepted and connects the Receiver to a stream")
+        test = Test()
 
         valid, receivers = self.do_request("GET", self.node_url + "receivers")
         if not valid:
@@ -467,8 +467,7 @@ class IS0401Test(GenericTest):
         """PUTing to a Receiver target resource with an empty JSON object payload is accepted and
         disconnects the Receiver from a stream"""
 
-        test = Test("PUTing to a Receiver target resource with an empty JSON object payload "
-                    "is accepted and disconnects the Receiver from a stream")
+        test = Test()
 
         valid, receivers = self.do_request("GET", self.node_url + "receivers")
         if not valid:
@@ -506,7 +505,7 @@ class IS0401Test(GenericTest):
     def test_15(self):
         """Node correctly selects a Registration API based on advertised priorities"""
 
-        test = Test("Node correctly selects a Registration API based on advertised priorities")
+        test = Test()
 
         if not ENABLE_DNS_SD:
             return test.DISABLED("This test cannot be performed when ENABLE_DNS_SD is False")
@@ -535,7 +534,7 @@ class IS0401Test(GenericTest):
     def test_16(self):
         """Node correctly fails over between advertised Registration APIs when one fails"""
 
-        test = Test("Node correctly fails over between advertised Registration APIs when one fails")
+        test = Test()
 
         if not ENABLE_DNS_SD:
             return test.DISABLED("This test cannot be performed when ENABLE_DNS_SD is False")
@@ -556,7 +555,7 @@ class IS0401Test(GenericTest):
     def test_17(self):
         """All Node resources use different UUIDs"""
 
-        test = Test("All Node resources use different UUIDs")
+        test = Test()
 
         uuids = set()
         valid, response = self.do_request("GET", self.node_url + "self")
@@ -585,7 +584,7 @@ class IS0401Test(GenericTest):
     def test_18(self):
         """All Node clocks are unique, and relate to any visible Sources' clocks"""
 
-        test = Test("All Node clocks are unique, and relate to any visible Sources' clocks")
+        test = Test()
 
         api = self.apis[NODE_API_KEY]
         if self.is04_utils.compare_api_version(api["version"], "v1.1") < 0:
@@ -620,7 +619,7 @@ class IS0401Test(GenericTest):
     def test_19(self):
         """All Node interfaces are unique, and relate to any visible Senders and Receivers' interface_bindings"""
 
-        test = Test("All Node interfaces are unique, and relate to any visible Senders and Receivers' interface_bindings")
+        test = Test()
 
         api = self.apis[NODE_API_KEY]
         if self.is04_utils.compare_api_version(api["version"], "v1.2") < 0:
@@ -671,7 +670,7 @@ class IS0401Test(GenericTest):
     def test_20(self):
         """Node's resources correctly signal the current protocol"""
 
-        test = Test("Node's resources correctly signal the current protocol")
+        test = Test()
 
         service_href_warn = False
         device_href_warn = False

--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -144,10 +144,8 @@ class IS0401Test(GenericTest):
 
         self.registry_basics_done = True
 
-    def test_01(self):
+    def test_01(self, test):
         """Node can discover network registration service via multicast DNS"""
-
-        test = Test()
 
         if not ENABLE_DNS_SD or DNS_SD_MODE != "multicast":
             return test.DISABLED("This test cannot be performed when ENABLE_DNS_SD is False or DNS_SD_MODE is not "
@@ -161,10 +159,8 @@ class IS0401Test(GenericTest):
 
         return test.FAIL("Node did not attempt to register with the advertised registry.")
 
-    def test_02(self):
+    def test_02(self, test):
         """Node can discover network registration service via unicast DNS"""
-
-        test = Test()
 
         if not ENABLE_DNS_SD or DNS_SD_MODE != "unicast":
             return test.DISABLED("This test cannot be performed when ENABLE_DNS_SD is False or DNS_SD_MODE is not "
@@ -178,10 +174,8 @@ class IS0401Test(GenericTest):
 
         return test.FAIL("Node did not attempt to register with the advertised registry.")
 
-    def test_03(self):
+    def test_03(self, test):
         """Registration API interactions use the correct Content-Type"""
-
-        test = Test()
 
         if not ENABLE_DNS_SD:
             return test.DISABLED("This test cannot be performed when ENABLE_DNS_SD is False")
@@ -260,20 +254,16 @@ class IS0401Test(GenericTest):
         else:
             return test.FAIL("Could not reach Node!")
 
-    def test_04(self):
+    def test_04(self, test):
         """Node can register a valid Node resource with the network registration service,
         matching its Node API self resource"""
-
-        test = Test()
 
         self.do_registry_basics_prereqs()
 
         return self.check_matching_resource(test, "node")
 
-    def test_05(self):
+    def test_05(self, test):
         """Node maintains itself in the registry via periodic calls to the health resource"""
-
-        test = Test()
 
         if not ENABLE_DNS_SD:
             return test.DISABLED("This test cannot be performed when ENABLE_DNS_SD is False")
@@ -322,61 +312,49 @@ class IS0401Test(GenericTest):
 
         return test.PASS()
 
-    def test_07(self):
+    def test_07(self, test):
         """Node can register a valid Device resource with the network registration service, matching its
         Node API Device resource"""
-
-        test = Test()
 
         self.do_registry_basics_prereqs()
 
         return self.check_matching_resource(test, "device")
 
-    def test_08(self):
+    def test_08(self, test):
         """Node can register a valid Source resource with the network
         registration service, matching its Node API Source resource"""
-
-        test = Test()
 
         self.do_registry_basics_prereqs()
 
         return self.check_matching_resource(test, "source")
 
-    def test_09(self):
+    def test_09(self, test):
         """Node can register a valid Flow resource with the network
         registration service, matching its Node API Flow resource"""
-
-        test = Test()
 
         self.do_registry_basics_prereqs()
 
         return self.check_matching_resource(test, "flow")
 
-    def test_10(self):
+    def test_10(self, test):
         """Node can register a valid Sender resource with the network
         registration service, matching its Node API Sender resource"""
-
-        test = Test()
 
         self.do_registry_basics_prereqs()
 
         return self.check_matching_resource(test, "sender")
 
-    def test_11(self):
+    def test_11(self, test):
         """Node can register a valid Receiver resource with the network
         registration service, matching its Node API Receiver resource"""
-
-        test = Test()
 
         self.do_registry_basics_prereqs()
 
         return self.check_matching_resource(test, "receiver")
 
-    def test_12(self):
+    def test_12(self, test):
         """Node advertises a Node type mDNS announcement with no ver_* TXT records
         in the presence of a Registration API"""
-
-        test = Test()
 
         browser = ServiceBrowser(self.zc, "_nmos-node._tcp.local.", self.zc_listener)
         time.sleep(1)
@@ -408,11 +386,9 @@ class IS0401Test(GenericTest):
                             " mode but may indicate a lack of support for peer to peer operation.",
                             "https://github.com/amwa-tv/nmos/wiki/IS-04#nodes-peer-to-peer-mode")
 
-    def test_13(self):
+    def test_13(self, test):
         """PUTing to a Receiver target resource with a Sender resource payload is accepted
         and connects the Receiver to a stream"""
-
-        test = Test()
 
         valid, receivers = self.do_request("GET", self.node_url + "receivers")
         if not valid:
@@ -463,11 +439,9 @@ class IS0401Test(GenericTest):
 
         return test.UNCLEAR("Node API does not expose any Receivers")
 
-    def test_14(self):
+    def test_14(self, test):
         """PUTing to a Receiver target resource with an empty JSON object payload is accepted and
         disconnects the Receiver from a stream"""
-
-        test = Test()
 
         valid, receivers = self.do_request("GET", self.node_url + "receivers")
         if not valid:
@@ -502,10 +476,8 @@ class IS0401Test(GenericTest):
 
         return test.UNCLEAR("Node API does not expose any Receivers")
 
-    def test_15(self):
+    def test_15(self, test):
         """Node correctly selects a Registration API based on advertised priorities"""
-
-        test = Test()
 
         if not ENABLE_DNS_SD:
             return test.DISABLED("This test cannot be performed when ENABLE_DNS_SD is False")
@@ -531,10 +503,8 @@ class IS0401Test(GenericTest):
 
         return test.PASS()
 
-    def test_16(self):
+    def test_16(self, test):
         """Node correctly fails over between advertised Registration APIs when one fails"""
-
-        test = Test()
 
         if not ENABLE_DNS_SD:
             return test.DISABLED("This test cannot be performed when ENABLE_DNS_SD is False")
@@ -552,10 +522,8 @@ class IS0401Test(GenericTest):
 
         return test.PASS()
 
-    def test_17(self):
+    def test_17(self, test):
         """All Node resources use different UUIDs"""
-
-        test = Test()
 
         uuids = set()
         valid, response = self.do_request("GET", self.node_url + "self")
@@ -581,10 +549,8 @@ class IS0401Test(GenericTest):
 
         return test.PASS()
 
-    def test_18(self):
+    def test_18(self, test):
         """All Node clocks are unique, and relate to any visible Sources' clocks"""
-
-        test = Test()
 
         api = self.apis[NODE_API_KEY]
         if self.is04_utils.compare_api_version(api["version"], "v1.1") < 0:
@@ -616,10 +582,8 @@ class IS0401Test(GenericTest):
 
         return test.PASS()
 
-    def test_19(self):
+    def test_19(self, test):
         """All Node interfaces are unique, and relate to any visible Senders and Receivers' interface_bindings"""
-
-        test = Test()
 
         api = self.apis[NODE_API_KEY]
         if self.is04_utils.compare_api_version(api["version"], "v1.2") < 0:
@@ -667,10 +631,8 @@ class IS0401Test(GenericTest):
 
         return test.PASS()
 
-    def test_20(self):
+    def test_20(self, test):
         """Node's resources correctly signal the current protocol"""
-
-        test = Test()
 
         service_href_warn = False
         device_href_warn = False

--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -64,10 +64,8 @@ class IS0402Test(GenericTest):
             self.zc.close()
             self.zc = None
 
-    def test_01(self):
+    def test_01(self, test):
         """Registration API advertises correctly via mDNS"""
-
-        test = Test()
 
         service_type = "_nmos-registration._tcp.local."
         if self.is04_reg_utils.compare_api_version(self.apis[REG_API_KEY]["version"], "v1.3") >= 0:
@@ -109,10 +107,8 @@ class IS0402Test(GenericTest):
                 return test.PASS()
         return test.FAIL("No matching mDNS announcement found for Registration API.")
 
-    def test_02(self):
+    def test_02(self, test):
         """Query API advertises correctly via mDNS"""
-
-        test = Test()
 
         browser = ServiceBrowser(self.zc, "_nmos-query._tcp.local.", self.zc_listener)
         sleep(2)
@@ -150,10 +146,8 @@ class IS0402Test(GenericTest):
                 return test.PASS()
         return test.FAIL("No matching mDNS announcement found for Query API.")
 
-    def test_03(self):
+    def test_03(self, test):
         """Registration API accepts and stores a valid Node resource"""
-
-        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -167,19 +161,15 @@ class IS0402Test(GenericTest):
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
-    def test_04(self):
+    def test_04(self, test):
         """Registration API rejects an invalid Node resource with a 400 HTTP code"""
-
-        test = Test()
 
         bad_json = {"notanode": True}
         return self.do_400_check(test, "node", bad_json)
 
     @test_depends
-    def test_05(self):
+    def test_05(self, test):
         """Registration API accepts and stores a valid Device resource"""
-
-        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -195,19 +185,15 @@ class IS0402Test(GenericTest):
             return test.FAIL("Version > 1 not supported yet.")
 
     @test_depends
-    def test_06(self):
+    def test_06(self, test):
         """Registration API rejects an invalid Device resource with a 400 HTTP code"""
-
-        test = Test()
 
         bad_json = {"notadevice": True}
         return self.do_400_check(test, "device", bad_json)
 
     @test_depends
-    def test_07(self):
+    def test_07(self, test):
         """Registration API accepts and stores a valid Source resource"""
-
-        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -222,19 +208,15 @@ class IS0402Test(GenericTest):
             return test.FAIL("Version > 1 not supported yet.")
 
     @test_depends
-    def test_08(self):
+    def test_08(self, test):
         """Registration API rejects an invalid Source resource with a 400 HTTP code"""
-
-        test = Test()
 
         bad_json = {"notasource": True}
         return self.do_400_check(test, "source", bad_json)
 
     @test_depends
-    def test_09(self):
+    def test_09(self, test):
         """Registration API accepts and stores a valid Flow resource"""
-
-        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -250,19 +232,15 @@ class IS0402Test(GenericTest):
             return test.FAIL("Version > 1 not supported yet.")
 
     @test_depends
-    def test_10(self):
+    def test_10(self, test):
         """Registration API rejects an invalid Flow resource with a 400 HTTP code"""
-
-        test = Test()
 
         bad_json = {"notaflow": True}
         return self.do_400_check(test, "flow", bad_json)
 
     @test_depends
-    def test_11(self):
+    def test_11(self, test):
         """Registration API accepts and stores a valid Sender resource"""
-
-        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -277,10 +255,8 @@ class IS0402Test(GenericTest):
             return test.FAIL("Version > 1 not supported yet.")
 
     @test_depends
-    def test_11_1(self):
+    def test_11_1(self, test):
         """Registration API accepts and stores a valid Sender resource with null flow_id"""
-
-        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -305,19 +281,15 @@ class IS0402Test(GenericTest):
             return test.FAIL("Version > 1 not supported yet.")
 
     @test_depends
-    def test_12(self):
+    def test_12(self, test):
         """Registration API rejects an invalid Sender resource with a 400 HTTP code"""
-
-        test = Test()
 
         bad_json = {"notasender": True}
         return self.do_400_check(test, "sender", bad_json)
 
     @test_depends
-    def test_13(self):
+    def test_13(self, test):
         """Registration API accepts and stores a valid Receiver resource"""
-
-        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -332,19 +304,15 @@ class IS0402Test(GenericTest):
             return test.FAIL("Version > 1 not supported yet.")
 
     @test_depends
-    def test_14(self):
+    def test_14(self, test):
         """Registration API rejects an invalid Receiver resource with a 400 HTTP code"""
-
-        test = Test()
 
         bad_json = {"notareceiver": True}
         return self.do_400_check(test, "receiver", bad_json)
 
     @test_depends
-    def test_15(self):
+    def test_15(self, test):
         """Registration API responds with 200 HTTP code on updating a registered Node"""
-
-        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -359,10 +327,8 @@ class IS0402Test(GenericTest):
             return test.FAIL("Version > 1 not supported yet.")
 
     @test_depends
-    def test_16(self):
+    def test_16(self, test):
         """Registration API responds with 200 HTTP code on updating a registered Device"""
-
-        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -378,10 +344,8 @@ class IS0402Test(GenericTest):
             return test.FAIL("Version > 1 not supported yet.")
 
     @test_depends
-    def test_17(self):
+    def test_17(self, test):
         """Registration API responds with 200 HTTP code on updating a registered Source"""
-
-        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -396,10 +360,8 @@ class IS0402Test(GenericTest):
             return test.FAIL("Version > 1 not supported yet.")
 
     @test_depends
-    def test_18(self):
+    def test_18(self, test):
         """Registration API responds with 200 HTTP code on updating a registered Flow"""
-
-        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -415,10 +377,8 @@ class IS0402Test(GenericTest):
             return test.FAIL("Version > 1 not supported yet.")
 
     @test_depends
-    def test_19(self):
+    def test_19(self, test):
         """Registration API responds with 200 HTTP code on updating a registered Sender"""
-
-        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -433,10 +393,8 @@ class IS0402Test(GenericTest):
             return test.FAIL("Version > 1 not supported yet.")
 
     @test_depends
-    def test_20(self):
+    def test_20(self, test):
         """Registration API responds with 200 HTTP code on updating a registered Receiver"""
-
-        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -657,10 +615,8 @@ class IS0402Test(GenericTest):
             raise NMOSTestException(test.FAIL("Query API response did not include the expected value "
                                               "in the Link header: {}".format(ex)))
 
-    def test_21_1(self):
+    def test_21_1(self, test):
         """Query API implements pagination (no query or paging parameters)"""
-
-        test = Test()
 
         self.check_paged_trait(test)
         description = "test_21_1"
@@ -675,10 +631,8 @@ class IS0402Test(GenericTest):
 
         return test.PASS()
 
-    def test_21_1_1(self):
+    def test_21_1_1(self, test):
         """Query API implements pagination (when explicitly requested)"""
-
-        test = Test()
 
         self.check_paged_trait(test)
         description = "test_21_1_1"
@@ -693,10 +647,8 @@ class IS0402Test(GenericTest):
 
         return test.PASS()
 
-    def test_21_2(self):
+    def test_21_2(self, test):
         """Query API implements pagination (documentation examples)"""
-
-        test = Test()
 
         self.check_paged_trait(test)
         description = "test_21_2"
@@ -754,10 +706,8 @@ class IS0402Test(GenericTest):
 
         return test.PASS()
 
-    def test_21_3(self):
+    def test_21_3(self, test):
         """Query API implements pagination (edge cases)"""
-
-        test = Test()
 
         self.check_paged_trait(test)
         description = "test_21_3"
@@ -798,10 +748,8 @@ class IS0402Test(GenericTest):
 
         return test.PASS()
 
-    def test_21_4(self):
+    def test_21_4(self, test):
         """Query API implements pagination (requests that require empty responses)"""
-
-        test = Test()
 
         self.check_paged_trait(test)
         description = "test_21_4"
@@ -833,10 +781,8 @@ class IS0402Test(GenericTest):
 
         return test.PASS()
 
-    def test_21_5(self):
+    def test_21_5(self, test):
         """Query API implements pagination (filters that select discontiguous resources)"""
-
-        test = Test()
 
         self.check_paged_trait(test)
         description = "test_21_5"
@@ -938,10 +884,8 @@ class IS0402Test(GenericTest):
 
         return test.PASS()
 
-    def test_21_6(self):
+    def test_21_6(self, test):
         """Query API implements pagination (bad requests)"""
-
-        test = Test()
 
         self.check_paged_trait(test)
         description = "test_21_6"
@@ -981,10 +925,8 @@ class IS0402Test(GenericTest):
 
         return test.PASS()
 
-    def test_21_7(self):
+    def test_21_7(self, test):
         """Query API implements pagination (updates between paged requests)"""
-
-        test = Test()
 
         self.check_paged_trait(test)
         description = "test_21_7"
@@ -1051,10 +993,8 @@ class IS0402Test(GenericTest):
 
         return test.PASS()
 
-    def test_21_8(self):
+    def test_21_8(self, test):
         """Query API implements pagination (correct encoding of URLs in Link header)"""
-
-        test = Test()
 
         self.check_paged_trait(test)
         description = "test_21_8"
@@ -1071,17 +1011,13 @@ class IS0402Test(GenericTest):
     def _test_21_x(self):
         """Query API implements pagination (paging.order=create)"""
 
-        test = Test()
-
         self.check_paged_trait(test)
         description = "test_21_x"
 
         return test.MANUAL()
 
-    def test_22(self):
+    def test_22(self, test):
         """Query API implements downgrade queries"""
-
-        test = Test()
 
         reg_api = self.apis[REG_API_KEY]
         query_api = self.apis[QUERY_API_KEY]
@@ -1202,10 +1138,8 @@ class IS0402Test(GenericTest):
 
         return test.PASS()
 
-    def test_22_1(self):
+    def test_22_1(self, test):
         """Query API subscriptions resource does not support downgrade queries"""
-
-        test = Test()
 
         api = self.apis[QUERY_API_KEY]
         if api["version"] == "v1.0":
@@ -1267,17 +1201,13 @@ class IS0402Test(GenericTest):
 
         return test.PASS()
 
-    def test_22_2(self):
+    def test_22_2(self, test):
         """Query API WebSockets implement downgrade queries"""
-
-        test = Test()
 
         return test.MANUAL()
 
-    def test_23(self):
+    def test_23(self, test):
         """Query API implements basic query parameters"""
-
-        test = Test()
 
         node_descriptions = [str(uuid.uuid4()), str(uuid.uuid4())]
         for node_desc in node_descriptions:
@@ -1315,10 +1245,8 @@ class IS0402Test(GenericTest):
 
         return test.PASS()
 
-    def test_23_1(self):
+    def test_23_1(self, test):
         """Query API WebSockets implement basic query parameters"""
-
-        test = Test()
 
         # Perform a basic test for APIs <= v1.2 checking for support
         try:
@@ -1436,10 +1364,8 @@ class IS0402Test(GenericTest):
 
         return test.PASS()
 
-    def test_24(self):
+    def test_24(self, test):
         """Query API implements RQL"""
-
-        test = Test()
 
         if self.apis[QUERY_API_KEY]["version"] == "v1.0":
             return test.NA("This test does not apply to v1.0")
@@ -1483,10 +1409,8 @@ class IS0402Test(GenericTest):
 
         return test.PASS()
 
-    def test_24_1(self):
+    def test_24_1(self, test):
         """Query API WebSockets implement RQL"""
-
-        test = Test()
 
         # Perform a basic test for APIs <= v1.2 checking for support
         try:
@@ -1603,10 +1527,8 @@ class IS0402Test(GenericTest):
 
         return test.PASS()
 
-    def test_25(self):
+    def test_25(self, test):
         """Query API implements ancestry queries"""
-
-        test = Test()
 
         if self.apis[QUERY_API_KEY]["version"] == "v1.0":
             return test.NA("This test does not apply to v1.0")
@@ -1640,17 +1562,13 @@ class IS0402Test(GenericTest):
 
         return test.PASS()
 
-    def test_25_1(self):
+    def test_25_1(self, test):
         """Query API WebSockets implement ancestry queries"""
-
-        test = Test()
 
         return test.MANUAL()
 
-    def test_26(self):
+    def test_26(self, test):
         """Registration API responds with 400 HTTP code on posting a resource without parent"""
-
-        test = Test()
 
         api = self.apis[REG_API_KEY]
 
@@ -1681,11 +1599,9 @@ class IS0402Test(GenericTest):
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
-    def test_27(self):
+    def test_27(self, test):
         """Registration API cleans up Nodes and their sub-resources when a heartbeat doesn't occur for
         the duration of a fixed timeout period"""
-
-        test = Test()
 
         api = self.apis[REG_API_KEY]
 
@@ -1729,10 +1645,8 @@ class IS0402Test(GenericTest):
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
-    def test_28(self):
+    def test_28(self, test):
         """Registry removes stale child-resources of an incorrectly unregistered Node"""
-
-        test = Test()
 
         api = self.apis[REG_API_KEY]
 
@@ -1772,10 +1686,8 @@ class IS0402Test(GenericTest):
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
-    def test_29(self):
+    def test_29(self, test):
         """Query API supports websocket subscription request"""
-
-        test = Test()
 
         api = self.apis[QUERY_API_KEY]
 
@@ -1801,10 +1713,8 @@ class IS0402Test(GenericTest):
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
-    def test_29_1(self):
+    def test_29_1(self, test):
         """Query API websocket subscription requests default to the current protocol"""
-
-        test = Test()
 
         api = self.apis[QUERY_API_KEY]
 
@@ -1824,10 +1734,8 @@ class IS0402Test(GenericTest):
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
-    def test_30(self):
+    def test_30(self, test):
         """Registration API accepts heartbeat requests for a Node held in the registry"""
-
-        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -1850,10 +1758,8 @@ class IS0402Test(GenericTest):
         else:
             return test.FAIL("Version > 1 not supported yet.")
 
-    def test_31(self):
+    def test_31(self, test):
         """Query API sends correct websocket event messages for UNCHANGED (SYNC), ADDED, MODIFIED and REMOVED"""
-
-        test = Test()
 
         api = self.apis[QUERY_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:

--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -67,7 +67,7 @@ class IS0402Test(GenericTest):
     def test_01(self):
         """Registration API advertises correctly via mDNS"""
 
-        test = Test("Registration API advertises correctly via mDNS")
+        test = Test()
 
         service_type = "_nmos-registration._tcp.local."
         if self.is04_reg_utils.compare_api_version(self.apis[REG_API_KEY]["version"], "v1.3") >= 0:
@@ -112,7 +112,7 @@ class IS0402Test(GenericTest):
     def test_02(self):
         """Query API advertises correctly via mDNS"""
 
-        test = Test("Query API advertises correctly via mDNS")
+        test = Test()
 
         browser = ServiceBrowser(self.zc, "_nmos-query._tcp.local.", self.zc_listener)
         sleep(2)
@@ -153,7 +153,7 @@ class IS0402Test(GenericTest):
     def test_03(self):
         """Registration API accepts and stores a valid Node resource"""
 
-        test = Test("Registration API accepts and stores a valid Node resource")
+        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -170,7 +170,7 @@ class IS0402Test(GenericTest):
     def test_04(self):
         """Registration API rejects an invalid Node resource with a 400 HTTP code"""
 
-        test = Test("Registration API rejects an invalid Node resource with a 400 HTTP code")
+        test = Test()
 
         bad_json = {"notanode": True}
         return self.do_400_check(test, "node", bad_json)
@@ -179,7 +179,7 @@ class IS0402Test(GenericTest):
     def test_05(self):
         """Registration API accepts and stores a valid Device resource"""
 
-        test = Test("Registration API accepts and stores a valid Device resource")
+        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -198,7 +198,7 @@ class IS0402Test(GenericTest):
     def test_06(self):
         """Registration API rejects an invalid Device resource with a 400 HTTP code"""
 
-        test = Test("Registration API rejects an invalid Device resource with a 400 HTTP code")
+        test = Test()
 
         bad_json = {"notadevice": True}
         return self.do_400_check(test, "device", bad_json)
@@ -207,7 +207,7 @@ class IS0402Test(GenericTest):
     def test_07(self):
         """Registration API accepts and stores a valid Source resource"""
 
-        test = Test("Registration API accepts and stores a valid Source resource")
+        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -225,7 +225,7 @@ class IS0402Test(GenericTest):
     def test_08(self):
         """Registration API rejects an invalid Source resource with a 400 HTTP code"""
 
-        test = Test("Registration API rejects an invalid Source resource with a 400 HTTP code")
+        test = Test()
 
         bad_json = {"notasource": True}
         return self.do_400_check(test, "source", bad_json)
@@ -234,7 +234,7 @@ class IS0402Test(GenericTest):
     def test_09(self):
         """Registration API accepts and stores a valid Flow resource"""
 
-        test = Test("Registration API accepts and stores a valid Flow resource")
+        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -253,7 +253,7 @@ class IS0402Test(GenericTest):
     def test_10(self):
         """Registration API rejects an invalid Flow resource with a 400 HTTP code"""
 
-        test = Test("Registration API rejects an invalid Flow resource with a 400 HTTP code")
+        test = Test()
 
         bad_json = {"notaflow": True}
         return self.do_400_check(test, "flow", bad_json)
@@ -262,7 +262,7 @@ class IS0402Test(GenericTest):
     def test_11(self):
         """Registration API accepts and stores a valid Sender resource"""
 
-        test = Test("Registration API accepts and stores a valid Sender resource")
+        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -280,7 +280,7 @@ class IS0402Test(GenericTest):
     def test_11_1(self):
         """Registration API accepts and stores a valid Sender resource with null flow_id"""
 
-        test = Test("Registration API accepts and stores a valid Sender resource with null flow_id")
+        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -308,7 +308,7 @@ class IS0402Test(GenericTest):
     def test_12(self):
         """Registration API rejects an invalid Sender resource with a 400 HTTP code"""
 
-        test = Test("Registration API rejects an invalid Sender resource with a 400 HTTP code")
+        test = Test()
 
         bad_json = {"notasender": True}
         return self.do_400_check(test, "sender", bad_json)
@@ -317,7 +317,7 @@ class IS0402Test(GenericTest):
     def test_13(self):
         """Registration API accepts and stores a valid Receiver resource"""
 
-        test = Test("Registration API accepts and stores a valid Receiver resource")
+        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -335,15 +335,16 @@ class IS0402Test(GenericTest):
     def test_14(self):
         """Registration API rejects an invalid Receiver resource with a 400 HTTP code"""
 
-        test = Test("Registration API rejects an invalid Receiver resource with a 400 HTTP code")
+        test = Test()
 
         bad_json = {"notareceiver": True}
         return self.do_400_check(test, "receiver", bad_json)
 
     @test_depends
     def test_15(self):
-        """Updating Node resource results in 200"""
-        test = Test("Registration API responds with 200 HTTP code on updating a registered Node")
+        """Registration API responds with 200 HTTP code on updating a registered Node"""
+
+        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -359,8 +360,9 @@ class IS0402Test(GenericTest):
 
     @test_depends
     def test_16(self):
-        """Updating Device resource results in 200"""
-        test = Test("Registration API responds with 200 HTTP code on updating a registered Device")
+        """Registration API responds with 200 HTTP code on updating a registered Device"""
+
+        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -377,8 +379,9 @@ class IS0402Test(GenericTest):
 
     @test_depends
     def test_17(self):
-        """Updating Source resource results in 200"""
-        test = Test("Registration API responds with 200 HTTP code on updating a registered Source")
+        """Registration API responds with 200 HTTP code on updating a registered Source"""
+
+        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -394,8 +397,9 @@ class IS0402Test(GenericTest):
 
     @test_depends
     def test_18(self):
-        """Updating Flow resource results in 200"""
-        test = Test("Registration API responds with 200 HTTP code on updating a registered Flow")
+        """Registration API responds with 200 HTTP code on updating a registered Flow"""
+
+        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -412,8 +416,9 @@ class IS0402Test(GenericTest):
 
     @test_depends
     def test_19(self):
-        """Updating Sender resource results in 200"""
-        test = Test("Registration API responds with 200 HTTP code on updating a registered Sender")
+        """Registration API responds with 200 HTTP code on updating a registered Sender"""
+
+        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -429,8 +434,9 @@ class IS0402Test(GenericTest):
 
     @test_depends
     def test_20(self):
-        """Updating Receiver resource results in 200"""
-        test = Test("Registration API responds with 200 HTTP code on updating a registered Receiver")
+        """Registration API responds with 200 HTTP code on updating a registered Receiver"""
+
+        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -654,9 +660,9 @@ class IS0402Test(GenericTest):
     def test_21_1(self):
         """Query API implements pagination (no query or paging parameters)"""
 
-        test = Test("Query API implements pagination (no query or paging parameters)")
+        test = Test()
+
         self.check_paged_trait(test)
-        # description = inspect.currentframe().f_code.co_name
         description = "test_21_1"
 
         # Perform a query with no query or paging parameters (see note in check_paged_response regarding 501)
@@ -672,7 +678,8 @@ class IS0402Test(GenericTest):
     def test_21_1_1(self):
         """Query API implements pagination (when explicitly requested)"""
 
-        test = Test("Query API implements pagination (when explicitly requested)")
+        test = Test()
+
         self.check_paged_trait(test)
         description = "test_21_1_1"
 
@@ -689,7 +696,8 @@ class IS0402Test(GenericTest):
     def test_21_2(self):
         """Query API implements pagination (documentation examples)"""
 
-        test = Test("Query API implements pagination (documentation examples)")
+        test = Test()
+
         self.check_paged_trait(test)
         description = "test_21_2"
 
@@ -749,7 +757,8 @@ class IS0402Test(GenericTest):
     def test_21_3(self):
         """Query API implements pagination (edge cases)"""
 
-        test = Test("Query API implements pagination (edge cases)")
+        test = Test()
+
         self.check_paged_trait(test)
         description = "test_21_3"
 
@@ -792,7 +801,8 @@ class IS0402Test(GenericTest):
     def test_21_4(self):
         """Query API implements pagination (requests that require empty responses)"""
 
-        test = Test("Query API implements pagination (requests that require empty responses)")
+        test = Test()
+
         self.check_paged_trait(test)
         description = "test_21_4"
 
@@ -826,7 +836,8 @@ class IS0402Test(GenericTest):
     def test_21_5(self):
         """Query API implements pagination (filters that select discontiguous resources)"""
 
-        test = Test("Query API implements pagination (filters that select discontiguous resources)")
+        test = Test()
+
         self.check_paged_trait(test)
         description = "test_21_5"
 
@@ -930,7 +941,8 @@ class IS0402Test(GenericTest):
     def test_21_6(self):
         """Query API implements pagination (bad requests)"""
 
-        test = Test("Query API implements pagination (bad requests)")
+        test = Test()
+
         self.check_paged_trait(test)
         description = "test_21_6"
 
@@ -972,7 +984,8 @@ class IS0402Test(GenericTest):
     def test_21_7(self):
         """Query API implements pagination (updates between paged requests)"""
 
-        test = Test("Query API implements pagination (updates between paged requests)")
+        test = Test()
+
         self.check_paged_trait(test)
         description = "test_21_7"
 
@@ -1041,7 +1054,8 @@ class IS0402Test(GenericTest):
     def test_21_8(self):
         """Query API implements pagination (correct encoding of URLs in Link header)"""
 
-        test = Test("Query API implements pagination (correct encoding of URLs in Link header)")
+        test = Test()
+
         self.check_paged_trait(test)
         description = "test_21_8"
 
@@ -1057,7 +1071,8 @@ class IS0402Test(GenericTest):
     def _test_21_x(self):
         """Query API implements pagination (paging.order=create)"""
 
-        test = Test("Query API implements pagination (paging.order=create)")
+        test = Test()
+
         self.check_paged_trait(test)
         description = "test_21_x"
 
@@ -1066,7 +1081,7 @@ class IS0402Test(GenericTest):
     def test_22(self):
         """Query API implements downgrade queries"""
 
-        test = Test("Query API implements downgrade queries")
+        test = Test()
 
         reg_api = self.apis[REG_API_KEY]
         query_api = self.apis[QUERY_API_KEY]
@@ -1190,7 +1205,7 @@ class IS0402Test(GenericTest):
     def test_22_1(self):
         """Query API subscriptions resource does not support downgrade queries"""
 
-        test = Test("Query API subscriptions resource does not support downgrade queries")
+        test = Test()
 
         api = self.apis[QUERY_API_KEY]
         if api["version"] == "v1.0":
@@ -1255,14 +1270,14 @@ class IS0402Test(GenericTest):
     def test_22_2(self):
         """Query API WebSockets implement downgrade queries"""
 
-        test = Test("Query API WebSockets implement downgrade queries")
+        test = Test()
 
         return test.MANUAL()
 
     def test_23(self):
         """Query API implements basic query parameters"""
 
-        test = Test("Query API implements basic query parameters")
+        test = Test()
 
         node_descriptions = [str(uuid.uuid4()), str(uuid.uuid4())]
         for node_desc in node_descriptions:
@@ -1303,7 +1318,7 @@ class IS0402Test(GenericTest):
     def test_23_1(self):
         """Query API WebSockets implement basic query parameters"""
 
-        test = Test("Query API WebSockets implement basic query parameters")
+        test = Test()
 
         # Perform a basic test for APIs <= v1.2 checking for support
         try:
@@ -1424,7 +1439,7 @@ class IS0402Test(GenericTest):
     def test_24(self):
         """Query API implements RQL"""
 
-        test = Test("Query API implements RQL")
+        test = Test()
 
         if self.apis[QUERY_API_KEY]["version"] == "v1.0":
             return test.NA("This test does not apply to v1.0")
@@ -1471,7 +1486,7 @@ class IS0402Test(GenericTest):
     def test_24_1(self):
         """Query API WebSockets implement RQL"""
 
-        test = Test("Query API WebSockets implement RQL")
+        test = Test()
 
         # Perform a basic test for APIs <= v1.2 checking for support
         try:
@@ -1591,7 +1606,7 @@ class IS0402Test(GenericTest):
     def test_25(self):
         """Query API implements ancestry queries"""
 
-        test = Test("Query API implements ancestry queries")
+        test = Test()
 
         if self.apis[QUERY_API_KEY]["version"] == "v1.0":
             return test.NA("This test does not apply to v1.0")
@@ -1628,13 +1643,14 @@ class IS0402Test(GenericTest):
     def test_25_1(self):
         """Query API WebSockets implement ancestry queries"""
 
-        test = Test("Query API WebSockets implement ancestry queries")
+        test = Test()
 
         return test.MANUAL()
 
     def test_26(self):
-        """Posting resource without parent results in 400"""
-        test = Test("Registration API responds with 400 HTTP code on posting a resource without parent")
+        """Registration API responds with 400 HTTP code on posting a resource without parent"""
+
+        test = Test()
 
         api = self.apis[REG_API_KEY]
 
@@ -1666,9 +1682,10 @@ class IS0402Test(GenericTest):
             return test.FAIL("Version > 1 not supported yet.")
 
     def test_27(self):
-        """Node and sub-resources should be removed after a timeout because of missing heartbeats"""
-        test = Test("Registration API cleans up Nodes and their sub-resources when a heartbeat doesn’t occur for "
-                    "the duration of a fixed timeout period")
+        """Registration API cleans up Nodes and their sub-resources when a heartbeat doesn't occur for
+        the duration of a fixed timeout period"""
+
+        test = Test()
 
         api = self.apis[REG_API_KEY]
 
@@ -1713,9 +1730,9 @@ class IS0402Test(GenericTest):
             return test.FAIL("Version > 1 not supported yet.")
 
     def test_28(self):
-        """Child-resources of a Node which unregistered it's resources in an incorrect order must be removed by
-        the registry"""
-        test = Test("Registry removes stale child-resources of an incorrectly unregistered Node")
+        """Registry removes stale child-resources of an incorrectly unregistered Node"""
+
+        test = Test()
 
         api = self.apis[REG_API_KEY]
 
@@ -1757,7 +1774,8 @@ class IS0402Test(GenericTest):
 
     def test_29(self):
         """Query API supports websocket subscription request"""
-        test = Test("Query API supports request of a websocket subscription")
+
+        test = Test()
 
         api = self.apis[QUERY_API_KEY]
 
@@ -1785,7 +1803,8 @@ class IS0402Test(GenericTest):
 
     def test_29_1(self):
         """Query API websocket subscription requests default to the current protocol"""
-        test = Test("Query API websocket subscription requests default to the current protocol")
+
+        test = Test()
 
         api = self.apis[QUERY_API_KEY]
 
@@ -1807,7 +1826,8 @@ class IS0402Test(GenericTest):
 
     def test_30(self):
         """Registration API accepts heartbeat requests for a Node held in the registry"""
-        test = Test("Registration API accepts heartbeat requests for a Node held in the registry")
+
+        test = Test()
 
         api = self.apis[REG_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
@@ -1833,8 +1853,8 @@ class IS0402Test(GenericTest):
     def test_31(self):
         """Query API sends correct websocket event messages for UNCHANGED (SYNC), ADDED, MODIFIED and REMOVED"""
 
-        test = Test("Query API sends correct websocket event messages for UNCHANGED (SYNC), ADDED, MODIFIED "
-                    "and REMOVED")
+        test = Test()
+
         api = self.apis[QUERY_API_KEY]
         if self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
 

--- a/IS0403Test.py
+++ b/IS0403Test.py
@@ -45,8 +45,9 @@ class IS0403Test(GenericTest):
     def test_01_node_mdns_with_txt(self):
         """Node advertises a Node type mDNS announcement with ver_* TXT records
         in the absence of a Registration API"""
-        test = Test("Node advertises a Node type mDNS announcement with ver_* TXT records in the absence "
-                    "of a Registration API")
+
+        test = Test()
+
         browser = ServiceBrowser(self.zc, "_nmos-node._tcp.local.", self.zc_listener)
         time.sleep(1)
         node_list = self.zc_listener.get_service_list()
@@ -88,6 +89,7 @@ class IS0403Test(GenericTest):
 
     def test_02_node_mdns_txt_increment(self):
         """Node increments its ver_* TXT records when its matching Node API resources change"""
-        test = Test("Node increments its ver_* TXT records when its matching Node API resources change")
+
+        test = Test()
 
         return test.MANUAL()

--- a/IS0403Test.py
+++ b/IS0403Test.py
@@ -42,11 +42,9 @@ class IS0403Test(GenericTest):
             self.zc.close()
             self.zc = None
 
-    def test_01_node_mdns_with_txt(self):
+    def test_01_node_mdns_with_txt(self, test):
         """Node advertises a Node type mDNS announcement with ver_* TXT records
         in the absence of a Registration API"""
-
-        test = Test()
 
         browser = ServiceBrowser(self.zc, "_nmos-node._tcp.local.", self.zc_listener)
         time.sleep(1)
@@ -87,9 +85,7 @@ class IS0403Test(GenericTest):
         return test.FAIL("No matching mDNS announcement found for Node. Peer to peer mode will not function correctly.",
                          "https://github.com/amwa-tv/nmos/wiki/IS-04#nodes-peer-to-peer-mode")
 
-    def test_02_node_mdns_txt_increment(self):
+    def test_02_node_mdns_txt_increment(self, test):
         """Node increments its ver_* TXT records when its matching Node API resources change"""
-
-        test = Test()
 
         return test.MANUAL()

--- a/IS0501Test.py
+++ b/IS0501Test.py
@@ -50,8 +50,10 @@ class IS0501Test(GenericTest):
         self.receivers = self.is05_utils.get_receivers()
 
     def test_01(self):
-        """Api root matches the spec"""
-        test = Test("Api root matches the spec")
+        """API root matches the spec"""
+
+        test = Test()
+
         expected = ["single/", "bulk/"]
         dest = ""
         valid, result = self.is05_utils.checkCleanRequestJSON("GET", dest)
@@ -67,7 +69,9 @@ class IS0501Test(GenericTest):
 
     def test_02(self):
         """Single endpoint root matches the spec"""
-        test = Test("Single endpoint root matches the spec")
+
+        test = Test()
+
         expected = ["receivers/", "senders/"]
         dest = "single/"
         valid, result = self.is05_utils.checkCleanRequestJSON("GET", dest)
@@ -83,7 +87,9 @@ class IS0501Test(GenericTest):
 
     def test_03(self):
         """Root of /single/senders/ matches the spec"""
-        test = Test("Root of /single/senders/ matches the spec")
+
+        test = Test()
+
         dest = "single/senders/"
         valid, response = self.is05_utils.checkCleanRequestJSON("GET", dest)
         smsg = "UUIDs missing trailing slashes in response from {}".format(dest)
@@ -112,7 +118,9 @@ class IS0501Test(GenericTest):
 
     def test_04(self):
         """Root of /single/receivers/ matches the spec"""
-        test = Test("Root of /single/receivers/ matches the spec")
+
+        test = Test()
+
         dest = "single/receivers/"
         valid, response = self.is05_utils.checkCleanRequestJSON("GET", dest)
         smsg = "UUIDs missing trailing slashes in response from {}".format(dest)
@@ -140,8 +148,10 @@ class IS0501Test(GenericTest):
             return test.FAIL(response)
 
     def test_05(self):
-        """Index of /single/senders/<uuid>/ matches the spec"""
-        test = Test("Index of /single/senders/<uuid>/ matches the spec")
+        """Index of /single/senders/{senderId}/ matches the spec"""
+
+        test = Test()
+
         if len(self.senders) > 0:
             for sender in self.senders:
                 dest = "single/senders/" + sender + "/"
@@ -168,8 +178,10 @@ class IS0501Test(GenericTest):
             return test.UNCLEAR("Not tested. No resources found.")
 
     def test_06(self):
-        """Index of /single/receivers/<uuid>/ matches the spec"""
-        test = Test("Index of /single/receivers/<uuid>/ matches the spec")
+        """Index of /single/receivers/{receiverId}/ matches the spec"""
+
+        test = Test()
+
         if len(self.receivers) > 0:
             for receiver in self.receivers:
                 dest = "single/receivers/" + receiver + "/"
@@ -195,8 +207,10 @@ class IS0501Test(GenericTest):
             return test.UNCLEAR("Not tested. No resources found.")
 
     def test_07(self):
-        """Return of /single/senders/<uuid>/constraints/ meets the schema"""
-        test = Test("Return of /single/senders/<uuid>/constraints/ meets the schema")
+        """Return of /single/senders/{senderId}/constraints/ meets the schema"""
+
+        test = Test()
+
         if len(self.senders) > 0:
             for sender in self.senders:
                 dest = "single/senders/" + sender + "/constraints/"
@@ -211,8 +225,10 @@ class IS0501Test(GenericTest):
             return test.UNCLEAR("Not tested. No resources found.")
 
     def test_08(self):
-        """Return of /single/receivers/<uuid>/constraints/ meets the schema"""
-        test = Test("Return of /single/receivers/<uuid>/constraints/ meets the schema")
+        """Return of /single/receivers/{receiverId}/constraints/ meets the schema"""
+
+        test = Test()
+
         if len(self.receivers) > 0:
             for receiver in self.receivers:
                 dest = "single/receivers/" + receiver + "/constraints/"
@@ -227,8 +243,10 @@ class IS0501Test(GenericTest):
             return test.UNCLEAR("Not tested. No resources found.")
 
     def test_09(self):
-        """All params listed in /single/senders/<uuid>/constraints/ matches /staged/ and /active/"""
-        test = Test("All params listed in /single/senders/<uuid>/constraints/ matches /staged/ and /active/")
+        """All params listed in /single/senders/{senderId}/constraints/ matches /staged/ and /active/"""
+
+        test = Test()
+
         if len(self.senders) > 0:
             valid, response = self.is05_utils.check_params_match("senders", self.senders)
             if valid:
@@ -242,8 +260,10 @@ class IS0501Test(GenericTest):
             return test.UNCLEAR("Not tested. No resources found.")
 
     def test_10(self):
-        """All params listed in /single/receivers/<uuid>/constraints/ matches /staged/ and /active/"""
-        test = Test("All params listed in /single/receivers/<uuid>/constraints/ matches /staged/ and /active/")
+        """All params listed in /single/receivers/{receiverId}/constraints/ matches /staged/ and /active/"""
+
+        test = Test()
+
         if len(self.receivers) > 0:
             valid, response = self.is05_utils.check_params_match("receivers", self.receivers)
             if valid:
@@ -258,7 +278,8 @@ class IS0501Test(GenericTest):
 
     def test_11(self):
         """Senders are using valid combination of parameters"""
-        test = Test("Senders are using valid combination of parameters")
+
+        test = Test()
 
         generalParams = ['source_ip', 'destination_ip', 'destination_port', 'source_port', 'rtp_enabled']
         fecParams = ['fec_enabled', 'fec_destination_ip', 'fec_mode', 'fec_type',
@@ -302,7 +323,8 @@ class IS0501Test(GenericTest):
 
     def test_12(self):
         """Receiver are using valid combination of parameters"""
-        test = Test("Receiver are using valid combination of parameters")
+
+        test = Test()
 
         generalParams = ['source_ip', 'multicast_ip', 'interface_ip', 'destination_port', 'rtp_enabled']
         fecParams = ['fec_enabled', 'fec_destination_ip', 'fec_mode',
@@ -343,8 +365,10 @@ class IS0501Test(GenericTest):
             return test.UNCLEAR("Not tested. No resources found.")
 
     def test_13(self):
-        """Return of /single/senders/<uuid>/staged/ meets the schema"""
-        test = Test("Return of /single/senders/<uuid>/staged/ meets the schema")
+        """Return of /single/senders/{senderId}/staged/ meets the schema"""
+
+        test = Test()
+
         if len(self.senders) > 0:
             for sender in self.senders:
                 dest = "single/senders/" + sender + "/staged/"
@@ -359,8 +383,10 @@ class IS0501Test(GenericTest):
             return test.UNCLEAR("Not tested. No resources found.")
 
     def test_14(self):
-        """Return of /single/receivers/<uuid>/staged/ meets the schema"""
-        test = Test("Return of /single/receivers/<uuid>/staged/ meets the schema")
+        """Return of /single/receivers/{receiverId}/staged/ meets the schema"""
+
+        test = Test()
+
         if len(self.receivers) > 0:
             for receiver in self.receivers:
                 dest = "single/receivers/" + receiver + "/staged/"
@@ -376,7 +402,9 @@ class IS0501Test(GenericTest):
 
     def test_15(self):
         """Staged parameters for senders comply with constraints"""
-        test = Test("Staged parameters for senders comply with constraints")
+
+        test = Test()
+
         if len(self.senders) > 0:
             valid, response = self.check_staged_complies_with_constraints("sender", self.senders)
             if valid:
@@ -388,7 +416,9 @@ class IS0501Test(GenericTest):
 
     def test_16(self):
         """Staged parameters for receivers comply with constraints"""
-        test = Test("Staged parameters for receivers comply with constraints")
+
+        test = Test()
+
         if len(self.receivers) > 0:
             valid, response = self.check_staged_complies_with_constraints("receiver", self.receivers)
             if valid:
@@ -400,7 +430,9 @@ class IS0501Test(GenericTest):
 
     def test_17(self):
         """Sender patch response schema is valid"""
-        test = Test("Sender patch response schema is valid")
+
+        test = Test()
+
         if len(self.senders) > 0:
             valid, response = self.check_patch_response_schema_valid("sender", self.senders)
             if valid:
@@ -412,7 +444,9 @@ class IS0501Test(GenericTest):
 
     def test_18(self):
         """Receiver patch response schema is valid"""
-        test = Test("Receiver patch response schema is valid")
+
+        test = Test()
+
         if len(self.receivers) > 0:
             valid, response = self.check_patch_response_schema_valid("receiver", self.receivers)
             if valid:
@@ -424,7 +458,9 @@ class IS0501Test(GenericTest):
 
     def test_19(self):
         """Sender invalid patch is refused"""
-        test = Test("Sender invalid patch is refused")
+
+        test = Test()
+
         if len(self.senders) > 0:
             valid, response = self.is05_utils.check_refuses_invalid_patch("sender", self.senders)
             if valid:
@@ -436,7 +472,9 @@ class IS0501Test(GenericTest):
 
     def test_20(self):
         """Receiver invalid patch is refused"""
-        test = Test("Receiver invalid patch is refused")
+
+        test = Test()
+
         if len(self.receivers) > 0:
             valid, response = self.is05_utils.check_refuses_invalid_patch("receiver", self.receivers)
             if valid:
@@ -448,7 +486,9 @@ class IS0501Test(GenericTest):
 
     def test_21(self):
         """Sender id on staged receiver is changeable"""
-        test = Test("Sender id on staged receiver is changeable")
+
+        test = Test()
+
         if len(self.receivers) > 0:
             for receiver in self.receivers:
                 url = "single/receivers/" + receiver + "/staged"
@@ -477,7 +517,9 @@ class IS0501Test(GenericTest):
 
     def test_22(self):
         """Receiver id on staged sender is changeable"""
-        test = Test("Receiver id on staged sender is changeable")
+
+        test = Test()
+
         if len(self.senders) > 0:
             for sender in self.senders:
                 url = "single/senders/" + sender + "/staged"
@@ -506,7 +548,9 @@ class IS0501Test(GenericTest):
 
     def test_23(self):
         """Sender transport parameters are changeable"""
-        test = Test("Sender transport parameters are changeable")
+
+        test = Test()
+
         if len(self.senders) > 0:
             for sender in self.senders:
                 valid, values = self.is05_utils.generate_destination_ports("sender", sender)
@@ -525,7 +569,9 @@ class IS0501Test(GenericTest):
 
     def test_24(self):
         """Receiver transport parameters are changeable"""
-        test = Test("Receiver transport parameters are changeable")
+
+        test = Test()
+
         if len(self.receivers) > 0:
             for receiver in self.receivers:
                 valid, values = self.is05_utils.generate_destination_ports("receiver", receiver)
@@ -545,7 +591,9 @@ class IS0501Test(GenericTest):
 
     def test_25(self):
         """Immediate activation of a sender is possible"""
-        test = Test("Immediate activation of a sender is possible")
+
+        test = Test()
+
         if len(self.senders) > 0:
             for sender in self.is05_utils.sampled_list(self.senders):
                 valid, response = self.is05_utils.check_activation("sender", sender,
@@ -560,7 +608,9 @@ class IS0501Test(GenericTest):
 
     def test_26(self):
         """Immediate activation of a receiver is possible"""
-        test = Test("Immediate activation of a receiver is possible")
+
+        test = Test()
+
         if len(self.receivers) > 0:
             for receiver in self.is05_utils.sampled_list(self.receivers):
                 valid, response = self.is05_utils.check_activation("receiver", receiver,
@@ -576,7 +626,9 @@ class IS0501Test(GenericTest):
 
     def test_27(self):
         """Relative activation of a sender is possible"""
-        test = Test("Relative activation of a sender is possible")
+
+        test = Test()
+
         if len(self.senders) > 0:
             for sender in self.is05_utils.sampled_list(self.senders):
                 valid, response = self.is05_utils.check_activation("sender", sender,
@@ -591,7 +643,9 @@ class IS0501Test(GenericTest):
 
     def test_28(self):
         """Relative activation of a receiver is possible"""
-        test = Test("Relative activation of a receiver is possible")
+
+        test = Test()
+
         if len(self.receivers) > 0:
             for receiver in self.is05_utils.sampled_list(self.receivers):
                 valid, response = self.is05_utils.check_activation("receiver", receiver,
@@ -606,7 +660,9 @@ class IS0501Test(GenericTest):
 
     def test_29(self):
         """Absolute activation of a sender is possible"""
-        test = Test("Absolute activation of a sender is possible")
+
+        test = Test()
+
         if len(self.senders) > 0:
             for sender in self.is05_utils.sampled_list(self.senders):
                 valid, response = self.is05_utils.check_activation("sender", sender,
@@ -621,7 +677,9 @@ class IS0501Test(GenericTest):
 
     def test_30(self):
         """Absolute activation of a receiver is possible"""
-        test = Test("Absolute activation of a receiver is possible")
+
+        test = Test()
+
         if len(self.receivers) > 0:
             for receiver in self.is05_utils.sampled_list(self.receivers):
                 valid, response = self.is05_utils.check_activation("receiver", receiver,
@@ -636,7 +694,9 @@ class IS0501Test(GenericTest):
 
     def test_31(self):
         """Sender active response schema is valid"""
-        test = Test("Sender active response schema is valid")
+
+        test = Test()
+
         if len(self.senders):
             for sender in self.senders:
                 activeUrl = "single/senders/" + sender + "/active"
@@ -652,7 +712,9 @@ class IS0501Test(GenericTest):
 
     def test_32(self):
         """Receiver active response schema is valid"""
-        test = Test("Receiver active response schema is valid")
+
+        test = Test()
+
         if len(self.receivers):
             for receiver in self.receivers:
                 activeUrl = "single/receivers/" + receiver + "/active"
@@ -668,7 +730,9 @@ class IS0501Test(GenericTest):
 
     def test_33(self):
         """/bulk/ endpoint returns correct JSON"""
-        test = Test("/bulk/ endpoint returns correct JSON")
+
+        test = Test()
+
         url = "bulk/"
         valid, response = self.is05_utils.checkCleanRequestJSON("GET", url)
         if valid:
@@ -683,7 +747,9 @@ class IS0501Test(GenericTest):
 
     def test_34(self):
         """GET on /bulk/senders returns 405"""
-        test = Test("GET on /bulk/senders returns 405")
+
+        test = Test()
+
         url = "bulk/senders"
         valid, response = self.is05_utils.checkCleanRequestJSON("GET", url, code=405)
         if valid:
@@ -693,7 +759,9 @@ class IS0501Test(GenericTest):
 
     def test_35(self):
         """GET on /bulk/receivers returns 405"""
-        test = Test("GET on /bulk/receivers returns 405")
+
+        test = Test()
+
         url = "bulk/receivers"
         valid, response = self.is05_utils.checkCleanRequestJSON("GET", url, code=405)
         if valid:
@@ -703,7 +771,9 @@ class IS0501Test(GenericTest):
 
     def test_36(self):
         """Bulk interface can be used to change destination port on all senders"""
-        test = Test("Bulk interface can be used to change destination port on all senders")
+
+        test = Test()
+
         if len(self.senders) > 0:
             valid, response = self.check_bulk_stage("sender", self.senders)
             if valid:
@@ -715,7 +785,9 @@ class IS0501Test(GenericTest):
 
     def test_37(self):
         """Bulk interface can be used to change destination port on all receivers"""
-        test = Test("Bulk interface can be used to change destination port on all receivers")
+
+        test = Test()
+
         if len(self.receivers) > 0:
             valid, response = self.check_bulk_stage("receiver", self.receivers)
             if valid:
@@ -727,7 +799,9 @@ class IS0501Test(GenericTest):
 
     def test_38(self):
         """Number of legs matches on constraints, staged and active endpoint for senders"""
-        test = Test("Number of legs matches on constraints, staged and active endpoint for senders")
+        
+        test = Test()
+
         if len(self.senders) > 0:
             for sender in self.senders:
                 url = "single/senders/{}/".format(sender)
@@ -742,7 +816,9 @@ class IS0501Test(GenericTest):
 
     def test_39(self):
         """Number of legs matches on constraints, staged and active endpoint for receivers"""
-        test = Test("Number of legs matches on constraints, staged and active endpoint for receivers")
+
+        test = Test()
+
         if len(self.receivers) > 0:
             for receiver in self.receivers:
                 url = "single/receivers/{}/".format(receiver)
@@ -757,7 +833,9 @@ class IS0501Test(GenericTest):
 
     def test_40(self):
         """Only valid transport types for a given API version are advertised"""
-        test = Test("Only valid transport types for a given API version are advertised")
+
+        test = Test()
+
         api = self.apis[CONN_API_KEY]
         if self.is05_utils.compare_api_version(api["version"], "v1.0") == 0:
             # Ensure rtp_enabled in present in each transport_params entry to confirm it's RTP

--- a/IS0501Test.py
+++ b/IS0501Test.py
@@ -49,10 +49,8 @@ class IS0501Test(GenericTest):
         self.senders = self.is05_utils.get_senders()
         self.receivers = self.is05_utils.get_receivers()
 
-    def test_01(self):
+    def test_01(self, test):
         """API root matches the spec"""
-
-        test = Test()
 
         expected = ["single/", "bulk/"]
         dest = ""
@@ -67,10 +65,8 @@ class IS0501Test(GenericTest):
         else:
             return test.FAIL(result)
 
-    def test_02(self):
+    def test_02(self, test):
         """Single endpoint root matches the spec"""
-
-        test = Test()
 
         expected = ["receivers/", "senders/"]
         dest = "single/"
@@ -85,10 +81,8 @@ class IS0501Test(GenericTest):
         else:
             return test.FAIL(result)
 
-    def test_03(self):
+    def test_03(self, test):
         """Root of /single/senders/ matches the spec"""
-
-        test = Test()
 
         dest = "single/senders/"
         valid, response = self.is05_utils.checkCleanRequestJSON("GET", dest)
@@ -116,10 +110,8 @@ class IS0501Test(GenericTest):
         else:
             return test.FAIL(response)
 
-    def test_04(self):
+    def test_04(self, test):
         """Root of /single/receivers/ matches the spec"""
-
-        test = Test()
 
         dest = "single/receivers/"
         valid, response = self.is05_utils.checkCleanRequestJSON("GET", dest)
@@ -147,10 +139,8 @@ class IS0501Test(GenericTest):
         else:
             return test.FAIL(response)
 
-    def test_05(self):
+    def test_05(self, test):
         """Index of /single/senders/{senderId}/ matches the spec"""
-
-        test = Test()
 
         if len(self.senders) > 0:
             for sender in self.senders:
@@ -177,10 +167,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_06(self):
+    def test_06(self, test):
         """Index of /single/receivers/{receiverId}/ matches the spec"""
-
-        test = Test()
 
         if len(self.receivers) > 0:
             for receiver in self.receivers:
@@ -206,10 +194,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_07(self):
+    def test_07(self, test):
         """Return of /single/senders/{senderId}/constraints/ meets the schema"""
-
-        test = Test()
 
         if len(self.senders) > 0:
             for sender in self.senders:
@@ -224,10 +210,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_08(self):
+    def test_08(self, test):
         """Return of /single/receivers/{receiverId}/constraints/ meets the schema"""
-
-        test = Test()
 
         if len(self.receivers) > 0:
             for receiver in self.receivers:
@@ -242,10 +226,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_09(self):
+    def test_09(self, test):
         """All params listed in /single/senders/{senderId}/constraints/ matches /staged/ and /active/"""
-
-        test = Test()
 
         if len(self.senders) > 0:
             valid, response = self.is05_utils.check_params_match("senders", self.senders)
@@ -259,10 +241,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_10(self):
+    def test_10(self, test):
         """All params listed in /single/receivers/{receiverId}/constraints/ matches /staged/ and /active/"""
-
-        test = Test()
 
         if len(self.receivers) > 0:
             valid, response = self.is05_utils.check_params_match("receivers", self.receivers)
@@ -276,10 +256,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_11(self):
+    def test_11(self, test):
         """Senders are using valid combination of parameters"""
-
-        test = Test()
 
         generalParams = ['source_ip', 'destination_ip', 'destination_port', 'source_port', 'rtp_enabled']
         fecParams = ['fec_enabled', 'fec_destination_ip', 'fec_mode', 'fec_type',
@@ -321,10 +299,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_12(self):
+    def test_12(self, test):
         """Receiver are using valid combination of parameters"""
-
-        test = Test()
 
         generalParams = ['source_ip', 'multicast_ip', 'interface_ip', 'destination_port', 'rtp_enabled']
         fecParams = ['fec_enabled', 'fec_destination_ip', 'fec_mode',
@@ -364,10 +340,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_13(self):
+    def test_13(self, test):
         """Return of /single/senders/{senderId}/staged/ meets the schema"""
-
-        test = Test()
 
         if len(self.senders) > 0:
             for sender in self.senders:
@@ -382,10 +356,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_14(self):
+    def test_14(self, test):
         """Return of /single/receivers/{receiverId}/staged/ meets the schema"""
-
-        test = Test()
 
         if len(self.receivers) > 0:
             for receiver in self.receivers:
@@ -400,10 +372,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_15(self):
+    def test_15(self, test):
         """Staged parameters for senders comply with constraints"""
-
-        test = Test()
 
         if len(self.senders) > 0:
             valid, response = self.check_staged_complies_with_constraints("sender", self.senders)
@@ -414,10 +384,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_16(self):
+    def test_16(self, test):
         """Staged parameters for receivers comply with constraints"""
-
-        test = Test()
 
         if len(self.receivers) > 0:
             valid, response = self.check_staged_complies_with_constraints("receiver", self.receivers)
@@ -428,10 +396,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_17(self):
+    def test_17(self, test):
         """Sender patch response schema is valid"""
-
-        test = Test()
 
         if len(self.senders) > 0:
             valid, response = self.check_patch_response_schema_valid("sender", self.senders)
@@ -442,10 +408,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_18(self):
+    def test_18(self, test):
         """Receiver patch response schema is valid"""
-
-        test = Test()
 
         if len(self.receivers) > 0:
             valid, response = self.check_patch_response_schema_valid("receiver", self.receivers)
@@ -456,10 +420,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_19(self):
+    def test_19(self, test):
         """Sender invalid patch is refused"""
-
-        test = Test()
 
         if len(self.senders) > 0:
             valid, response = self.is05_utils.check_refuses_invalid_patch("sender", self.senders)
@@ -470,10 +432,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_20(self):
+    def test_20(self, test):
         """Receiver invalid patch is refused"""
-
-        test = Test()
 
         if len(self.receivers) > 0:
             valid, response = self.is05_utils.check_refuses_invalid_patch("receiver", self.receivers)
@@ -484,10 +444,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_21(self):
+    def test_21(self, test):
         """Sender id on staged receiver is changeable"""
-
-        test = Test()
 
         if len(self.receivers) > 0:
             for receiver in self.receivers:
@@ -515,10 +473,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_22(self):
+    def test_22(self, test):
         """Receiver id on staged sender is changeable"""
-
-        test = Test()
 
         if len(self.senders) > 0:
             for sender in self.senders:
@@ -546,10 +502,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_23(self):
+    def test_23(self, test):
         """Sender transport parameters are changeable"""
-
-        test = Test()
 
         if len(self.senders) > 0:
             for sender in self.senders:
@@ -567,10 +521,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_24(self):
+    def test_24(self, test):
         """Receiver transport parameters are changeable"""
-
-        test = Test()
 
         if len(self.receivers) > 0:
             for receiver in self.receivers:
@@ -589,11 +541,9 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_25(self):
+    def test_25(self, test):
         """Immediate activation of a sender is possible"""
 
-        test = Test()
-
         if len(self.senders) > 0:
             for sender in self.is05_utils.sampled_list(self.senders):
                 valid, response = self.is05_utils.check_activation("sender", sender,
@@ -606,11 +556,9 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_26(self):
+    def test_26(self, test):
         """Immediate activation of a receiver is possible"""
 
-        test = Test()
-
         if len(self.receivers) > 0:
             for receiver in self.is05_utils.sampled_list(self.receivers):
                 valid, response = self.is05_utils.check_activation("receiver", receiver,
@@ -624,11 +572,9 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_27(self):
+    def test_27(self, test):
         """Relative activation of a sender is possible"""
 
-        test = Test()
-
         if len(self.senders) > 0:
             for sender in self.is05_utils.sampled_list(self.senders):
                 valid, response = self.is05_utils.check_activation("sender", sender,
@@ -641,11 +587,9 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_28(self):
+    def test_28(self, test):
         """Relative activation of a receiver is possible"""
 
-        test = Test()
-
         if len(self.receivers) > 0:
             for receiver in self.is05_utils.sampled_list(self.receivers):
                 valid, response = self.is05_utils.check_activation("receiver", receiver,
@@ -658,10 +602,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_29(self):
+    def test_29(self, test):
         """Absolute activation of a sender is possible"""
-
-        test = Test()
 
         if len(self.senders) > 0:
             for sender in self.is05_utils.sampled_list(self.senders):
@@ -675,10 +617,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_30(self):
+    def test_30(self, test):
         """Absolute activation of a receiver is possible"""
-
-        test = Test()
 
         if len(self.receivers) > 0:
             for receiver in self.is05_utils.sampled_list(self.receivers):
@@ -692,10 +632,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_31(self):
+    def test_31(self, test):
         """Sender active response schema is valid"""
-
-        test = Test()
 
         if len(self.senders):
             for sender in self.senders:
@@ -710,10 +648,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_32(self):
+    def test_32(self, test):
         """Receiver active response schema is valid"""
-
-        test = Test()
 
         if len(self.receivers):
             for receiver in self.receivers:
@@ -728,10 +664,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_33(self):
+    def test_33(self, test):
         """/bulk/ endpoint returns correct JSON"""
-
-        test = Test()
 
         url = "bulk/"
         valid, response = self.is05_utils.checkCleanRequestJSON("GET", url)
@@ -745,10 +679,8 @@ class IS0501Test(GenericTest):
         else:
             return test.FAIL(response)
 
-    def test_34(self):
+    def test_34(self, test):
         """GET on /bulk/senders returns 405"""
-
-        test = Test()
 
         url = "bulk/senders"
         valid, response = self.is05_utils.checkCleanRequestJSON("GET", url, code=405)
@@ -757,10 +689,8 @@ class IS0501Test(GenericTest):
         else:
             return test.FAIL(response)
 
-    def test_35(self):
+    def test_35(self, test):
         """GET on /bulk/receivers returns 405"""
-
-        test = Test()
 
         url = "bulk/receivers"
         valid, response = self.is05_utils.checkCleanRequestJSON("GET", url, code=405)
@@ -769,10 +699,8 @@ class IS0501Test(GenericTest):
         else:
             return test.FAIL(response)
 
-    def test_36(self):
+    def test_36(self, test):
         """Bulk interface can be used to change destination port on all senders"""
-
-        test = Test()
 
         if len(self.senders) > 0:
             valid, response = self.check_bulk_stage("sender", self.senders)
@@ -783,10 +711,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_37(self):
+    def test_37(self, test):
         """Bulk interface can be used to change destination port on all receivers"""
-
-        test = Test()
 
         if len(self.receivers) > 0:
             valid, response = self.check_bulk_stage("receiver", self.receivers)
@@ -797,11 +723,9 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_38(self):
+    def test_38(self, test):
         """Number of legs matches on constraints, staged and active endpoint for senders"""
         
-        test = Test()
-
         if len(self.senders) > 0:
             for sender in self.senders:
                 url = "single/senders/{}/".format(sender)
@@ -814,10 +738,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_39(self):
+    def test_39(self, test):
         """Number of legs matches on constraints, staged and active endpoint for receivers"""
-
-        test = Test()
 
         if len(self.receivers) > 0:
             for receiver in self.receivers:
@@ -831,10 +753,8 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-    def test_40(self):
+    def test_40(self, test):
         """Only valid transport types for a given API version are advertised"""
-
-        test = Test()
 
         api = self.apis[CONN_API_KEY]
         if self.is05_utils.compare_api_version(api["version"], "v1.0") == 0:

--- a/IS0502Test.py
+++ b/IS0502Test.py
@@ -248,10 +248,8 @@ class IS0502Test(GenericTest):
 
         return True, ""
 
-    def test_01_node_api_1_2_or_greater(self):
+    def test_01_node_api_1_2_or_greater(self, test):
         """Check that version 1.2 or greater of the Node API is available"""
-
-        test = Test()
 
         api = self.apis[NODE_API_KEY]
         if self.is05_utils.compare_api_version(api["version"], "v1.2") >= 0:
@@ -263,10 +261,8 @@ class IS0502Test(GenericTest):
         else:
             return test.FAIL("Node API must be running v1.2 or greater")
 
-    def test_02_device_control_present(self):
+    def test_02_device_control_present(self, test):
         """At least one Device is showing an IS-05 control advertisement matching the API under test"""
-
-        test = Test()
 
         valid, devices = self.do_request("GET", self.node_url + "devices")
         if not valid:
@@ -295,10 +291,8 @@ class IS0502Test(GenericTest):
         else:
             return test.FAIL("Unable to find any Devices which expose the control type '{}'".format(device_type))
 
-    def test_03_is04_is05_rx_match(self):
+    def test_03_is04_is05_rx_match(self, test):
         """Receivers shown in Connection API matches those shown in Node API"""
-
-        test = Test()
 
         valid, result = self.get_is04_resources("receivers")
         if not valid:
@@ -315,10 +309,8 @@ class IS0502Test(GenericTest):
 
         return test.PASS()
 
-    def test_04_is04_is05_tx_match(self):
+    def test_04_is04_is05_tx_match(self, test):
         """Senders shown in Connection API matches those shown in Node API"""
-
-        test = Test()
 
         valid, result = self.get_is04_resources("senders")
         if not valid:
@@ -335,11 +327,9 @@ class IS0502Test(GenericTest):
 
         return test.PASS()
 
-    def test_05_rx_activate_updates_ver(self):
+    def test_05_rx_activate_updates_ver(self, test):
         """Activation of a receiver increments the version timestamp"""
 
-        test = Test()
-
         resource_type = "receivers"
 
         valid, result = self.refresh_is04_resources(resource_type)
@@ -358,11 +348,9 @@ class IS0502Test(GenericTest):
         else:
             return test.PASS()
 
-    def test_06_tx_activate_updates_ver(self):
+    def test_06_tx_activate_updates_ver(self, test):
         """Activation of a sender increments the version timestamp"""
 
-        test = Test()
-
         resource_type = "senders"
 
         valid, result = self.refresh_is04_resources(resource_type)
@@ -381,11 +369,9 @@ class IS0502Test(GenericTest):
         else:
             return test.PASS()
 
-    def test_07_rx_nmos_updates_sub(self):
+    def test_07_rx_nmos_updates_sub(self, test):
         """Activation of a receiver from an NMOS sender updates the IS-04 subscription"""
 
-        test = Test()
-
         resource_type = "receivers"
 
         valid, result = self.get_is04_resources(resource_type)
@@ -408,11 +394,9 @@ class IS0502Test(GenericTest):
         else:
             return test.PASS()
 
-    def test_08_rx_ext_updates_sub(self):
+    def test_08_rx_ext_updates_sub(self, test):
         """Activation of a receiver from a non-NMOS sender updates the IS-04 subscription"""
 
-        test = Test()
-
         resource_type = "receivers"
 
         valid, result = self.get_is04_resources(resource_type)
@@ -435,11 +419,9 @@ class IS0502Test(GenericTest):
         else:
             return test.PASS()
 
-    def test_09_tx_mcast_updates_sub(self):
+    def test_09_tx_mcast_updates_sub(self, test):
         """Activation of a sender to a multicast address updates the IS-04 subscription"""
 
-        test = Test()
-
         api = self.apis[NODE_API_KEY]
         if self.is05_utils.compare_api_version(api["version"], "v1.2") < 0:
             return test.NA("IS-04 v1.1 and earlier Senders do not have a subscription object")
@@ -466,11 +448,9 @@ class IS0502Test(GenericTest):
         else:
             return test.PASS()
 
-    def test_10_tx_ucast_nmos_updates_sub(self):
+    def test_10_tx_ucast_nmos_updates_sub(self, test):
         """Activation of a sender to a unicast NMOS receiver updates the IS-04 subscription"""
 
-        test = Test()
-
         api = self.apis[NODE_API_KEY]
         if self.is05_utils.compare_api_version(api["version"], "v1.2") < 0:
             return test.NA("IS-04 v1.1 and earlier Senders do not have a subscription object")
@@ -497,10 +477,8 @@ class IS0502Test(GenericTest):
         else:
             return test.PASS()
 
-    def test_11_tx_ucast_ext_updates_sub(self):
+    def test_11_tx_ucast_ext_updates_sub(self, test):
         """Activation of a sender to a unicast non-NMOS receiver updates the IS-04 subscription"""
-
-        test = Test()
 
         api = self.apis[NODE_API_KEY]
         if self.is05_utils.compare_api_version(api["version"], "v1.2") < 0:
@@ -528,10 +506,8 @@ class IS0502Test(GenericTest):
         else:
             return test.PASS()
 
-    def test_12_interface_bindings_length(self):
+    def test_12_interface_bindings_length(self, test):
         """IS-04 interface bindings array matches length of IS-05 transport_params array"""
-
-        test = Test()
 
         for resource_type in ["senders", "receivers"]:
             valid, result = self.get_is04_resources(resource_type)
@@ -564,10 +540,8 @@ class IS0502Test(GenericTest):
 
         return test.PASS()
 
-    def test_13_transport_files_match(self):
+    def test_13_transport_files_match(self, test):
         """IS-04 manifest_href matches IS-05 transportfile"""
-
-        test = Test()
 
         valid, result = self.get_is04_resources("senders")
         if not valid:

--- a/IS0502Test.py
+++ b/IS0502Test.py
@@ -251,7 +251,7 @@ class IS0502Test(GenericTest):
     def test_01_node_api_1_2_or_greater(self):
         """Check that version 1.2 or greater of the Node API is available"""
 
-        test = Test("Check that version 1.2 or greater of the Node API is available")
+        test = Test()
 
         api = self.apis[NODE_API_KEY]
         if self.is05_utils.compare_api_version(api["version"], "v1.2") >= 0:
@@ -266,7 +266,7 @@ class IS0502Test(GenericTest):
     def test_02_device_control_present(self):
         """At least one Device is showing an IS-05 control advertisement matching the API under test"""
 
-        test = Test("At least one Device is showing an IS-05 control advertisement matching the API under test")
+        test = Test()
 
         valid, devices = self.do_request("GET", self.node_url + "devices")
         if not valid:
@@ -298,7 +298,7 @@ class IS0502Test(GenericTest):
     def test_03_is04_is05_rx_match(self):
         """Receivers shown in Connection API matches those shown in Node API"""
 
-        test = Test("Receivers shown in Connection API matches those shown in Node API")
+        test = Test()
 
         valid, result = self.get_is04_resources("receivers")
         if not valid:
@@ -318,7 +318,7 @@ class IS0502Test(GenericTest):
     def test_04_is04_is05_tx_match(self):
         """Senders shown in Connection API matches those shown in Node API"""
 
-        test = Test("Senders shown in Connection API matches those shown in Node API")
+        test = Test()
 
         valid, result = self.get_is04_resources("senders")
         if not valid:
@@ -338,7 +338,7 @@ class IS0502Test(GenericTest):
     def test_05_rx_activate_updates_ver(self):
         """Activation of a receiver increments the version timestamp"""
 
-        test = Test("Activation of a receiver increments the version timestamp")
+        test = Test()
 
         resource_type = "receivers"
 
@@ -361,7 +361,7 @@ class IS0502Test(GenericTest):
     def test_06_tx_activate_updates_ver(self):
         """Activation of a sender increments the version timestamp"""
 
-        test = Test("Activation of a sender increments the version timestamp")
+        test = Test()
 
         resource_type = "senders"
 
@@ -384,7 +384,7 @@ class IS0502Test(GenericTest):
     def test_07_rx_nmos_updates_sub(self):
         """Activation of a receiver from an NMOS sender updates the IS-04 subscription"""
 
-        test = Test("Activation of a receiver from an NMOS sender updates the IS-04 subscription")
+        test = Test()
 
         resource_type = "receivers"
 
@@ -411,7 +411,7 @@ class IS0502Test(GenericTest):
     def test_08_rx_ext_updates_sub(self):
         """Activation of a receiver from a non-NMOS sender updates the IS-04 subscription"""
 
-        test = Test("Activation of a receiver from a non-NMOS sender updates the IS-04 subscription")
+        test = Test()
 
         resource_type = "receivers"
 
@@ -438,7 +438,7 @@ class IS0502Test(GenericTest):
     def test_09_tx_mcast_updates_sub(self):
         """Activation of a sender to a multicast address updates the IS-04 subscription"""
 
-        test = Test("Activation of a sender to a multicast address updates the IS-04 subscription")
+        test = Test()
 
         api = self.apis[NODE_API_KEY]
         if self.is05_utils.compare_api_version(api["version"], "v1.2") < 0:
@@ -469,7 +469,7 @@ class IS0502Test(GenericTest):
     def test_10_tx_ucast_nmos_updates_sub(self):
         """Activation of a sender to a unicast NMOS receiver updates the IS-04 subscription"""
 
-        test = Test("Activation of a sender to a unicast NMOS receiver updates the IS-04 subscription")
+        test = Test()
 
         api = self.apis[NODE_API_KEY]
         if self.is05_utils.compare_api_version(api["version"], "v1.2") < 0:
@@ -500,7 +500,7 @@ class IS0502Test(GenericTest):
     def test_11_tx_ucast_ext_updates_sub(self):
         """Activation of a sender to a unicast non-NMOS receiver updates the IS-04 subscription"""
 
-        test = Test("Activation of a sender to a unicast non-NMOS receiver updates the IS-04 subscription")
+        test = Test()
 
         api = self.apis[NODE_API_KEY]
         if self.is05_utils.compare_api_version(api["version"], "v1.2") < 0:
@@ -531,7 +531,7 @@ class IS0502Test(GenericTest):
     def test_12_interface_bindings_length(self):
         """IS-04 interface bindings array matches length of IS-05 transport_params array"""
 
-        test = Test("IS-04 interface bindings array matches length of IS-05 transport_params array")
+        test = Test()
 
         for resource_type in ["senders", "receivers"]:
             valid, result = self.get_is04_resources(resource_type)
@@ -567,7 +567,7 @@ class IS0502Test(GenericTest):
     def test_13_transport_files_match(self):
         """IS-04 manifest_href matches IS-05 transportfile"""
 
-        test = Test("IS-04 manifest_href matches IS-05 transportfile")
+        test = Test()
 
         valid, result = self.get_is04_resources("senders")
         if not valid:

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -87,7 +87,8 @@ This test suite is intended to be straightforward to extend. If you encounter an
 
 All test classes inherit from `GenericTest` which implements some basic schema checks on GET/HEAD/OPTIONS methods from the specification. It also provides access to a 'Specification' object which contains a parsed version of the API RAML, and provides access to schemas for the development of additional tests.
 
-Each manually defined test is expected to be defined as a method starting with `test_`. This will allow it to be automatically discovered and run by the test suite. The return type for each test must be the result of calling one of the following methods on an object of class `Test`.
+Each manually defined test case is expected to be defined as a method starting with `test_`, taking an object of class `Test`. This will allow it to be automatically discovered and run by the test suite.
+The return type for each test case must be the result of calling one of the methods on the `Test` object shown below.
 
 * The first argument, `details`, is used to specify the reason for the test result.
   It is required for `FAIL`, `OPTIONAL` (Not Implemented), or `NA` (Not Applicable), and is recommended for all cases other than a straightforward `PASS`.
@@ -100,8 +101,9 @@ Examples of each result are included below:
 ```python
 from TestResult import Test
 
-def test_my_stuff(self):
-    test = Test("My test description")
+def test_my_stuff(self, test):
+    """My test description"""
+
     # Test code
     if test_passed:
         return test.PASS()

--- a/TestResult.py
+++ b/TestResult.py
@@ -59,21 +59,12 @@ class TestResult(object):
 
 
 class Test(object):
-    def __init__(self, description=None, name=None):
+    def __init__(self, description, name=None):
         self.description = description
         self.name = name
-
-        caller_frame = inspect.currentframe().f_back
-        caller_self = caller_frame.f_locals.get('self')
-        caller_method = getattr(caller_self, caller_frame.f_code.co_name, None)
-
-        if caller_method and not self.name:
+        if not self.name:
             # Get name of calling function
-            self.name = caller_method.__name__
-        if not self.description:
-            # Get docstring of calling function
-            self.description = inspect.getdoc(caller_method)
-
+            self.name = inspect.stack()[1][3]
         self.timer = time.time()
 
     def _current_time(self):

--- a/TestResult.py
+++ b/TestResult.py
@@ -59,12 +59,21 @@ class TestResult(object):
 
 
 class Test(object):
-    def __init__(self, description, name=None):
+    def __init__(self, description=None, name=None):
         self.description = description
         self.name = name
-        if not self.name:
+
+        caller_frame = inspect.currentframe().f_back
+        caller_self = caller_frame.f_locals.get('self')
+        caller_method = getattr(caller_self, caller_frame.f_code.co_name, None)
+
+        if caller_method and not self.name:
             # Get name of calling function
-            self.name = inspect.stack()[1][3]
+            self.name = caller_method.__name__
+        if not self.description:
+            # Get docstring of calling function
+            self.description = inspect.getdoc(caller_method)
+
         self.timer = time.time()
 
     def _current_time(self):


### PR DESCRIPTION
Getting rid of the duplicate descriptions of the test cases seems like a win.

The implementation is a little fragile, mostly around interaction with `@test_depends`, but @KevinTao-Sony is readying a PR to get rid of all uses of that (only in `IS0402Test`).