### PR TITLE
bcp003: change ecdsa check to warning rather than fail

### DIFF
--- a/BCP00301Test.py
+++ b/BCP00301Test.py
@@ -275,7 +275,7 @@ class BCP00301Test(GenericTest):
                         ecdsa_found = True
 
             if not ecdsa_found:
-                return test.FAIL("Server is not providing an ECDSA certificate")
+                return test.WARNING("Server is not providing an ECDSA certificate")
             if not rsa_found:
                 return test.WARNING("Server is not providing an RSA certificate")
 


### PR DESCRIPTION
This is in preparation for a change to the required cipher suites which will make support for RSA certs mandatory instead.