### PR TITLE
Modify CA scripts to support modified domain names

### DIFF
--- a/test_data/BCP00301/README.md
+++ b/test_data/BCP00301/README.md
@@ -65,7 +65,7 @@ require that the unit under test communicate directly with entities which are 'm
 ## Additional Certificates
 
 Additional certificates can be generated using this CA if required, using the './generateCerts' script followed by a
-domain name and an optional additional domain name ending in '.local' for mDNS usage.
+hostname, domain name and an optional additional fully-qualified domain name ending in '.local' for mDNS usage.
 
 Example: `./generateCerts myapi testsuite.nmos.tv myapi.local`
 

--- a/test_data/BCP00301/README.md
+++ b/test_data/BCP00301/README.md
@@ -67,7 +67,7 @@ require that the unit under test communicate directly with entities which are 'm
 Additional certificates can be generated using this CA if required, using the './generateCerts' script followed by a
 domain name and an optional additional domain name ending in '.local' for mDNS usage.
 
-Example: `./generateCerts myapi.testsuite.nmos.tv myapi.local`
+Example: `./generateCerts myapi testsuite.nmos.tv myapi.local`
 
 ## Temporary Diffie-Hellman Parameters
 

--- a/test_data/BCP00301/ca/generateCA
+++ b/test_data/BCP00301/ca/generateCA
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+DOMAIN=$1
+if [ -z $DOMAIN ]; then
+    DOMAIN="testsuite.nmos.tv"
+fi
+
 # Remove old CA files
 rm -rf certs
 rm -rf crl
@@ -16,7 +21,7 @@ touch index.txt
 echo 1000 > serial
 openssl genrsa -out private/ca.key.pem 4096
 chmod 400 private/ca.key.pem
-openssl req -config openssl.cnf -key private/ca.key.pem -new -x509 -days 18250 -sha256 -extensions v3_ca -out certs/ca.cert.pem -subj "/C=GB/ST=England/O=NMOS Testing Ltd/CN=ca.testsuite.nmos.tv"
+openssl req -config openssl.cnf -key private/ca.key.pem -new -x509 -days 18250 -sha256 -extensions v3_ca -out certs/ca.cert.pem -subj "/C=GB/ST=England/O=NMOS Testing Ltd/CN=ca.$DOMAIN"
 chmod 444 certs/ca.cert.pem
 
 # Create Intermediate
@@ -28,8 +33,9 @@ echo 1000 > intermediate/serial
 echo 1000 > intermediate/crlnumber
 openssl genrsa -out intermediate/private/intermediate.key.pem 4096
 chmod 400 intermediate/private/intermediate.key.pem
-export SAN="DNS.1:ica.testsuite.nmos.tv"
-openssl req -config intermediate/openssl.cnf -new -sha256 -key intermediate/private/intermediate.key.pem -out intermediate/csr/intermediate.csr.pem -subj "/C=GB/ST=England/O=NMOS Testing Ltd/CN=ica.testsuite.nmos.tv"
+export SAN="DNS.1:ica.$DOMAIN"
+export DOMAIN=$DOMAIN
+openssl req -config intermediate/openssl.cnf -new -sha256 -key intermediate/private/intermediate.key.pem -out intermediate/csr/intermediate.csr.pem -subj "/C=GB/ST=England/O=NMOS Testing Ltd/CN=ica.$DOMAIN"
 openssl ca -batch -config openssl.cnf -extensions v3_intermediate_ca -days 18250 -notext -md sha256 -in intermediate/csr/intermediate.csr.pem -out intermediate/certs/intermediate.cert.pem
 chmod 444 intermediate/certs/intermediate.cert.pem
 
@@ -41,6 +47,6 @@ chmod 444 intermediate/certs/ca-chain.cert.pem
 openssl ca -config intermediate/openssl.cnf -gencrl -out intermediate/crl/intermediate.crl.pem
 
 # Create OCSP pair
