### PR TITLE
Rework assignment of ports to the various Flask apps

### DIFF
--- a/CRL.py
+++ b/CRL.py
@@ -15,10 +15,16 @@
 from flask import Blueprint, make_response
 
 
-CRL = Blueprint('crl', __name__)
+class CRLDistributionPoint(object):
+    def __init__(self):
+        self.port = 5007  # cf. test_data/BCP00301/ca/intermediate/openssl.cnf
 
 
-@CRL.route('/intermediate.crl.pem', methods=["GET"])
+CRL = CRLDistributionPoint()
+CRL_API = Blueprint('crl', __name__)
+
+
+@CRL_API.route('/intermediate.crl.pem', methods=["GET"])
 def crl_pem():
     response = None
     with open("test_data/BCP00301/ca/intermediate/crl/intermediate.crl.pem") as f:

--- a/Node.py
+++ b/Node.py
@@ -20,8 +20,8 @@ from TestHelper import get_default_ip
 
 
 class Node(object):
-    def __init__(self):
-        pass
+    def __init__(self, port_increment):
+        self.port = 5200 + port_increment
 
     def get_sender(self, stream_type="video"):
         protocol = "http"
@@ -37,7 +37,7 @@ class Node(object):
             "version": "50:50",
             "caps": {},
             "tags": {},
-            "manifest_href": "{}://{}:5006/{}.sdp".format(protocol, host, stream_type),
+            "manifest_href": "{}://{}:{}/{}.sdp".format(protocol, host, self.port, stream_type),
             "flow_id": str(uuid.uuid4()),
             "transport": "urn:x-nmos:transport:rtp.mcast",
             "device_id": str(uuid.uuid4()),
@@ -50,7 +50,7 @@ class Node(object):
         return sender
 
 
-NODE = Node()
+NODE = Node(1)
 NODE_API = Blueprint('node_api', __name__)
 
 

--- a/Registry.py
+++ b/Registry.py
@@ -37,7 +37,7 @@ class RegistryData(object):
 class Registry(object):
     def __init__(self, data_store, port_increment):
         self.common = data_store
-        self.port = 5000 + port_increment
+        self.port = 5100 + port_increment  # cf. test_data/IS0401/dns_records.zone
         self.reset()
 
     def reset(self):

--- a/test_data/IS0401/dns_records.zone
+++ b/test_data/IS0401/dns_records.zone
@@ -3,84 +3,84 @@ mocks.testsuite.nmos.tv.	IN	A	{{ ip_address }}
 timeout.testsuite.nmos.tv.	IN	A	192.0.2.1
 
 ; There should be one PTR record for each instance of the service you wish to advertise.
-_nmos-registration._tcp	PTR	reg-api-5001-ver._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5001-ver._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-5001-ver._nmos-query._tcp
-_nmos-registration._tcp	PTR	reg-api-5001-proto._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5001-proto._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-5001-proto._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-5101-ver._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5101-ver._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-5101-ver._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-5101-proto._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5101-proto._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-5101-proto._nmos-query._tcp
 
-_nmos-registration._tcp	PTR	reg-api-5002._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5002._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-5002._nmos-query._tcp
-_nmos-registration._tcp	PTR	reg-api-5003._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5003._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-5003._nmos-query._tcp
-_nmos-registration._tcp	PTR	reg-api-5004._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5004._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-5004._nmos-query._tcp
-_nmos-registration._tcp	PTR	reg-api-5005._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5005._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-5005._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-5102._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5102._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-5102._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-5103._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5103._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-5103._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-5104._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5104._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-5104._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-5105._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5105._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-5105._nmos-query._tcp
 _nmos-registration._tcp	PTR	reg-api-timeout._nmos-registration._tcp
 _nmos-register._tcp	PTR	reg-api-timeout._nmos-register._tcp
 _nmos-query._tcp	PTR	qry-api-timeout._nmos-query._tcp
-_nmos-registration._tcp	PTR	reg-api-5006._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5006._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-5006._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-5106._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5106._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-5106._nmos-query._tcp
 
 ; Next we have a SRV and a TXT record corresponding to each PTR above, first the Registration API
 ; The SRV links the PTR name to a resolvable DNS name (see the A records above) and identify the port which the API runs on
 ; The TXT records indicate additional metadata relevant to the IS-04 spec
-reg-api-5001-ver._nmos-registration._tcp	SRV	0 0 5001 mocks.testsuite.nmos.tv.
-reg-api-5001-ver._nmos-register._tcp	SRV	0 0 5001 mocks.testsuite.nmos.tv.
-reg-api-5001-ver._nmos-registration._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
-reg-api-5001-ver._nmos-register._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
-reg-api-5001-proto._nmos-registration._tcp	SRV	0 0 5001 mocks.testsuite.nmos.tv.
-reg-api-5001-proto._nmos-register._tcp	SRV	0 0 5001 mocks.testsuite.nmos.tv.
-reg-api-5001-proto._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
-reg-api-5001-proto._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
+reg-api-5101-ver._nmos-registration._tcp	SRV	0 0 5101 mocks.testsuite.nmos.tv.
+reg-api-5101-ver._nmos-register._tcp	SRV	0 0 5101 mocks.testsuite.nmos.tv.
+reg-api-5101-ver._nmos-registration._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
+reg-api-5101-ver._nmos-register._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
+reg-api-5101-proto._nmos-registration._tcp	SRV	0 0 5101 mocks.testsuite.nmos.tv.
+reg-api-5101-proto._nmos-register._tcp	SRV	0 0 5101 mocks.testsuite.nmos.tv.
+reg-api-5101-proto._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
+reg-api-5101-proto._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
 
