### PR TITLE
Add config to delay testing after selecting what to run

### DIFF
--- a/Config.py
+++ b/Config.py
@@ -59,6 +59,10 @@ HTTP_TIMEOUT = 1
 # 0 = unlimited for a really thorough test!
 MAX_TEST_ITERATIONS = 0
 
+# Number of seconds to wait after selecting a test to run before carrying it out
+# Useful for unicast DNS testing where the device under test needs to restart in order to observe the new DNS records
+TEST_START_DELAY = 0
+
 # Test using HTTPS rather than HTTP as per AMWA BCP-003-01
 ENABLE_HTTPS = False
 
@@ -82,7 +86,6 @@ KEYS_MOCKS = [
 
 # Default User Credentials for interacting with Authorization Server
 AUTH_USERNAME = "TEST_USER"
-
 AUTH_PASSWORD = "TEST_PASSWORD"
 
 # Domain name to use for the local DNS server and mock Node

--- a/GenericTest.py
+++ b/GenericTest.py
@@ -20,10 +20,11 @@ import TestHelper
 import traceback
 import inspect
 import uuid
+import time
 
 from Specification import Specification
 from TestResult import Test
-from Config import ENABLE_HTTPS
+from Config import ENABLE_HTTPS, TEST_START_DELAY
 
 
 NMOS_WIKI_URL = "https://github.com/AMWA-TV/nmos/wiki"
@@ -177,6 +178,10 @@ class GenericTest(object):
         test = Test("Test setup")
         self.set_up_tests()
         self.result.append(test.NA(""))
+
+        if TEST_START_DELAY > 0:
+            print(" * Waiting for {} seconds before executing tests".format(TEST_START_DELAY))
+        time.sleep(TEST_START_DELAY)
 
         # Run tests
         self.execute_tests(test_name)

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -65,7 +65,7 @@ In order to test unicast discovery, the test suite launches its own mock DNS ser
 *   Configure the DNS search domain for your Node to be `testsuite.nmos.tv` (either manually or by providing this to your Node via DHCP).
 *   Configure the DNS server IP address for your Node to be the IP address of the host which is running the testing tool (either manually or by providing this to your Node via DHCP).
 
-Unicast DNS advertisements for registries only become available once tests are running. As a result the unit under test may need prompting to re-scan the DNS server for records at this point. The `DNS_SD_ADVERT_TIMEOUT` config parameter may be used to increase the period which the test suite waits for in this situation.
+Unicast DNS advertisements for registries only become available once tests are running. As a result the unit under test may need prompting to re-scan the DNS server for records at this point. The `TEST_START_DELAY` config parameter may be used to increase the period which the test suite waits for in this situation.
 
 If your network requires the use of the proxy server, you may find it necessary to disable this configuration on the host running the test suite and on the unit under test when using unicast DNS. This is because any requests to fully qualified hostnames are likely to be directed to your proxy server, which will be unable to resolve them.
 


### PR DESCRIPTION
It was pointed out to me by Miroslav that if you need to restart your Node in order to test unicast discovery, simply increasing `DNS_SD_ADVERT_TIMEOUT` can have some unintended consequences. If your Node is mid-reboot when the testing starts the 'auto' tests will indicate a fail as the waiting only happens after these have executed. This PR adds a wait period ahead of any tests running, but after the `set_up_tests` method which prepares the DNS server.