-openssl genrsa -out intermediate/private/ocsp.testsuite.nmos.tv.key.pem 4096
-openssl req -config intermediate/openssl.cnf -new -sha256 -key intermediate/private/ocsp.testsuite.nmos.tv.key.pem -out intermediate/csr/ocsp.testsuite.nmos.tv.csr.pem -subj "/C=GB/ST=England/O=NMOS Testing Ltd/CN=ocsp.testsuite.nmos.tv"
-openssl ca -batch -config intermediate/openssl.cnf -extensions ocsp -days 18250 -notext -md sha256 -in intermediate/csr/ocsp.testsuite.nmos.tv.csr.pem -out intermediate/certs/ocsp.testsuite.nmos.tv.cert.pem
+openssl genrsa -out intermediate/private/ocsp.$DOMAIN.key.pem 4096
+openssl req -config intermediate/openssl.cnf -new -sha256 -key intermediate/private/ocsp.$DOMAIN.key.pem -out intermediate/csr/ocsp.$DOMAIN.csr.pem -subj "/C=GB/ST=England/O=NMOS Testing Ltd/CN=ocsp.$DOMAIN"
+openssl ca -batch -config intermediate/openssl.cnf -extensions ocsp -days 18250 -notext -md sha256 -in intermediate/csr/ocsp.$DOMAIN.csr.pem -out intermediate/certs/ocsp.$DOMAIN.cert.pem

--- a/test_data/BCP00301/ca/generateCerts
+++ b/test_data/BCP00301/ca/generateCerts
@@ -1,43 +1,50 @@
 #!/bin/bash
 
-DOMAIN=$1
+HOSTNAME=$1
+DOMAIN=$2
+LOCALDOMAIN=$3
+if [ -z $HOSTNAME ]; then
+    echo "Expected hostname argument"
+    exit 1
+fi
 if [ -z $DOMAIN ]; then
     echo "Expected domain argument"
     exit 1
 fi
-LOCALDOMAIN=$2
+FQDN=$HOSTNAME"."$DOMAIN
 
-SANDATA="DNS.1:"$DOMAIN
+SANDATA="DNS.1:"$FQDN
 if [ ! -z $LOCALDOMAIN ]; then
-    SANDATA=$SANDATA", DNS.2:"$LOCALDOMAIN
+    SANDATA="DNS.1:"$FQDN", DNS.2:"$LOCALDOMAIN
 fi
 export SAN=$SANDATA
+export DOMAIN=$DOMAIN
 
-rm -f intermediate/private/ecdsa.$DOMAIN.key.pem
-rm -f intermediate/private/rsa.$DOMAIN.key.pem
-rm intermediate/csr/ecdsa.$DOMAIN.csr.pem
-rm intermediate/csr/rsa.$DOMAIN.csr.pem
-rm intermediate/certs/ecdsa.$DOMAIN.cert.pem
-rm intermediate/certs/rsa.$DOMAIN.cert.pem
+rm -f intermediate/private/ecdsa.$FQDN.key.pem
+rm -f intermediate/private/rsa.$FQDN.key.pem
+rm intermediate/csr/ecdsa.$FQDN.csr.pem
+rm intermediate/csr/rsa.$FQDN.csr.pem
+rm intermediate/certs/ecdsa.$FQDN.cert.pem
+rm intermediate/certs/rsa.$FQDN.cert.pem
 
 # Create ECDSA key
-openssl ecparam -name secp256r1 -genkey -noout -out intermediate/private/ecdsa.$DOMAIN.key.pem
-chmod 400 intermediate/private/ecdsa.$DOMAIN.key.pem
+openssl ecparam -name secp256r1 -genkey -noout -out intermediate/private/ecdsa.$FQDN.key.pem
+chmod 400 intermediate/private/ecdsa.$FQDN.key.pem
 
 # Create RSA Key
-openssl genrsa -out intermediate/private/rsa.$DOMAIN.key.pem 2048
-chmod 400 intermediate/private/rsa.$DOMAIN.key.pem
+openssl genrsa -out intermediate/private/rsa.$FQDN.key.pem 2048
+chmod 400 intermediate/private/rsa.$FQDN.key.pem
 
 # Create ECDSA CSR
-openssl req -config intermediate/openssl.cnf -key intermediate/private/ecdsa.$DOMAIN.key.pem -new -sha256 -out intermediate/csr/ecdsa.$DOMAIN.csr.pem -subj "/C=GB/ST=England/O=NMOS Testing Ltd/CN=$DOMAIN"
+openssl req -config intermediate/openssl.cnf -key intermediate/private/ecdsa.$FQDN.key.pem -new -sha256 -out intermediate/csr/ecdsa.$FQDN.csr.pem -subj "/C=GB/ST=England/O=NMOS Testing Ltd/CN=$FQDN"
 
 # Create RSA CSR