-reg-api-5002._nmos-registration._tcp	SRV	0 0 5002 mocks.testsuite.nmos.tv.
-reg-api-5002._nmos-register._tcp	SRV	0 0 5002 mocks.testsuite.nmos.tv.
-reg-api-5002._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
-reg-api-5002._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
-reg-api-5003._nmos-registration._tcp	SRV	0 0 5003 mocks.testsuite.nmos.tv.
-reg-api-5003._nmos-register._tcp	SRV	0 0 5003 mocks.testsuite.nmos.tv.
-reg-api-5003._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
-reg-api-5003._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
-reg-api-5004._nmos-registration._tcp	SRV	0 0 5004 mocks.testsuite.nmos.tv.
-reg-api-5004._nmos-register._tcp	SRV	0 0 5004 mocks.testsuite.nmos.tv.
-reg-api-5004._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
-reg-api-5004._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
-reg-api-5005._nmos-registration._tcp	SRV	0 0 5005 mocks.testsuite.nmos.tv.
-reg-api-5005._nmos-register._tcp	SRV	0 0 5005 mocks.testsuite.nmos.tv.
-reg-api-5005._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
-reg-api-5005._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
+reg-api-5102._nmos-registration._tcp	SRV	0 0 5102 mocks.testsuite.nmos.tv.
+reg-api-5102._nmos-register._tcp	SRV	0 0 5102 mocks.testsuite.nmos.tv.
+reg-api-5102._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
+reg-api-5102._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
+reg-api-5103._nmos-registration._tcp	SRV	0 0 5103 mocks.testsuite.nmos.tv.
+reg-api-5103._nmos-register._tcp	SRV	0 0 5103 mocks.testsuite.nmos.tv.
+reg-api-5103._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
+reg-api-5103._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
+reg-api-5104._nmos-registration._tcp	SRV	0 0 5104 mocks.testsuite.nmos.tv.
+reg-api-5104._nmos-register._tcp	SRV	0 0 5104 mocks.testsuite.nmos.tv.
+reg-api-5104._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
+reg-api-5104._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
+reg-api-5105._nmos-registration._tcp	SRV	0 0 5105 mocks.testsuite.nmos.tv.
+reg-api-5105._nmos-register._tcp	SRV	0 0 5105 mocks.testsuite.nmos.tv.
+reg-api-5105._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
+reg-api-5105._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
 reg-api-timeout._nmos-registration._tcp	SRV	0 0 444 timeout.testsuite.nmos.tv.
 reg-api-timeout._nmos-register._tcp	SRV	0 0 444 timeout.testsuite.nmos.tv.
 reg-api-timeout._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
 reg-api-timeout._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
-reg-api-5006._nmos-registration._tcp	SRV	0 0 5006 mocks.testsuite.nmos.tv.
-reg-api-5006._nmos-register._tcp	SRV	0 0 5006 mocks.testsuite.nmos.tv.
-reg-api-5006._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"
-reg-api-5006._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"
+reg-api-5106._nmos-registration._tcp	SRV	0 0 5106 mocks.testsuite.nmos.tv.
+reg-api-5106._nmos-register._tcp	SRV	0 0 5106 mocks.testsuite.nmos.tv.
+reg-api-5106._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"
+reg-api-5106._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"
 
 ; Finally, the SRV and TXT for the Query API
-qry-api-5001-ver._nmos-query._tcp	SRV	0 0 5001 mocks.testsuite.nmos.tv.
-qry-api-5001-ver._nmos-query._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
-qry-api-5001-proto._nmos-query._tcp	SRV	0 0 5001 mocks.testsuite.nmos.tv.
-qry-api-5001-proto._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
+qry-api-5101-ver._nmos-query._tcp	SRV	0 0 5101 mocks.testsuite.nmos.tv.
+qry-api-5101-ver._nmos-query._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
+qry-api-5101-proto._nmos-query._tcp	SRV	0 0 5101 mocks.testsuite.nmos.tv.
+qry-api-5101-proto._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
 
-qry-api-5002._nmos-query._tcp	SRV	0 0 5002 mocks.testsuite.nmos.tv.
-qry-api-5002._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
-qry-api-5003._nmos-query._tcp	SRV	0 0 5003 mocks.testsuite.nmos.tv.
-qry-api-5003._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
-qry-api-5004._nmos-query._tcp	SRV	0 0 5004 mocks.testsuite.nmos.tv.
-qry-api-5004._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
-qry-api-5005._nmos-query._tcp	SRV	0 0 5005 mocks.testsuite.nmos.tv.
-qry-api-5005._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
+qry-api-5102._nmos-query._tcp	SRV	0 0 5102 mocks.testsuite.nmos.tv.
+qry-api-5102._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
+qry-api-5103._nmos-query._tcp	SRV	0 0 5103 mocks.testsuite.nmos.tv.
+qry-api-5103._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
+qry-api-5104._nmos-query._tcp	SRV	0 0 5104 mocks.testsuite.nmos.tv.
+qry-api-5104._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
+qry-api-5105._nmos-query._tcp	SRV	0 0 5105 mocks.testsuite.nmos.tv.
+qry-api-5105._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
 qry-api-timeout._nmos-query._tcp	SRV	0 0 444 timeout.testsuite.nmos.tv.
 qry-api-timeout._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
-qry-api-5006._nmos-query._tcp	SRV	0 0 5005 mocks.testsuite.nmos.tv.
-qry-api-5006._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"
+qry-api-5106._nmos-query._tcp	SRV	0 0 5106 mocks.testsuite.nmos.tv.
+qry-api-5106._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"


### PR DESCRIPTION
… in order to fix failing IS0401Test.test_13 due to the additional Registry bumping the port number of sender_app (and crl_app)
