### PR TITLE
is0501: add testing of SDP files by calling out to sdpoker

### DIFF
--- a/IS0501Test.py
+++ b/IS0501Test.py
@@ -835,14 +835,13 @@ class IS0501Test(GenericTest):
         # First pass to check for errors
         access_error = False
         for sender in rtp_senders:
-            dup_params = []
+            dup_params = ""
             if sender in dup_senders:
-                dup_params = ["--duplicate", "true"]
+                dup_params = " --duplicate true"
             path = "single/senders/{}/transportfile".format(sender)
             try:
-                output = subprocess.check_output(["sdpoker", "--nmos", "false", "--shaping", "true"] + dup_params +
-                                                 [self.url + path],
-                                                 stderr=subprocess.STDOUT, shell=True)
+                cmd_string = "sdpoker --nmos false --shaping true{} {}".format(dup_params, self.url + path)
+                output = subprocess.check_output(cmd_string, stderr=subprocess.STDOUT, shell=True)
                 if output.decode("utf-8").startswith("{ StatusCodeError:"):
                     # This case exits with a zero error code so can't be handled in the exception
                     access_error = True
@@ -856,15 +855,14 @@ class IS0501Test(GenericTest):
 
         # Second pass to check for warnings
         for sender in rtp_senders:
-            dup_params = []
+            dup_params = ""
             if sender in dup_senders:
-                dup_params = ["--duplicate", "true"]
+                dup_params = " --duplicate true"
             path = "single/senders/{}/transportfile".format(sender)
             try:
-                output = subprocess.check_output(["sdpoker", "--nmos", "false", "--shaping", "true"] + dup_params +
-                                                 ["--whitespace", "true", "--should", "true", "--checkEndings", "true",
-                                                 self.url + path],
-                                                 stderr=subprocess.STDOUT, shell=True)
+                cmd_string = "sdpoker --nmos false --shaping true --whitespace true --should true " \
+                             "--checkEndings true{} {}".format(dup_params, self.url + path)
+                output = subprocess.check_output(cmd_string, stderr=subprocess.STDOUT, shell=True)
                 if output.decode("utf-8").startswith("{ StatusCodeError:"):
                     # This case exits with a zero error code so can't be handled in the exception
                     access_error = True

--- a/IS0501Test.py
+++ b/IS0501Test.py
@@ -856,8 +856,8 @@ class IS0501Test(GenericTest):
             path = "single/senders/{}/transportfile".format(sender)
             try:
                 subprocess.check_output(["sdpoker", "--nmos", "false"] + dup_params +
-                                        ["--whitespace", "true", "--should", "true", self.url + path],
-                                        stderr=subprocess.STDOUT)
+                                        ["--whitespace", "true", "--should", "true", "--checkEndings", "true",
+                                         self.url + path], stderr=subprocess.STDOUT)
             except subprocess.CalledProcessError as e:
                 output = str(e.output, "utf-8")
                 if output.startswith("Found"):

--- a/IS0501Test.py
+++ b/IS0501Test.py
@@ -840,7 +840,8 @@ class IS0501Test(GenericTest):
                 dup_params = ["--duplicate", "true"]
             path = "single/senders/{}/transportfile".format(sender)
             try:
