### PR TITLE
is0401: ensure Nodes correctly interpret registry TXT records

### DIFF
--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -109,8 +109,8 @@ class IS0401Test(GenericTest):
         for registry in self.registries:
             registry.reset()
 
+        self.invalid_registry.enable(invalid_reg=True)
         self.primary_registry.enable()
-        self.invalid_registry.enable()
 
         if DNS_SD_MODE == "multicast":
             # Advertise the primary registry and invalid ones at pri 0, and allow the Node to do a basic registration

--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -114,8 +114,9 @@ class IS0401Test(GenericTest):
 
         if DNS_SD_MODE == "multicast":
             # Advertise the primary registry and invalid ones at pri 0, and allow the Node to do a basic registration
-            self.zc.register_service(registry_mdns[0])
-            self.zc.register_service(registry_mdns[1])
+            if self.is04_utils.compare_api_version(self.apis[NODE_API_KEY]["version"], "v1.0") != 0:
+                self.zc.register_service(registry_mdns[0])
+                self.zc.register_service(registry_mdns[1])
             self.zc.register_service(registry_mdns[2])
 
         # Wait for n seconds after advertising the service for the first POST from a Node
@@ -163,7 +164,8 @@ class IS0401Test(GenericTest):
                     break
 
         # Clean up mDNS advertisements and disable registries
-        if DNS_SD_MODE == "multicast":
+        if DNS_SD_MODE == "multicast" and \
+                self.is04_utils.compare_api_version(self.apis[NODE_API_KEY]["version"], "v1.0") != 0:
             self.zc.unregister_service(registry_mdns[0])
             self.zc.unregister_service(registry_mdns[1])
         self.invalid_registry.disable()
@@ -195,6 +197,9 @@ class IS0401Test(GenericTest):
     def test_01_01(self, test):
         """Node does not attempt to register with an unsuitable registry"""
 
+        if self.is04_utils.compare_api_version(self.apis[NODE_API_KEY]["version"], "v1.0") == 0:
+            return test.NA("Nodes running v1.0 do not check DNS-SD api_ver and api_proto TXT records")
+
         if not ENABLE_DNS_SD or DNS_SD_MODE != "multicast":
             return test.DISABLED("This test cannot be performed when ENABLE_DNS_SD is False or DNS_SD_MODE is not "
                                  "'multicast'")
@@ -224,6 +229,9 @@ class IS0401Test(GenericTest):
 
     def test_02_01(self, test):
         """Node does not attempt to register with an unsuitable registry"""
