### PR TITLE
is0401: add tests for handling of timeouts from Registration APIs

### DIFF
--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -108,7 +108,7 @@ class IS0401Test(GenericTest):
                 priority += 10
 
             # Add a fake advertisement for a timeout simulating registry
-            info = self._registry_mdns_info(81, priority, ip="192.0.2.1")
+            info = self._registry_mdns_info(444, priority, ip="192.0.2.1")
             registry_mdns.append(info)
             priority += 10
 

--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -68,8 +68,12 @@ class IS0401Test(GenericTest):
             api_ver = self.apis[NODE_API_KEY]["version"]
         if api_proto is None:
             api_proto = self.protocol
+
         if ip is None:
             ip = get_default_ip()
+            hostname = "nmos-mocks.local."
+        else:
+            hostname = ip.replace(".", "-") + ".local."
 
         # TODO: Add another test which checks support for parsing CSV string in api_ver
         txt = {'api_ver': api_ver, 'api_proto': api_proto, 'pri': str(priority)}
@@ -81,7 +85,7 @@ class IS0401Test(GenericTest):
         info = ServiceInfo(service_type,
                            "NMOSTestSuite{}{}.{}".format(port, api_proto, service_type),
                            socket.inet_aton(ip), port, 0, 0,
-                           txt, "nmos-mocks.local.")
+                           txt, hostname)
         return info
 
     def do_registry_basics_prereqs(self):
@@ -714,7 +718,7 @@ class IS0401Test(GenericTest):
 
         last_hb = None
         last_registry = None
-        for registry_data in self.registry_basics_data:
+        for registry_data in self.registry_basics_data[0:-1]:
             if len(registry_data.heartbeats) < 1:
                 return test.FAIL("Node never made contact with registry advertised on port {}"
                                  .format(registry_data.port))
@@ -763,12 +767,12 @@ class IS0401Test(GenericTest):
         # out its attempted connection within a heartbeat period and then registers with the next available one.
         registry_data = self.registry_basics_data[-1]
         if len(registry_data.heartbeats) < 1:
-            return test.FAIL("Node never made contact with registry advertised on port {}"
-                             .format(registry_data.port))
+            return test.WARNING("Node never made contact with registry advertised on port {}"
+                                .format(registry_data.port))
 
         if len(registry_data.posts) > 0:
-            return test.FAIL("Node re-registered its resources when it failed over to a new registry, when it "
-                             "should only have issued a heartbeat")
+            return test.WARNING("Node re-registered its resources when it failed over to a new registry, when it "
+                                "should only have issued a heartbeat")
 
         return test.PASS()
 

--- a/test_data/IS0401/dns_records.zone
+++ b/test_data/IS0401/dns_records.zone
@@ -1,5 +1,6 @@
 ; These lines give the fully qualified DNS names to the IP addresses of the hosts which we'd like to discover
 mocks.testsuite.nmos.tv.	IN	A	{{ ip_address }}
+timeout.testsuite.nmos.tv.	IN	A	192.0.2.1
 
 ; There should be one PTR record for each instance of the service you wish to advertise.
 _nmos-registration._tcp	PTR	reg-api-5001-ver._nmos-registration._tcp
@@ -21,6 +22,9 @@ _nmos-query._tcp	PTR	qry-api-5004._nmos-query._tcp
 _nmos-registration._tcp	PTR	reg-api-5005._nmos-registration._tcp
 _nmos-register._tcp	PTR	reg-api-5005._nmos-register._tcp
 _nmos-query._tcp	PTR	qry-api-5005._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-timeout._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-timeout._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-timeout._nmos-query._tcp
 _nmos-registration._tcp	PTR	reg-api-5006._nmos-registration._tcp
 _nmos-register._tcp	PTR	reg-api-5006._nmos-register._tcp
 _nmos-query._tcp	PTR	qry-api-5006._nmos-query._tcp
