### PR TITLE
Add further command line arguments to list and describe tests/suites

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -62,10 +62,10 @@ The test suite supports non-interactive operation in order use it within continu
 python3 nmos-test.py --list-suites
 
 # List the available tests for a given test definition
-python3 nmos-test.py --suite IS-04-02 --list-tests
+python3 nmos-test.py suite --key IS-04-02 --list-tests
 
 # Run a test set, saving the output as a JUnit XML file
-python3 nmos-test.py --suite IS-04-02 --selection auto --ip 128.66.12.5 128.66.12.6 --port 80 80 --version v1.2 v1.2 --ignore auto_5 auto_6 --output results.xml
+python3 nmos-test.py suite --key IS-04-02 --selection auto --ip 128.66.12.5 128.66.12.6 --port 80 80 --version v1.2 v1.2 --ignore auto_5 auto_6 --output results.xml
 ```
 
 ## External Dependencies

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -65,7 +65,7 @@ python3 nmos-test.py --list-suites
 python3 nmos-test.py suite IS-04-02 --list-tests
 
 # Run a test set, saving the output as a JUnit XML file
-python3 nmos-test.py suite IS-04-02 --selection auto --ip 128.66.12.5 128.66.12.6 --port 80 80 --version v1.2 v1.2 --ignore auto_5 auto_6 --output results.xml
+python3 nmos-test.py suite IS-04-02 --selection auto --host 128.66.12.5 128.66.12.6 --port 80 80 --version v1.2 v1.2 --ignore auto_5 auto_6 --output results.xml
 ```
 
 ## External Dependencies

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -58,8 +58,11 @@ Testing of certain aspects of BCP-003-01 makes use of an external tool 'testssl.
 The test suite supports non-interactive operation in order use it within continuous integration systems. An example of this usage can be seen below:
 
 ```shell
+# List the available test suites
+python3 nmos-test.py --list-suites
+
 # List the available tests for a given test definition
-python3 nmos-test.py --suite IS-04-02 --list
+python3 nmos-test.py --suite IS-04-02 --list-tests
 
 # Run a test set, saving the output as a JUnit XML file
 python3 nmos-test.py --suite IS-04-02 --selection auto --ip 128.66.12.5 128.66.12.6 --port 80 80 --version v1.2 v1.2 --ignore auto_5 auto_6 --output results.xml

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -62,10 +62,10 @@ The test suite supports non-interactive operation in order use it within continu
 python3 nmos-test.py --list-suites
 
 # List the available tests for a given test definition
-python3 nmos-test.py suite --key IS-04-02 --list-tests
+python3 nmos-test.py suite IS-04-02 --list-tests
 
 # Run a test set, saving the output as a JUnit XML file
-python3 nmos-test.py suite --key IS-04-02 --selection auto --ip 128.66.12.5 128.66.12.6 --port 80 80 --version v1.2 v1.2 --ignore auto_5 auto_6 --output results.xml
+python3 nmos-test.py suite IS-04-02 --selection auto --ip 128.66.12.5 128.66.12.6 --port 80 80 --version v1.2 v1.2 --ignore auto_5 auto_6 --output results.xml
 ```
 
 ## External Dependencies

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -61,11 +61,21 @@ The test suite supports non-interactive operation in order use it within continu
 # List the available test suites
 python3 nmos-test.py --list-suites
 
-# List the available tests for a given test definition
+# List the available tests for a given test suite
 python3 nmos-test.py suite IS-04-02 --list-tests
 
-# Run a test set, saving the output as a JUnit XML file
+# Run just the 'auto' tests for the given suite, saving the output as a JUnit XML file
 python3 nmos-test.py suite IS-04-02 --selection auto --host 128.66.12.5 128.66.12.6 --port 80 80 --version v1.2 v1.2 --ignore auto_5 auto_6 --output results.xml
