### PR TITLE
testssl: update version requirement to include bug fix for OCSP

### DIFF
--- a/testssl/README.md
+++ b/testssl/README.md
@@ -1,6 +1,6 @@
 # testssl.sh
 
-In order to test BCP-003-01, the 'testssl.sh' script (v3.0 rc5) must be placed in this directory with 'execute' permission enabled. This tool is known to work on Linux and Mac OS, but will not work on Windows.
+In order to test BCP-003-01, the 'testssl.sh' script (v3.0 rc5) must be placed in this directory with 'execute' permission enabled. This tool is known to work on Linux and Mac OS, but requires [Ubuntu terminal](https://tutorials.ubuntu.com/tutorial/tutorial-ubuntu-on-windows) for usage on Windows. Note that the Linux VM approach on Windows will be significantly slower to run than a pure Linux system.
 
 Please download the required files using the following link, then untar the results into this directory:
 <https://github.com/drwetter/testssl.sh/archive/3.0rc5.tar.gz>

--- a/testssl/README.md
+++ b/testssl/README.md
@@ -1,6 +1,6 @@
 # testssl.sh
 
-In order to test BCP-003-01, the 'testssl.sh' script (v3.0 rc5) must be placed in this directory with 'execute' permission enabled. This tool is known to work on Linux and Mac OS, but requires [Ubuntu terminal](https://tutorials.ubuntu.com/tutorial/tutorial-ubuntu-on-windows) for usage on Windows. Note that the Linux VM approach on Windows will be significantly slower to run than a pure Linux system.
+In order to test BCP-003-01, the 'testssl.sh' script (v3.0 rc5) must be placed in this directory with 'execute' permission enabled. This tool is known to work on Linux and Mac OS, but requires [Ubuntu terminal](https://tutorials.ubuntu.com/tutorial/tutorial-ubuntu-on-windows) for usage on Windows. Note that the Linux terminal approach on Windows will be significantly slower to run than a pure Linux system (or Linux VM on Windows).
 
 Please download the required files using the following link, then untar the results into this directory:
 <https://github.com/drwetter/testssl.sh/archive/3.0rc5.tar.gz>

--- a/testssl/README.md
+++ b/testssl/README.md
@@ -1,13 +1,13 @@
 # testssl.sh
 
-In order to test BCP-003-01, the 'testssl.sh' script (v3.0 rc4) must be placed in this directory with 'execute' permission enabled. This tool is known to work on Linux and Mac OS, but will not work on Windows.
+In order to test BCP-003-01, the 'testssl.sh' script (v3.0 rc5) must be placed in this directory with 'execute' permission enabled. This tool is known to work on Linux and Mac OS, but will not work on Windows.
 
 Please download the required files using the following link, then untar the results into this directory:
-<https://github.com/drwetter/testssl.sh/archive/3.0rc4.tar.gz>
+<https://github.com/drwetter/testssl.sh/archive/3.0rc5.tar.gz>
 
 Alternatively, use the following command which can be executed from within this 'testssl' directory.
 
 ```shell
-wget https://github.com/drwetter/testssl.sh/archive/3.0rc4.tar.gz
-tar -xvzf 3.0rc4.tar.gz --strip-components=1
+wget https://github.com/drwetter/testssl.sh/archive/3.0rc5.tar.gz
+tar -xvzf 3.0rc5.tar.gz --strip-components=1
 ```


### PR DESCRIPTION
Having set this up on a new host I realised my version of testssl was patched to resolve an OCSP issue which causes failures for all tests using that check mechanism.