-                output = subprocess.check_output("sdpoker --nmos false --shaping true " + self.url + path,
+                output = subprocess.check_output(["sdpoker", "--nmos", "false", "--shaping", "true"] + dup_params +
+                                                 [self.url + path],
                                                  stderr=subprocess.STDOUT, shell=True)
                 if output.decode("utf-8").startswith("{ StatusCodeError:"):
                     # This case exits with a zero error code so can't be handled in the exception

--- a/IS0501Test.py
+++ b/IS0501Test.py
@@ -839,8 +839,8 @@ class IS0501Test(GenericTest):
                 dup_params = ["--duplicate", "true"]
             path = "single/senders/{}/transportfile".format(sender)
             try:
-                subprocess.check_output(["sdpoker", "--nmos", "false"] + dup_params + [self.url + path],
-                                        stderr=subprocess.STDOUT)
+                subprocess.check_output(["sdpoker", "--nmos", "false", "--shaping", "true"] + dup_params +
+                                        [self.url + path], stderr=subprocess.STDOUT)
             except subprocess.CalledProcessError as e:
                 output = str(e.output, "utf-8")
                 if output.startswith("Found"):
@@ -855,7 +855,7 @@ class IS0501Test(GenericTest):
                 dup_params = ["--duplicate", "true"]
             path = "single/senders/{}/transportfile".format(sender)
             try:
-                subprocess.check_output(["sdpoker", "--nmos", "false"] + dup_params +
+                subprocess.check_output(["sdpoker", "--nmos", "false", "--shaping", "true"] + dup_params +
                                         ["--whitespace", "true", "--should", "true", "--checkEndings", "true",
                                          self.url + path], stderr=subprocess.STDOUT)
             except subprocess.CalledProcessError as e:

--- a/IS0501Test.py
+++ b/IS0501Test.py
@@ -840,7 +840,8 @@ class IS0501Test(GenericTest):
             path = "single/senders/{}/transportfile".format(sender)
             try:
                 subprocess.check_output(["sdpoker", "--nmos", "false", "--shaping", "true"] + dup_params +
-                                        [self.url + path], stderr=subprocess.STDOUT)
+                                        [self.url + path],
+                                        stderr=subprocess.STDOUT, shell=True)
             except subprocess.CalledProcessError as e:
                 output = str(e.output, "utf-8")
                 if output.startswith("Found"):
@@ -857,7 +858,8 @@ class IS0501Test(GenericTest):
             try:
                 subprocess.check_output(["sdpoker", "--nmos", "false", "--shaping", "true"] + dup_params +
                                         ["--whitespace", "true", "--should", "true", "--checkEndings", "true",
-                                         self.url + path], stderr=subprocess.STDOUT)
+                                         self.url + path],
+                                        stderr=subprocess.STDOUT, shell=True)
             except subprocess.CalledProcessError as e:
                 output = str(e.output, "utf-8")
                 if output.startswith("Found"):

--- a/IS0501Test.py
+++ b/IS0501Test.py
@@ -847,7 +847,8 @@ class IS0501Test(GenericTest):
                 if output.startswith("Found"):
                     return test.FAIL("Error for Sender {}: {}".format(sender, output))
                 else:
-                    return test.DISABLED("SDPoker may be unavailable on this system")
+                    return test.DISABLED("SDPoker may be unavailable on this system. Please see the README for "
+                                         "installation instructions.")
 
         # Second pass to check for warnings
         for sender in rtp_senders:
@@ -865,7 +866,8 @@ class IS0501Test(GenericTest):
                 if output.startswith("Found"):
                     return test.WARNING("Warning for Sender {}: {}".format(sender, output))
                 else:
-                    return test.DISABLED("SDPoker may be unavailable on this system")
+                    return test.DISABLED("SDPoker may be unavailable on this system. Please see the README for "
+                                         "installation instructions.")
 
         return test.PASS()
 

--- a/IS0501Test.py
+++ b/IS0501Test.py
@@ -875,8 +875,8 @@ class IS0501Test(GenericTest):
                                          "installation instructions.")
 
         if access_error:
-            return test.UNCLEAR("One or more of the tested transport files returned a non-200 HTTP code. Please ensure"
-                                "'master_enable' is set to true for all Senders and re-test.")
+            return test.UNCLEAR("One or more of the tested transport files returned a non-200 HTTP code. Please "
+                                "ensure 'master_enable' is set to true for all Senders and re-test.")
 
         return test.PASS()
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -53,6 +53,10 @@ In order to test unicast discovery, ensure the `DNS_SD_MODE` is set to `'unicast
 
 Testing of certain aspects of BCP-003-01 makes use of an external tool 'testssl.sh'. Please see [testssl/README.md](testssl/README.md) for installation instructions.
 
+### Testing of SDP files
+
+IS-05 test_41 checks that SDP files conform to the expectations of ST.2110. In order to enable these tests, please ensure that [SDPoker](https://github.com/Streampunk/sdpoker) is available on your system.
+
 ### Non-Interative Mode
 
 The test suite supports non-interactive operation in order use it within continuous integration systems. An example of this usage can be seen below:


### PR DESCRIPTION
I'd suggest this may need testing against a few implementations before merging. I'm also not certain how well it will handle non-2110 SDP files, but that may be something we need to contribute back to sdpoker for in order to have a suitable command line argument.