### PR TITLE
Add support for an OCSP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ cache/
 testssl/
 !testssl/README.md
 tls-report.json
+test_data/BCP00301/ca/ocspreq.der
+test_data/BCP00301/ca/ocspresp.der

--- a/OCSP.py
+++ b/OCSP.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import subprocess
-import time
 
 from flask import Blueprint, make_response, request, abort
 

--- a/OCSP.py
+++ b/OCSP.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2019 Advanced Media Workflow Association
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import time
+
+from flask import Blueprint, make_response, request, abort
+
+
+class OCSPDistributionPoint(object):
+    def __init__(self):
+        self.port = 5008  # cf. test_data/BCP00301/ca/intermediate/openssl.cnf
+
+
+OCSP = OCSPDistributionPoint()
+OCSP_API = Blueprint('ocsp', __name__)
+
+
+@OCSP_API.route('/', methods=["POST"])
+def ocsp_response():
+    if request.headers["Content-Type"] != "application/ocsp-request":
+        abort(400)
+
+    with open("test_data/BCP00301/ca/ocspreq.der", "wb") as f:
+        f.write(request.data)
+
+    try:
+        subprocess.run(["openssl", "ocsp", "-index", "test_data/BCP00301/ca/intermediate/index.txt",
+                        "-rsigner", "test_data/BCP00301/ca/intermediate/certs/intermediate.cert.pem",
+                        "-rkey", "test_data/BCP00301/ca/intermediate/private/intermediate.key.pem",
+                        "-CA", "test_data/BCP00301/ca/intermediate/certs/ca-chain.cert.pem",
+                        "-reqin", "test_data/BCP00301/ca/ocspreq.der",
+                        "-respout", "test_data/BCP00301/ca/ocspresp.der"])
+    except Exception as e:
+        print(" * ERROR: {}".format(e))
+        abort(500)
+
+    response = None
+    with open("test_data/BCP00301/ca/ocspresp.der", "rb") as f2:
+        response = make_response(f2.read())
+
+    response.headers["Content-Type"] = "application/ocsp-response"
+    return response

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -22,6 +22,7 @@ from GenericTest import NMOSInitException
 from TestResult import TestStates
 from Node import NODE, NODE_API
 from CRL import CRL, CRL_API
+from OCSP import OCSP, OCSP_API
 from Config import CACHE_PATH, SPECIFICATIONS, ENABLE_DNS_SD, DNS_SD_MODE, ENABLE_HTTPS, QUERY_API_HOST, QUERY_API_PORT
 from Config import CERTS_MOCKS, KEYS_MOCKS
 from DNS import DNS
@@ -95,6 +96,13 @@ crl_app.config['PORT'] = CRL.port
 crl_app.config['SECURE'] = False
 crl_app.register_blueprint(CRL_API)  # CRL server
 FLASK_APPS.append(crl_app)
+
+ocsp_app = Flask(__name__)
+ocsp_app.debug = False
+ocsp_app.config['PORT'] = OCSP.port
+ocsp_app.config['SECURE'] = False
+ocsp_app.register_blueprint(OCSP_API)  # OCSP server
+FLASK_APPS.append(ocsp_app)
 
 # Definitions of each set of tests made available from the dropdowns
 TEST_DEFINITIONS = {


### PR DESCRIPTION
This relies upon openssl to do a good job of escaping the file input to avoid a remote code execution issue. Otherwise it'll require some pre-parsing of the input.