### PR TITLE
Add utility function to get default ip

### DIFF
--- a/DNS.py
+++ b/DNS.py
@@ -16,14 +16,12 @@ from dnslib.server import DNSServer
 from dnslib.zoneresolver import ZoneResolver
 from jinja2 import Template
 
-import netifaces
+from TestHelper import get_default_ip
 
 
 class DNS(object):
     def __init__(self):
-        default_gw_interface = netifaces.gateways()['default'][netifaces.AF_INET][1]
-        default_ip = netifaces.ifaddresses(default_gw_interface)[netifaces.AF_INET][0]['addr']
-        self.default_ip = default_ip
+        self.default_ip = get_default_ip()
         self.resolver = None
         self.server = None
         self.base_zone_data = None

--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -16,7 +16,6 @@
 
 import time
 import socket
-import netifaces
 import json
 
 from zeroconf_monkey import ServiceBrowser, ServiceInfo, Zeroconf
@@ -24,6 +23,7 @@ from MdnsListener import MdnsListener
 from GenericTest import GenericTest, NMOSTestException
 from IS04Utils import IS04Utils
 from Config import ENABLE_DNS_SD, QUERY_API_HOST, QUERY_API_PORT, DNS_SD_MODE, DNS_SD_ADVERT_TIMEOUT, HEARTBEAT_INTERVAL
+from TestHelper import get_default_ip
 
 NODE_API_KEY = "node"
 
@@ -59,8 +59,6 @@ class IS0401Test(GenericTest):
 
     def _registry_mdns_info(self, port, priority=0):
         """Get an mDNS ServiceInfo object in order to create an advertisement"""
-        default_gw_interface = netifaces.gateways()['default'][netifaces.AF_INET][1]
-        default_ip = netifaces.ifaddresses(default_gw_interface)[netifaces.AF_INET][0]['addr']
         # TODO: Add another test which checks support for parsing CSV string in api_ver
         txt = {'api_ver': self.apis[NODE_API_KEY]["version"], 'api_proto': self.protocol, 'pri': str(priority)}
 
@@ -70,7 +68,7 @@ class IS0401Test(GenericTest):
 
         info = ServiceInfo(service_type,
                            "NMOSTestSuite{}.{}".format(port, service_type),
-                           socket.inet_aton(default_ip), port, 0, 0,
+                           socket.inet_aton(get_default_ip()), port, 0, 0,
                            txt, "nmos-mocks.local.")
         return info
 

--- a/Node.py
+++ b/Node.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import uuid
-import netifaces
 
 from flask import Blueprint, make_response, abort
 from Config import ENABLE_HTTPS
+from TestHelper import get_default_ip
 
 
 class Node(object):
@@ -24,8 +24,6 @@ class Node(object):
         pass
 
     def get_sender(self, stream_type="video"):
-        default_gw_interface = netifaces.gateways()['default'][netifaces.AF_INET][1]
-        default_ip = netifaces.ifaddresses(default_gw_interface)[netifaces.AF_INET][0]['addr']
         protocol = "http"
         if ENABLE_HTTPS:
             protocol = "https"
@@ -37,7 +35,7 @@ class Node(object):
             "version": "50:50",
             "caps": {},
             "tags": {},
-            "manifest_href": "{}://{}:5000/{}.sdp".format(protocol, default_ip, stream_type),
+            "manifest_href": "{}://{}:5000/{}.sdp".format(protocol, get_default_ip(), stream_type),
             "flow_id": str(uuid.uuid4()),
             "transport": "urn:x-nmos:transport:rtp.mcast",
             "device_id": str(uuid.uuid4()),

--- a/TestHelper.py
+++ b/TestHelper.py
@@ -20,6 +20,7 @@ import requests
 import websocket
 import os
 import jsonref
+import netifaces
 from pathlib import Path
 
 from Config import HTTP_TIMEOUT, CERT_TRUST_ROOT_CA
@@ -37,6 +38,17 @@ def ordered(obj):
 def compare_json(json1, json2):
     """Compares two json objects for equality"""
     return ordered(json1) == ordered(json2)
+
+
+def get_default_ip():
+    """Get this machine's default IPv4 address"""
+    default_gw = netifaces.gateways()['default']
+    if netifaces.AF_INET in default_gw:
+        default_interface = default_gw[netifaces.AF_INET][1]
+    else:
+        interfaces = netifaces.interfaces()
+        default_interface = next((i for i in interfaces if i is not 'lo'), interfaces[0])
+    return netifaces.ifaddresses(default_interface)[netifaces.AF_INET][0]['addr']
 
 
 def do_request(method, url, data=None):


### PR DESCRIPTION
Add utility function to get default ip, using default gateway if found, attempting fallback otherwise.
Resolves #216.

Can probably still throw KeyError etc. if no interfaces found, or the fallback interface doesn't have an IPv4 address, but that's no worse than things were already...