### PR TITLE
Tweaks to avoid frustration of hitting 'Run' when there are no tests selected

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -46,7 +46,8 @@ h1 {
 }
 
 .backlink {
-    float: right;
+    position: absolute;
+    right: 0;
 }
 
 th {

--- a/static/js/result_script.js
+++ b/static/js/result_script.js
@@ -1,4 +1,4 @@
-function fixUpTestSelection(source) {
+function changeTestSelection(source) {
 
     // Toggling the "failed_all" checkbox should apply to all failed test checkboxes
     failed_auto = false;
@@ -36,6 +36,22 @@ function fixUpTestSelection(source) {
         }
     }
     document.getElementById("failed_all").checked = fail_all;
+
+    test_any = false;
+    test_checkboxes = document.getElementsByName("test_selection");
+    for (var i = 0, n = test_checkboxes.length; i < n; i++) {
+        if (test_checkboxes[i].checked) {
+            test_any = true;
+            break;
+        }
+    }
+    document.getElementById("runbtn").disabled = !test_any;
+}
+
+function disableRunbtn() {
+    var runbtn = document.getElementById("runbtn");
+    runbtn.value = "Executing tests...";
+    runbtn.disabled = true;
 }
 
 document.addEventListener("DOMContentLoaded", function() {
@@ -44,4 +60,5 @@ document.addEventListener("DOMContentLoaded", function() {
         document.getElementById("failed_all").disabled = true;
         document.getElementById("failed_all_label").style.opacity = 0.5;
     }
+    document.getElementById("runbtn").disabled = true;
 });

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -103,6 +103,12 @@ function saveSettings() {
     }
 };
 
+function disableRunbtn() {
+    var runbtn = document.getElementById("runbtn");
+    runbtn.value = "Executing tests...";
+    runbtn.disabled = true;
+}
+
 document.addEventListener("DOMContentLoaded", function() {
     document.getElementById("test").onchange = function() {
         updateDropdown();
@@ -121,6 +127,15 @@ document.addEventListener("DOMContentLoaded", function() {
         else {
             testOptions[0].selected = false;
         }
+
+        test_any = false;
+        for (var i = 0, n = testOptions.length; i < n; i++) {
+            if (testOptions[i].selected) {
+                test_any = true;
+                break;
+            }
+        }
+        document.getElementById("runbtn").disabled = !test_any;
     }
 
     loadSettings();

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,7 +37,7 @@
             This test suite is under active development and does not yet provide 100% coverage of specifications.<br />
             We recommend regularly re-testing implementations as new tests are developed.
         </div>
-        <form action="" method='POST'>
+        <form action="" method='POST' onsubmit="disableRunbtn(); saveSettings(); return true;">
             <div class="input_data">
                 <div class="input dropdown input_data_fld">
                     {{ form.test.label }} {{ form.test }}
@@ -100,7 +100,7 @@
                 {% endwith %}
                 <br/>
                 <div class="input submit input_data_fld">
-                    <input type="submit" id="runbtn" value="Run" onclick="document.getElementById('runbtn').value='Executing tests...';document.getElementById('runbtn').className += 'disabled'; saveSettings();"/>
+                    <input type="submit" id="runbtn" value="Run"/>
                 </div>
             </div>
 

--- a/templates/result.html
+++ b/templates/result.html
@@ -27,13 +27,13 @@
 </head>
 <body>
     <a href="../" class="backlink">More Options</a>
-    <h1 style="text-align: center">NMOS Test</h1>
-    <div class="text text_result" style="text-align: center">
+    <h1>NMOS Test</h1>
+    <div class="text text_result">
         <h5>Result for test suite <b>{{ test }}</b> on <b><a href={{ url }}>{{ url }}</a></b></h5>
     </div>
     <div class="text text_result">
-        <form action="" method="POST">
-            <input type="submit" id="runbtn" value="Run" style="margin:auto; display:block;" onclick="document.getElementById('runbtn').value='Executing tests...';document.getElementById('runbtn').className +='disabled';"/>
+        <form action="" method="POST" onsubmit="disableRunbtn(); return true;">
+            <input type="submit" id="runbtn" value="Run" style="margin:auto; display:block;"/>
             <div style="display: none;">
                 {{ form.test }}
                 {{ form.hidden_tests }}
@@ -51,7 +51,7 @@
                 <thead>
                     <tr onclick="document.getElementById('failed_all').click();">
                         <th>
-                            <input type="checkbox" id="failed_all" unchecked onclick="event.stopPropagation(); fixUpTestSelection(this);"/>
+                            <input type="checkbox" id="failed_all" unchecked onclick="event.stopPropagation(); changeTestSelection(this);"/>
                             <label id="failed_all_label" style="opacity: 1;"> Failed Tests</label>
                         </th>
                     </tr>
@@ -77,7 +77,7 @@
                                             name="test_selection" value="{{ curr_result[0] }}"
                                         {% endif %}
                                         class="{% if curr_auto %}auto{% endif %} {% if curr_fail %}failed{% endif %}"
-                                        id="{{ curr_result[0] }}" onclick="event.stopPropagation(); fixUpTestSelection(this);"
+                                        id="{{ curr_result[0] }}" onclick="event.stopPropagation(); changeTestSelection(this);"
                                     />
                                     <label>
                                         {{ curr_result[0] }}


### PR DESCRIPTION
Disable 'runbtn' when no tests are selected, and use 'onsubmit' rather than 'onclick' so that the button can actually be disabled visually when 'Executing tests...' (hopefully a better fix cf. c826b1c094c932ea863a12784ff803e672732217)