### PR TITLE
is08: prevent auto testing of /map/active/{outputId}

### DIFF
--- a/IS0801Test.py
+++ b/IS0801Test.py
@@ -34,7 +34,11 @@ class IS0801Test(GenericTest):
     """
 
     def __init__(self, apis):
-        GenericTest.__init__(self, apis)
+        # Don't auto-test /map/active/{outputId} as the tests cannot find the {outputId}s automatically
+        omit_paths = [
+            "/map/active/{outputId}"
+        ]
+        GenericTest.__init__(self, apis, omit_paths)
         globalConfig.apiUrl = apis[MAPPING_API_KEY]['url']
         globalConfig.testSuite = self
         globalConfig.apiKey = MAPPING_API_KEY

--- a/IS0802Test.py
+++ b/IS0802Test.py
@@ -31,7 +31,11 @@ class IS0802Test(GenericTest):
     """
 
     def __init__(self, apis):
-        GenericTest.__init__(self, apis)
+        # Don't auto-test /map/active/{outputId} as the tests cannot find the {outputId}s automatically
+        omit_paths = [
+            "/map/active/{outputId}"
+        ]
+        GenericTest.__init__(self, apis, omit_paths)
         globalConfig.apiUrl = apis[MAPPING_API_KEY]['url']
         globalConfig.testSuite = self
         globalConfig.apiKey = MAPPING_API_KEY


### PR DESCRIPTION
This should resolve #205, but I don't have an IS-08 implementation in order to confirm 100%.

I haven't added any further testing of the affected endpoint, but this should prevent failures being recorded incorrectly.