### PR TITLE
IS-04-02 Don't check for mDNS advertisements in 'unicast' mode

### DIFF
--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -64,17 +64,11 @@ class IS0402Test(GenericTest):
             self.zc.close()
             self.zc = None
 
-    def test_01(self, test):
+    def do_dns_sd_advertisement_check(self, test, api, service_type):
         """Registration API advertises correctly via mDNS"""
 
         if DNS_SD_MODE != "multicast":
             return test.DISABLED("This test cannot be performed when DNS_SD_MODE is not 'multicast'")
-
-        api = self.apis[REG_API_KEY]
-
-        service_type = "_nmos-registration._tcp.local."
-        if self.is04_reg_utils.compare_api_version(api["version"], "v1.3") >= 0:
-            service_type = "_nmos-register._tcp.local."
 
         ServiceBrowser(self.zc, service_type, self.zc_listener)
         sleep(2)
@@ -85,7 +79,7 @@ class IS0402Test(GenericTest):
             if address == api["ip"] and port == api["port"]:
                 properties = self.convert_bytes(service.properties)
                 if "pri" not in properties:
-                    return test.FAIL("No 'pri' TXT record found in Registration API advertisement.")
+                    return test.FAIL("No 'pri' TXT record found in {} advertisement.".format(api["name"]))
                 try:
                     priority = int(properties["pri"])
                     if priority < 0:
@@ -99,62 +93,36 @@ class IS0402Test(GenericTest):
                 # Other TXT records only came in for IS-04 v1.1+
                 if self.is04_reg_utils.compare_api_version(api["version"], "v1.1") >= 0:
                     if "api_ver" not in properties:
-                        return test.FAIL("No 'api_ver' TXT record found in Registration API advertisement.")
+                        return test.FAIL("No 'api_ver' TXT record found in {} advertisement.".format(api["name"]))
                     elif api["version"] not in properties["api_ver"].split(","):
                         return test.FAIL("Registry does not claim to support version under test.")
 
                     if "api_proto" not in properties:
-                        return test.FAIL("No 'api_proto' TXT record found in Registration API advertisement.")
+                        return test.FAIL("No 'api_proto' TXT record found in {} advertisement.".format(api["name"]))
                     elif properties["api_proto"] != self.protocol:
                         return test.FAIL("API protocol ('api_proto') TXT record is not '{}'.".format(self.protocol))
 
                 return test.PASS()
-        return test.FAIL("No matching mDNS announcement found for Registration API with IP/Port {}:{}."
-                         .format(api["ip"], api["port"]))
+        return test.FAIL("No matching mDNS announcement found for {} with IP/Port {}:{}."
+                         .format(api["name"], api["ip"], api["port"]))
+
+    def test_01(self, test):
+        """Registration API advertises correctly via mDNS"""
+
+        api = self.apis[REG_API_KEY]
+
+        service_type = "_nmos-registration._tcp.local."
+        if self.is04_reg_utils.compare_api_version(api["version"], "v1.3") >= 0:
+            service_type = "_nmos-register._tcp.local."
+
+        return self.do_dns_sd_advertisement_check(test, api, service_type)
 
     def test_02(self, test):
         """Query API advertises correctly via mDNS"""
 
-        if DNS_SD_MODE != "multicast":
-            return test.DISABLED("This test cannot be performed when DNS_SD_MODE is not 'multicast'")
-
         api = self.apis[QUERY_API_KEY]
 
-        ServiceBrowser(self.zc, "_nmos-query._tcp.local.", self.zc_listener)
-        sleep(2)
-        serv_list = self.zc_listener.get_service_list()
-        for service in serv_list:
-            address = socket.inet_ntoa(service.address)
-            port = service.port
-            if address == api["ip"] and port == api["port"]:
-                properties = self.convert_bytes(service.properties)
-                if "pri" not in properties:
-                    return test.FAIL("No 'pri' TXT record found in Query API advertisement.")
-                try:
-                    priority = int(properties["pri"])
-                    if priority < 0:
-                        return test.FAIL("Priority ('pri') TXT record must be greater than zero.")
-                    elif priority >= 100:
-                        return test.WARNING("Priority ('pri') TXT record must be less than 100 for a production "
-                                            "instance.")
-                except Exception:
-                    return test.FAIL("Priority ('pri') TXT record is not an integer.")
-
-                # Other TXT records only came in for IS-04 v1.1+
-                if self.is04_query_utils.compare_api_version(api["version"], "v1.1") >= 0:
-                    if "api_ver" not in properties:
-                        return test.FAIL("No 'api_ver' TXT record found in Query API advertisement.")
-                    elif api["version"] not in properties["api_ver"].split(","):
-                        return test.FAIL("Registry does not claim to support version under test.")
-
-                    if "api_proto" not in properties:
-                        return test.FAIL("No 'api_proto' TXT record found in Query API advertisement.")
-                    elif properties["api_proto"] != self.protocol:
-                        return test.FAIL("API protocol ('api_proto') TXT record is not '{}'.".format(self.protocol))
-
-                return test.PASS()
-        return test.FAIL("No matching mDNS announcement found for Query API with IP/Port {}:{}."
-                         .format(api["ip"], api["port"]))
+        return self.do_dns_sd_advertisement_check(test, api, "_nmos-query._tcp.local.")
 
     def test_03(self, test):
         """Registration API accepts and stores a valid Node resource"""

--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -26,7 +26,7 @@ from zeroconf_monkey import ServiceBrowser, Zeroconf
 from MdnsListener import MdnsListener
 from GenericTest import GenericTest, NMOSTestException, NMOSInitException, NMOS_WIKI_URL
 from IS04Utils import IS04Utils
-from Config import GARBAGE_COLLECTION_TIMEOUT, WS_MESSAGE_TIMEOUT, ENABLE_HTTPS
+from Config import DNS_SD_MODE, GARBAGE_COLLECTION_TIMEOUT, WS_MESSAGE_TIMEOUT, ENABLE_HTTPS
 from TestHelper import WebsocketWorker, load_resolved_schema
 from TestResult import Test
 
@@ -66,6 +66,9 @@ class IS0402Test(GenericTest):
 
     def test_01(self, test):
         """Registration API advertises correctly via mDNS"""
+
+        if DNS_SD_MODE != "multicast":
+            return test.DISABLED("This test cannot be performed when DNS_SD_MODE is not 'multicast'")
 
         api = self.apis[REG_API_KEY]
 
@@ -111,6 +114,9 @@ class IS0402Test(GenericTest):
 
     def test_02(self, test):
         """Query API advertises correctly via mDNS"""
+
+        if DNS_SD_MODE != "multicast":
+            return test.DISABLED("This test cannot be performed when DNS_SD_MODE is not 'multicast'")
 
         api = self.apis[QUERY_API_KEY]
 

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -369,6 +369,7 @@ def run_tests(test, endpoints, test_selection=["all"]):
                 "spec": None  # Used inside GenericTest
             }
             if SPECIFICATIONS[spec_key]["repo"] is not None and api_key in SPECIFICATIONS[spec_key]["apis"]:
+                apis[api_key]["name"] = SPECIFICATIONS[spec_key]["apis"][api_key]["name"]
                 apis[api_key]["spec_path"] = CACHE_PATH + '/' + spec_key
                 apis[api_key]["raml"] = SPECIFICATIONS[spec_key]["apis"][api_key]["raml"]
 


### PR DESCRIPTION
`ENABLE_DNS_SD` is only intended to handle advertisements made by the test suite, not browsing, so we only check `DNS_SD_MODE` to decide whether to disable `IS0402Test.test_01/_02`.