### PR TITLE
dns: attempt to prompt Nodes to re-query for records

### DIFF
--- a/test_data/IS0401/dns_base.zone
+++ b/test_data/IS0401/dns_base.zone
@@ -1,5 +1,5 @@
 $ORIGIN testsuite.nmos.tv.
-$TTL 60s
+$TTL 5s
 
 testsuite.nmos.tv.  IN  SOA   ns.testsuite.nmos.tv. postmaster.testsuite.nmos.tv. ( 2007120710 1d 2h 4w 1h )
 testsuite           IN  A     {{ ip_address }}
@@ -12,3 +12,19 @@ lb._dns-sd._udp	IN	PTR	@
 _services._dns-sd._udp	PTR	_nmos-registration._tcp
 _services._dns-sd._udp	PTR	_nmos-register._tcp
 _services._dns-sd._udp	PTR	_nmos-query._tcp
+
+; These lines give the fully qualified DNS names to the IP addresses of the hosts which we'd like to discover
+mocks.testsuite.nmos.tv.	IN	A	{{ ip_address }}
+timeout.testsuite.nmos.tv.	IN	A	192.0.2.1
+
+; The following IS-04 discovery records are included to ensure Nodes can always find something with a low TTL (above)
+; This should cause them to refresh their cache frequently for testing purposes.
+_nmos-registration._tcp	PTR	reg-api-invalid._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-invalid._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-invalid._nmos-query._tcp
+reg-api-invalid._nmos-registration._tcp	SRV	0 0 8000 mocks.testsuite.nmos.tv.
+reg-api-invalid._nmos-registration._tcp	TXT	"api_ver=v1.0" "api_proto=http" "pri=255"
+reg-api-invalid._nmos-register._tcp	SRV	0 0 8000 mocks.testsuite.nmos.tv.
+reg-api-invalid._nmos-register._tcp	TXT	"api_ver=v1.0" "api_proto=http" "pri=255"
+qry-api-invalid._nmos-query._tcp	SRV	0 0 8000 mocks.testsuite.nmos.tv.
+qry-api-invalid._nmos-query._tcp	TXT	"api_ver=v1.0" "api_proto=http" "pri=255"

--- a/test_data/IS0401/dns_records.zone
+++ b/test_data/IS0401/dns_records.zone
@@ -1,7 +1,3 @@
-; These lines give the fully qualified DNS names to the IP addresses of the hosts which we'd like to discover
-mocks.testsuite.nmos.tv.	IN	A	{{ ip_address }}
-timeout.testsuite.nmos.tv.	IN	A	192.0.2.1
-
 ; There should be one PTR record for each instance of the service you wish to advertise.
 _nmos-registration._tcp	PTR	reg-api-5101-ver._nmos-registration._tcp
 _nmos-register._tcp	PTR	reg-api-5101-ver._nmos-register._tcp


### PR DESCRIPTION
This is an experimental change which I'm posting more for feedback at present than anything else. It attempts to tackle the issue in testing unicast DNS implementations that if there are no valid services when the Node starts up, it may be a long time before it re-queries the DNS server for changes.

The approach used here assumes that a Node is being a good citizen with regard to TTLs. By setting the TTL for all records to a low number (5 seconds) and including an intentionally invalid service in the records at all times, the browser should know that it can regularly re-check for expiry of the invalid service.

I wouldn't be surprised if this doesn't work in all cases, but certainly for our implementation this change means that we can repeatably pass the unicast DNS tests without having to increase the timeouts specified in Config.py.

_Side note..._ I think the specs probably need a formalised re-query interval to handle the case where no records are present at all, either intentionally or due to user error. This wouldn't solve the test suite issue unless it was linked to a published TTL for a specific record, so this workaround may still be required.
