### PR TITLE
is08: fix error with double quotes appearing around source_id

### DIFF
--- a/is08/calls.py
+++ b/is08/calls.py
@@ -20,8 +20,7 @@ from is08.testConfig import globalConfig
 
 class Call:
 
-    def __init__(self, url, string=False):
-        self.string = string
+    def __init__(self, url):
         self.url = url
         self.expectedCode = 200
         self.test = globalConfig.test
@@ -76,11 +75,8 @@ class Call:
             )
 
     def _getJSON(self):
-        if self.string:
-            return self._responseObject.text
-        else:
-            try:
-                response = self._responseObject.json()
-            except ValueError:
-                raise NMOSTestException(self.test.FAIL("Invalid JSON received from {}".format(self.url)))
-            return response
+        try:
+            response = self._responseObject.json()
+        except ValueError:
+            raise NMOSTestException(self.test.FAIL("Invalid JSON received from {}".format(self.url)))
+        return response

--- a/is08/outputs.py
+++ b/is08/outputs.py
@@ -46,10 +46,7 @@ class ACMOutput:
         }
         for apiId, ioId in resourceList.items():
             url = "{}{}".format(self.url, apiId)
-            if apiId == 'sourceid':
-                call = Call(url, True)
-            else:
-                call = Call(url)
+            call = Call(url)
             toReturn[ioId] = call.get()
         if toReturn['source_id'] == "null":
             toReturn['source_id'] = None


### PR DESCRIPTION
This resolves an issue encountered in test_01 where the JSON comparison would fail because the source_id in the mock IO resource had double quotes around it.