### PR TITLE
registry: fix trailing slash policy adherence

### DIFF
--- a/Registry.py
+++ b/Registry.py
@@ -109,8 +109,11 @@ REGISTRY_API = Blueprint('registry_api', __name__)
 
 
 # IS-04 resources
-@REGISTRY_API.route('/x-nmos/registration/<version>', methods=["GET"])
+@REGISTRY_API.route('/x-nmos/registration/<version>', methods=["GET"], strict_slashes=False)
 def base_resource(version):
+    registry = REGISTRIES[flask.current_app.config["REGISTRY_INSTANCE"]]
+    if not registry.enabled:
+        abort(404)
     base_data = ["resource/", "health/"]
     # Using json.dumps to support older Flask versions http://flask.pocoo.org/docs/1.0/security/#json-security
     return Response(json.dumps(base_data), mimetype='application/json')

--- a/Registry.py
+++ b/Registry.py
@@ -113,7 +113,7 @@ REGISTRY_API = Blueprint('registry_api', __name__)
 def base_resource(version):
     registry = REGISTRIES[flask.current_app.config["REGISTRY_INSTANCE"]]
     if not registry.enabled:
-        abort(404)
+        abort(503)
     base_data = ["resource/", "health/"]
     # Using json.dumps to support older Flask versions http://flask.pocoo.org/docs/1.0/security/#json-security
     return Response(json.dumps(base_data), mimetype='application/json')


### PR DESCRIPTION
I had implemented the 'primary' path, but failed to adhere to the server requirements in https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.x/docs/2.0.%20APIs.md#get-and-head-requests. Disabling `strict_slashes` provides one way around this.

I've also added an explicit 404 code for when the registry is disabled, which seems slightly more applicable than a 5xx in this case.