+```
+
+To display additional information about the available command-line options:
+
+```shell
+# Show the usage
+python3 nmos-test.py -h
+
+# Show the specific options for the 'suite' command
+python3 nmos-test.py suite -h
 ```
 
 ## External Dependencies

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -174,9 +174,11 @@ TEST_DEFINITIONS = {
 
 
 def enumerate_tests(class_def, describe=False):
-    tests = []
-    if not describe:
-        tests.extend(["all", "auto"])
+    if describe:
+        tests = ["all: Runs all tests in the suite",
+                 "auto: Basic API tests derived directly from the specification RAML"]
+    else:
+        tests = ["all", "auto"]
     for method_name in dir(class_def):
         if method_name.startswith("test_"):
             method = getattr(class_def, method_name)
@@ -463,6 +465,7 @@ def validate_args(args):
         for test_suite in sorted(TEST_DEFINITIONS):
             print(test_suite + ": " + TEST_DEFINITIONS[test_suite]["name"])
         sys.exit(ExitCodes.OK)
+
     if args.suite:
         if args.suite not in TEST_DEFINITIONS:
             print(" * ERROR: The requested test suite '{}' does not exist".format(args.suite))
@@ -487,6 +490,25 @@ def validate_args(args):
         if len(args.ip) != len(TEST_DEFINITIONS[args.suite]["specs"]):
             print(" * ERROR: This test definition expects {} IP(s), port(s) and version(s)"
                   .format(len(TEST_DEFINITIONS[args.suite]["specs"])))
+            sys.exit(ExitCodes.ERROR)
+    else:
+        arg_error = False
+        for arg_name in vars(args):
+            arg_value = getattr(args, arg_name)
+            if isinstance(arg_value, bool):
+                if arg_value is True:
+                    arg_error = arg_name
+                    break
+            elif isinstance(arg_value, list):
+                if len(arg_value) > 0:
+                    arg_error = arg_name
+                    break
+            elif isinstance(arg_value, str):
+                if arg_value not in ["", "all"]:
+                    arg_error = arg_name
+                    break
+        if arg_error:
+            print(" * ERROR: A '--suite' must be specified when using the '--{}' argument".format(arg_error))
             sys.exit(ExitCodes.ERROR)
 
 

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -447,7 +447,7 @@ def parse_arguments():
 
     subparsers = parser.add_subparsers()
     suite_parser = subparsers.add_parser("suite", help="select a test suite to run tests from in non-interactive mode")
-    suite_parser.add_argument("--key", help="select a test suite to run tests from in non-interactive mode", required=True)
+    suite_parser.add_argument("suite", help="select a test suite to run tests from in non-interactive mode")
     suite_parser.add_argument('--list-tests', action='store_true', help="list available tests for a given suite")
     suite_parser.add_argument('--describe-tests', action='store_true', help="describe the available tests for a given suite")
     suite_parser.add_argument('--selection', default="all", help="select a specific test to run, otherwise 'all' will be tested")
@@ -470,30 +470,30 @@ def validate_args(args):
             print(test_suite + ": " + TEST_DEFINITIONS[test_suite]["name"])
         sys.exit(ExitCodes.OK)
 
-    if "key" in vars(args):
-        if args.key not in TEST_DEFINITIONS:
-            print(" * ERROR: The requested test suite '{}' does not exist".format(args.key))
+    if "suite" in vars(args):
+        if args.suite not in TEST_DEFINITIONS:
+            print(" * ERROR: The requested test suite '{}' does not exist".format(args.suite))
             sys.exit(ExitCodes.ERROR)
         if args.list_tests:
-            tests = enumerate_tests(TEST_DEFINITIONS[args.key]["class"])
+            tests = enumerate_tests(TEST_DEFINITIONS[args.suite]["class"])
             for test_name in tests:
                 print(test_name)
             sys.exit(ExitCodes.OK)
         if args.describe_tests:
-            tests = enumerate_tests(TEST_DEFINITIONS[args.key]["class"], describe=True)
+            tests = enumerate_tests(TEST_DEFINITIONS[args.suite]["class"], describe=True)
             for test_description in tests:
                 print(test_description)
             sys.exit(ExitCodes.OK)
-        if args.selection and args.selection not in enumerate_tests(TEST_DEFINITIONS[args.key]["class"]):
+        if args.selection and args.selection not in enumerate_tests(TEST_DEFINITIONS[args.suite]["class"]):
             print(" * ERROR: Test with name '{}' does not exist in test definition '{}'"
-                  .format(args.selection, args.key))
+                  .format(args.selection, args.suite))
             sys.exit(ExitCodes.ERROR)
         if len(args.ip) != len(args.port) or len(args.ip) != len(args.version):
             print(" * ERROR: IPs, ports and versions must contain the same number of elements")
             sys.exit(ExitCodes.ERROR)
-        if len(args.ip) != len(TEST_DEFINITIONS[args.key]["specs"]):
+        if len(args.ip) != len(TEST_DEFINITIONS[args.suite]["specs"]):
             print(" * ERROR: This test definition expects {} IP(s), port(s) and version(s)"
-                  .format(len(TEST_DEFINITIONS[args.key]["specs"])))
+                  .format(len(TEST_DEFINITIONS[args.suite]["specs"])))
             sys.exit(ExitCodes.ERROR)
 
 
@@ -514,7 +514,7 @@ def run_noninteractive_tests(args):
     for i in range(len(args.ip)):
         endpoints.append({"ip": args.ip[i], "port": args.port[i], "version": args.version[i]})
     try:
-        results = run_tests(args.key, endpoints, [args.selection])
+        results = run_tests(args.suite, endpoints, [args.selection])
         if args.output:
             exit_code = write_test_results(results, args)
         else:
@@ -561,7 +561,7 @@ if __name__ == '__main__':
     start_web_servers()
 
     exit_code = 0
-    if "key" not in vars(args):
+    if "suite" not in vars(args):
         # Interactive testing mode. Await user input.
         try:
             while True:


### PR DESCRIPTION
Following a request from Felix at CBC, I've added some extra command line arguments (and modified one) to allow listing and describing of suites and tests.