### PR TITLE
Update copyright headers for recently added files

### DIFF
--- a/BCP00301Test.py
+++ b/BCP00301Test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 British Broadcasting Corporation
+# Copyright (C) 2019 Advanced Media Workflow Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BCP00302Test.py
+++ b/BCP00302Test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 British Broadcasting Corporation
+# Copyright (C) 2019 Advanced Media Workflow Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/CRL.py
+++ b/CRL.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Sony Corporation
+# Copyright (C) 2019 Advanced Media Workflow Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/IS0801Test.py
+++ b/IS0801Test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 British Broadcasting Corporation
+# Copyright (C) 2019 Advanced Media Workflow Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/IS0802Test.py
+++ b/IS0802Test.py
@@ -1,4 +1,4 @@
-# Copyright 2018 British Broadcasting Corporation
+# Copyright 2019 Advanced Media Workflow Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/IS0901Test.py
+++ b/IS0901Test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 British Broadcasting Corporation
+# Copyright (C) 2019 Advanced Media Workflow Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/is08/__init__.py
+++ b/is08/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 British Broadcasting Corporation
+# Copyright (C) 2019 Advanced Media Workflow Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/is08/action.py
+++ b/is08/action.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 British Broadcasting Corporation
+# Copyright (C) 2019 Advanced Media Workflow Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/is08/activation.py
+++ b/is08/activation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 British Broadcasting Corporation
+# Copyright (C) 2019 Advanced Media Workflow Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/is08/active.py
+++ b/is08/active.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 British Broadcasting Corporation
+# Copyright (C) 2019 Advanced Media Workflow Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/is08/calls.py
+++ b/is08/calls.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 British Broadcasting Corporation
+# Copyright (C) 2019 Advanced Media Workflow Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/is08/helperTools.py
+++ b/is08/helperTools.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 British Broadcasting Corporation
+# Copyright (C) 2019 Advanced Media Workflow Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/is08/inputs.py
+++ b/is08/inputs.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 British Broadcasting Corporation
+# Copyright (C) 2019 Advanced Media Workflow Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/is08/io.py
+++ b/is08/io.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 British Broadcasting Corporation
+# Copyright (C) 2019 Advanced Media Workflow Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/is08/outputs.py
+++ b/is08/outputs.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 British Broadcasting Corporation
+# Copyright (C) 2019 Advanced Media Workflow Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/is08/testConfig.py
+++ b/is08/testConfig.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 British Broadcasting Corporation
+# Copyright (C) 2019 Advanced Media Workflow Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
As-per https://github.com/AMWA-TV/nmos-testing/pull/221#issuecomment-490082820

I've changed the header for files which were obviously added since we moved to AMWA-TV, but can add to others if needed.