+
+        if self.is04_utils.compare_api_version(self.apis[NODE_API_KEY]["version"], "v1.0") == 0:
+            return test.NA("Nodes running v1.0 do not check DNS-SD api_ver and api_proto TXT records")
 
         if not ENABLE_DNS_SD or DNS_SD_MODE != "unicast":
             return test.DISABLED("This test cannot be performed when ENABLE_DNS_SD is False or DNS_SD_MODE is not "

--- a/Registry.py
+++ b/Registry.py
@@ -47,6 +47,7 @@ class Registry(object):
         self.common.reset()
         self.enabled = False
         self.test_first_reg = False
+        self.test_invalid_reg = False
 
     def add(self, headers, payload):
         self.last_time = time.time()
@@ -74,12 +75,14 @@ class Registry(object):
     def get_resources(self):
         return self.common.resources
 
-    def enable(self, first_reg=False):
+    def enable(self, first_reg=False, invalid_reg=False):
         self.test_first_reg = first_reg
+        self.test_invalid_reg = invalid_reg
         self.enabled = True
 
     def disable(self):
         self.test_first_reg = False
+        self.test_invalid_reg = False
         self.enabled = False
 
 
@@ -98,6 +101,8 @@ def post_resource(version):
     registry = REGISTRIES[flask.current_app.config["REGISTRY_INSTANCE"]]
     if not registry.enabled:
         abort(500)
+    if registry.test_invalid_reg:
+        registry.disable()
     if not registry.test_first_reg:
         registered = False
         try:

--- a/Registry.py
+++ b/Registry.py
@@ -83,7 +83,10 @@ class Registry(object):
         self.enabled = False
 
 
-NUM_REGISTRIES = 5
+# 0 = Invalid request testing registry
+# 1 = Primary testing registry
+# 2+ = Failover testing registries
+NUM_REGISTRIES = 6
 REGISTRY_COMMON = RegistryCommon()
 REGISTRIES = [Registry(REGISTRY_COMMON, i+1) for i in range(NUM_REGISTRIES)]
 REGISTRY_API = Blueprint('registry_api', __name__)

--- a/test_data/IS0401/dns_records.zone
+++ b/test_data/IS0401/dns_records.zone
@@ -2,9 +2,13 @@
 mocks.testsuite.nmos.tv.	IN	A	{{ ip_address }}
 
 ; There should be one PTR record for each instance of the service you wish to advertise.
-_nmos-registration._tcp	PTR	reg-api-5001._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5001._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-5001._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-5001-ver._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5001-ver._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-5001-ver._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-5001-proto._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5001-proto._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-5001-proto._nmos-query._tcp
+
 _nmos-registration._tcp	PTR	reg-api-5002._nmos-registration._tcp
 _nmos-register._tcp	PTR	reg-api-5002._nmos-register._tcp
 _nmos-query._tcp	PTR	qry-api-5002._nmos-query._tcp
@@ -17,39 +21,56 @@ _nmos-query._tcp	PTR	qry-api-5004._nmos-query._tcp
 _nmos-registration._tcp	PTR	reg-api-5005._nmos-registration._tcp
 _nmos-register._tcp	PTR	reg-api-5005._nmos-register._tcp
 _nmos-query._tcp	PTR	qry-api-5005._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-5006._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5006._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-5006._nmos-query._tcp
 
 ; Next we have a SRV and a TXT record corresponding to each PTR above, first the Registration API
 ; The SRV links the PTR name to a resolvable DNS name (see the A records above) and identify the port which the API runs on
 ; The TXT records indicate additional metadata relevant to the IS-04 spec
-reg-api-5001._nmos-registration._tcp	SRV	0 0 5001 mocks.testsuite.nmos.tv.
-reg-api-5001._nmos-register._tcp	SRV	0 0 5001 mocks.testsuite.nmos.tv.
-reg-api-5001._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
-reg-api-5001._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
+reg-api-5001-ver._nmos-registration._tcp	SRV	0 0 5001 mocks.testsuite.nmos.tv.
+reg-api-5001-ver._nmos-register._tcp	SRV	0 0 5001 mocks.testsuite.nmos.tv.
+reg-api-5001-ver._nmos-registration._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
+reg-api-5001-ver._nmos-register._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
+reg-api-5001-proto._nmos-registration._tcp	SRV	0 0 5001 mocks.testsuite.nmos.tv.
+reg-api-5001-proto._nmos-register._tcp	SRV	0 0 5001 mocks.testsuite.nmos.tv.
+reg-api-5001-proto._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
+reg-api-5001-proto._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
+
 reg-api-5002._nmos-registration._tcp	SRV	0 0 5002 mocks.testsuite.nmos.tv.
 reg-api-5002._nmos-register._tcp	SRV	0 0 5002 mocks.testsuite.nmos.tv.
-reg-api-5002._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
-reg-api-5002._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
+reg-api-5002._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
+reg-api-5002._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
 reg-api-5003._nmos-registration._tcp	SRV	0 0 5003 mocks.testsuite.nmos.tv.
 reg-api-5003._nmos-register._tcp	SRV	0 0 5003 mocks.testsuite.nmos.tv.
-reg-api-5003._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
-reg-api-5003._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
+reg-api-5003._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
+reg-api-5003._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
 reg-api-5004._nmos-registration._tcp	SRV	0 0 5004 mocks.testsuite.nmos.tv.
 reg-api-5004._nmos-register._tcp	SRV	0 0 5004 mocks.testsuite.nmos.tv.
-reg-api-5004._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
-reg-api-5004._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
+reg-api-5004._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
+reg-api-5004._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
 reg-api-5005._nmos-registration._tcp	SRV	0 0 5005 mocks.testsuite.nmos.tv.
 reg-api-5005._nmos-register._tcp	SRV	0 0 5005 mocks.testsuite.nmos.tv.
-reg-api-5005._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
-reg-api-5005._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
+reg-api-5005._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
+reg-api-5005._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
+reg-api-5006._nmos-registration._tcp	SRV	0 0 5006 mocks.testsuite.nmos.tv.
+reg-api-5006._nmos-register._tcp	SRV	0 0 5006 mocks.testsuite.nmos.tv.
+reg-api-5006._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
+reg-api-5006._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
 
 ; Finally, the SRV and TXT for the Query API
-qry-api-5001._nmos-query._tcp	SRV	0 0 5001 mocks.testsuite.nmos.tv.
-qry-api-5001._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
+qry-api-5001-ver._nmos-query._tcp	SRV	0 0 5001 mocks.testsuite.nmos.tv.
+qry-api-5001-ver._nmos-query._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
+qry-api-5001-proto._nmos-query._tcp	SRV	0 0 5001 mocks.testsuite.nmos.tv.
+qry-api-5001-proto._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
+
 qry-api-5002._nmos-query._tcp	SRV	0 0 5002 mocks.testsuite.nmos.tv.
-qry-api-5002._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
+qry-api-5002._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
 qry-api-5003._nmos-query._tcp	SRV	0 0 5003 mocks.testsuite.nmos.tv.
-qry-api-5003._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
+qry-api-5003._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
 qry-api-5004._nmos-query._tcp	SRV	0 0 5004 mocks.testsuite.nmos.tv.
-qry-api-5004._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
+qry-api-5004._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
 qry-api-5005._nmos-query._tcp	SRV	0 0 5005 mocks.testsuite.nmos.tv.
-qry-api-5005._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
+qry-api-5005._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
+qry-api-5006._nmos-query._tcp	SRV	0 0 5005 mocks.testsuite.nmos.tv.
+qry-api-5006._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"


### PR DESCRIPTION
Another one that I think may require some feedback. I'm attempting to add a test to ensure that Nodes only register with registries which have suitable TXT records.

The trouble is that when a Node fails this test, lots of other tests fail because the Node has registered with the invalid first registry. As such it could make a Node look far less compliant with the spec than it really is. Potential resolutions include re-ordering the prereqs tests so that the invalid registry test happens after the others (however this will incur an additional 'DNS_SD_ADVERT_TIMEOUT' wait period). An alternative would be to add a further IS-04 Node test suite which covers some more time consuming tests. Any thoughts?

Notes:
* Untested with unicast so far
* Will require an exception for v1.0 as this didn't use the additional text records under test here