@@ -53,10 +57,14 @@ reg-api-5005._nmos-registration._tcp	SRV	0 0 5005 mocks.testsuite.nmos.tv.
 reg-api-5005._nmos-register._tcp	SRV	0 0 5005 mocks.testsuite.nmos.tv.
 reg-api-5005._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
 reg-api-5005._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
+reg-api-timeout._nmos-registration._tcp	SRV	0 0 81 timeout.testsuite.nmos.tv.
+reg-api-timeout._nmos-register._tcp	SRV	0 0 81 timeout.testsuite.nmos.tv.
+reg-api-timeout._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
+reg-api-timeout._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
 reg-api-5006._nmos-registration._tcp	SRV	0 0 5006 mocks.testsuite.nmos.tv.
 reg-api-5006._nmos-register._tcp	SRV	0 0 5006 mocks.testsuite.nmos.tv.
-reg-api-5006._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
-reg-api-5006._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
+reg-api-5006._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"
+reg-api-5006._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"
 
 ; Finally, the SRV and TXT for the Query API
 qry-api-5001-ver._nmos-query._tcp	SRV	0 0 5001 mocks.testsuite.nmos.tv.
@@ -72,5 +80,7 @@ qry-api-5004._nmos-query._tcp	SRV	0 0 5004 mocks.testsuite.nmos.tv.
 qry-api-5004._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
 qry-api-5005._nmos-query._tcp	SRV	0 0 5005 mocks.testsuite.nmos.tv.
 qry-api-5005._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
+qry-api-timeout._nmos-query._tcp	SRV	0 0 81 timeout.testsuite.nmos.tv.
+qry-api-timeout._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
 qry-api-5006._nmos-query._tcp	SRV	0 0 5005 mocks.testsuite.nmos.tv.
-qry-api-5006._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
+qry-api-5006._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"

--- a/test_data/IS0401/dns_records.zone
+++ b/test_data/IS0401/dns_records.zone
@@ -57,8 +57,8 @@ reg-api-5005._nmos-registration._tcp	SRV	0 0 5005 mocks.testsuite.nmos.tv.
 reg-api-5005._nmos-register._tcp	SRV	0 0 5005 mocks.testsuite.nmos.tv.
 reg-api-5005._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
 reg-api-5005._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
-reg-api-timeout._nmos-registration._tcp	SRV	0 0 81 timeout.testsuite.nmos.tv.
-reg-api-timeout._nmos-register._tcp	SRV	0 0 81 timeout.testsuite.nmos.tv.
+reg-api-timeout._nmos-registration._tcp	SRV	0 0 444 timeout.testsuite.nmos.tv.
+reg-api-timeout._nmos-register._tcp	SRV	0 0 444 timeout.testsuite.nmos.tv.
 reg-api-timeout._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
 reg-api-timeout._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
 reg-api-5006._nmos-registration._tcp	SRV	0 0 5006 mocks.testsuite.nmos.tv.
@@ -80,7 +80,7 @@ qry-api-5004._nmos-query._tcp	SRV	0 0 5004 mocks.testsuite.nmos.tv.
 qry-api-5004._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
 qry-api-5005._nmos-query._tcp	SRV	0 0 5005 mocks.testsuite.nmos.tv.
 qry-api-5005._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
-qry-api-timeout._nmos-query._tcp	SRV	0 0 81 timeout.testsuite.nmos.tv.
+qry-api-timeout._nmos-query._tcp	SRV	0 0 444 timeout.testsuite.nmos.tv.
 qry-api-timeout._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
 qry-api-5006._nmos-query._tcp	SRV	0 0 5005 mocks.testsuite.nmos.tv.
 qry-api-5006._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"


### PR DESCRIPTION
Untested as yet. This is an attempt to extend the failover tests to identify any Nodes which have a connection/request timeout figure set to a default which is likely to be far longer than required in this situation.

The second to last registry in the advertised list doesn't exist and uses an unroutable IP address intended for documentation. The test should ensure that a connection to this address times out within one heartbeat interval, and the Node then proceeds to the next best registry, successfully heartbeating with it.

This builds upon the changes in https://github.com/AMWA-TV/nmos-testing/pull/232