-openssl req -config intermediate/openssl.cnf -key intermediate/private/rsa.$DOMAIN.key.pem -new -sha256 -out intermediate/csr/rsa.$DOMAIN.csr.pem -subj "/C=GB/ST=England/O=NMOS Testing Ltd/CN=$DOMAIN"
+openssl req -config intermediate/openssl.cnf -key intermediate/private/rsa.$FQDN.key.pem -new -sha256 -out intermediate/csr/rsa.$FQDN.csr.pem -subj "/C=GB/ST=England/O=NMOS Testing Ltd/CN=$FQDN"
 
 # Sign ECDSA CSR
-openssl ca -batch -config intermediate/openssl.cnf -extensions server_cert -days 18250 -notext -md sha256 -in intermediate/csr/ecdsa.$DOMAIN.csr.pem -out intermediate/certs/ecdsa.$DOMAIN.cert.pem
-cat intermediate/certs/ecdsa.$DOMAIN.cert.pem intermediate/certs/ca-chain.cert.pem > intermediate/certs/ecdsa.$DOMAIN.cert.chain.pem
+openssl ca -batch -config intermediate/openssl.cnf -extensions server_cert -days 18250 -notext -md sha256 -in intermediate/csr/ecdsa.$FQDN.csr.pem -out intermediate/certs/ecdsa.$FQDN.cert.pem
+cat intermediate/certs/ecdsa.$FQDN.cert.pem intermediate/certs/ca-chain.cert.pem > intermediate/certs/ecdsa.$FQDN.cert.chain.pem
 
 # Sign RSA CSR
-openssl ca -batch -config intermediate/openssl.cnf -extensions server_cert -days 18250 -notext -md sha256 -in intermediate/csr/rsa.$DOMAIN.csr.pem -out intermediate/certs/rsa.$DOMAIN.cert.pem
-cat intermediate/certs/rsa.$DOMAIN.cert.pem intermediate/certs/ca-chain.cert.pem > intermediate/certs/rsa.$DOMAIN.cert.chain.pem
+openssl ca -batch -config intermediate/openssl.cnf -extensions server_cert -days 18250 -notext -md sha256 -in intermediate/csr/rsa.$FQDN.csr.pem -out intermediate/certs/rsa.$FQDN.cert.pem
+cat intermediate/certs/rsa.$FQDN.cert.pem intermediate/certs/ca-chain.cert.pem > intermediate/certs/rsa.$FQDN.cert.chain.pem

--- a/test_data/BCP00301/ca/generateDefaultCerts
+++ b/test_data/BCP00301/ca/generateDefaultCerts
@@ -1,3 +1,3 @@
 #!/bin/bash
-./generateCerts mocks.testsuite.nmos.tv nmos-mocks.local
-./generateCerts api.testsuite.nmos.tv nmos-api.local
+./generateCerts mocks testsuite.nmos.tv nmos-mocks.local
+./generateCerts api testsuite.nmos.tv nmos-api.local

--- a/test_data/BCP00301/ca/openssl.cnf.intermediate
+++ b/test_data/BCP00301/ca/openssl.cnf.intermediate
@@ -121,8 +121,8 @@ authorityKeyIdentifier = keyid,issuer:always
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
 subjectAltName=${ENV::SAN}
-crlDistributionPoints = URI:http://crl.testsuite.nmos.tv:5007/intermediate.crl.pem
-authorityInfoAccess = OCSP;URI:http://ocsp.testsuite.nmos.tv:5008
+crlDistributionPoints = URI:http://crl.${ENV::DOMAIN}:5007/intermediate.crl.pem
+authorityInfoAccess = OCSP;URI:http://ocsp.${ENV::DOMAIN}:5008
 
 [ crl_ext ]
 # Extension for CRLs (`man x509v3_config`).


### PR DESCRIPTION
This shouldn't make any difference to the test suite itself (or the existing certificates), but makes the scripts a little more flexible to support generation of a CA/certs for an alternative domain name.

Ports and similar for the CRL/OCSP server remain hard-coded for now.