### PR TITLE
Add invalid path test for error JSON validation

### DIFF
--- a/GenericTest.py
+++ b/GenericTest.py
@@ -300,8 +300,8 @@ class GenericTest(object):
         test = Test("GET /x-nmos/{}/{}/{} ({})".format(api_name, api["version"], invalid_path, error_code),
                     self.auto_test_name())
 
-        status, response = self.do_request("GET", url)
-        if not status:
+        valid, response = self.do_request("GET", url)
+        if not valid:
             return test.FAIL(response)
 
         if response.status_code != error_code:
@@ -348,8 +348,8 @@ class GenericTest(object):
         else:
             return None
 
-        status, response = self.do_request(resource[1]['method'], url)
-        if not status:
+        valid, response = self.do_request(resource[1]['method'], url)
+        if not valid:
             return test.FAIL(response)
 
         if response.status_code != response_code:

--- a/TestHelper.py
+++ b/TestHelper.py
@@ -66,7 +66,7 @@ def do_request(method, url, data=None):
         return False, str(e)
 
 
-def load_resolved_schema(spec_path, file_name=None, schema_obj=None):
+def load_resolved_schema(spec_path, file_name=None, schema_obj=None, path_prefix=True):
     """
     Parses JSON as well as resolves any `$ref`s, including references to
     local files and remote (HTTP/S) files.
@@ -75,7 +75,9 @@ def load_resolved_schema(spec_path, file_name=None, schema_obj=None):
     # Only one of file_name or schema_obj must be set
     assert bool(file_name) != bool(schema_obj)
 
-    base_path = os.path.abspath(os.path.join(spec_path, "APIs/schemas/"))
+    if path_prefix:
+        spec_path = os.path.join(spec_path, "APIs/schemas/")
+    base_path = os.path.abspath(spec_path)
     if not base_path.endswith("/"):
         base_path = base_path + "/"
     if os.name == "nt":

--- a/test_data/core/error.json
+++ b/test_data/core/error.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes the standard error response which is returned with HTTP codes 400 and above",
+  "title": "Error response",
+  "required": [
+    "code",
+    "error",
+    "debug"
+  ],
+  "properties": {
+    "code": {
+      "description": "HTTP error code",
+      "type": "integer",
+      "minimum": 400,
+      "maximum": 599
+    },
+    "error": {
+      "description": "Human readable message which is suitable for user interface display, and helpful to the user",
+      "type": "string"
+    },
+    "debug": {
+      "description": "Debug information which may assist a programmer working with the API",
+      "type": ["null", "string"]
+    }
+  }
+}


### PR DESCRIPTION
This goes at least part of the way to resolving https://github.com/AMWA-TV/nmos-testing/issues/173

It's hard to test every error code in an automated fashion, and we do already check the schema returned by registries for 400s, but this adds something basic to test out every API implementation.