### PR TITLE
ports: allow base port number to be configured

### DIFF
--- a/CRL.py
+++ b/CRL.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 from flask import Blueprint, make_response
+from Config import PORT_BASE
 
 
 class CRLDistributionPoint(object):
     def __init__(self):
-        self.port = 5007  # cf. test_data/BCP00301/ca/intermediate/openssl.cnf
+        self.port = PORT_BASE + 7  # cf. test_data/BCP00301/ca/intermediate/openssl.cnf
 
 
 CRL = CRLDistributionPoint()

--- a/Config.py
+++ b/Config.py
@@ -94,7 +94,7 @@ DNS_DOMAIN = "testsuite.nmos.tv"
 
 # The testing tool uses multiple ports to run mock services. This sets the lowest of these, which also runs the GUI
 # Note that changing this from the default of 5000 also requires changes to supporting files such as
-# test_data/BCP00301/ca/intermediate/openssl.cnf and test_data/IS0401/dns_records.zone.
+# test_data/BCP00301/ca/intermediate/openssl.cnf and any generated certificates.
 # The mock DNS server port cannot be modified from the default of 53.
 PORT_BASE = 5000
 

--- a/Config.py
+++ b/Config.py
@@ -92,6 +92,12 @@ AUTH_PASSWORD = "TEST_PASSWORD"
 # This must match the domain name used for certificates in HTTPS mode
 DNS_DOMAIN = "testsuite.nmos.tv"
 
+# The testing tool uses multiple ports to run mock services. This sets the lowest of these, which also runs the GUI
+# Note that changing this from the default of 5000 also requires changes to supporting files such as
+# test_data/BCP00301/ca/intermediate/openssl.cnf and test_data/IS0401/dns_records.zone.
+# The mock DNS server port cannot be modified from the default of 53.
+PORT_BASE = 5000
+
 # Definition of each API specification and its versions.
 SPECIFICATIONS = {
     "is-04": {

--- a/DNS.py
+++ b/DNS.py
@@ -17,7 +17,7 @@ from dnslib.zoneresolver import ZoneResolver
 from jinja2 import Template
 
 from TestHelper import get_default_ip
-from Config import DNS_DOMAIN
+from Config import DNS_DOMAIN, PORT_BASE
 
 
 class DNS(object):
@@ -32,7 +32,7 @@ class DNS(object):
         zone_file = open("test_data/IS0401/dns_records.zone").read()
         template = Template(zone_file)
         zone_data = template.render(ip_address=self.default_ip, api_ver=api_version, api_proto=api_protocol,
-                                    domain=DNS_DOMAIN)
+                                    domain=DNS_DOMAIN, reg_port_base=PORT_BASE+100)
         self.resolver = ZoneResolver(self.base_zone_data + zone_data)
         self.stop()
         print(" * Loading DNS zone file with api_ver={}".format(api_version))

--- a/Node.py
+++ b/Node.py
@@ -15,13 +15,13 @@
 import uuid
 
 from flask import Blueprint, make_response, abort
-from Config import ENABLE_HTTPS, DNS_DOMAIN
+from Config import ENABLE_HTTPS, DNS_DOMAIN, PORT_BASE
 from TestHelper import get_default_ip
 
 
 class Node(object):
     def __init__(self, port_increment):
-        self.port = 5200 + port_increment
+        self.port = PORT_BASE + 200 + port_increment
 
     def get_sender(self, stream_type="video"):
         protocol = "http"

--- a/OCSP.py
+++ b/OCSP.py
@@ -15,11 +15,12 @@
 import subprocess
 
 from flask import Blueprint, make_response, request, abort
+from Config import PORT_BASE
 
 
 class OCSPDistributionPoint(object):
     def __init__(self):
-        self.port = 5008  # cf. test_data/BCP00301/ca/intermediate/openssl.cnf
+        self.port = PORT_BASE + 8  # cf. test_data/BCP00301/ca/intermediate/openssl.cnf
 
 
 OCSP = OCSPDistributionPoint()

--- a/Registry.py
+++ b/Registry.py
@@ -18,6 +18,7 @@ import json
 
 from flask import request, jsonify, abort, Blueprint, Response
 from threading import Event
+from Config import PORT_BASE
 
 
 class RegistryCommon(object):
@@ -39,7 +40,7 @@ class RegistryData(object):
 class Registry(object):
     def __init__(self, data_store, port_increment):
         self.common = data_store
-        self.port = 5100 + port_increment  # cf. test_data/IS0401/dns_records.zone
+        self.port = PORT_BASE + 100 + port_increment  # cf. test_data/IS0401/dns_records.zone
         self.event = Event()
         self.reset()
 

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -24,7 +24,7 @@ from Node import NODE, NODE_API
 from CRL import CRL, CRL_API
 from OCSP import OCSP, OCSP_API
 from Config import CACHE_PATH, SPECIFICATIONS, ENABLE_DNS_SD, DNS_SD_MODE, ENABLE_HTTPS, QUERY_API_HOST, QUERY_API_PORT
-from Config import CERTS_MOCKS, KEYS_MOCKS
+from Config import CERTS_MOCKS, KEYS_MOCKS, PORT_BASE
 from DNS import DNS
 from datetime import datetime, timedelta
 from junit_xml import TestSuite, TestCase
@@ -69,7 +69,7 @@ core_app = Flask(__name__)
 core_app.debug = False
 core_app.config['SECRET_KEY'] = 'nmos-interop-testing-jtnm'
 core_app.config['TEST_ACTIVE'] = False
-core_app.config['PORT'] = 5000
+core_app.config['PORT'] = PORT_BASE
 core_app.config['SECURE'] = False
 core_app.register_blueprint(NODE_API)  # Dependency for IS0401Test
 FLASK_APPS.append(core_app)

--- a/test_data/IS0401/dns_records.zone
+++ b/test_data/IS0401/dns_records.zone
@@ -3,84 +3,84 @@ mocks.{{ domain }}.	IN	A	{{ ip_address }}
 timeout.{{ domain }}.	IN	A	192.0.2.1
 
 ; There should be one PTR record for each instance of the service you wish to advertise.
-_nmos-registration._tcp	PTR	reg-api-101-ver._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-101-ver._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-101-ver._nmos-query._tcp
-_nmos-registration._tcp	PTR	reg-api-101-proto._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-101-proto._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-101-proto._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-1-ver._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-1-ver._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-1-ver._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-1-proto._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-1-proto._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-1-proto._nmos-query._tcp
 
-_nmos-registration._tcp	PTR	reg-api-102._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-102._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-102._nmos-query._tcp
-_nmos-registration._tcp	PTR	reg-api-103._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-103._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-103._nmos-query._tcp
-_nmos-registration._tcp	PTR	reg-api-104._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-104._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-104._nmos-query._tcp
-_nmos-registration._tcp	PTR	reg-api-105._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-105._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-105._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-2._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-2._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-2._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-3._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-3._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-3._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-4._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-4._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-4._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-5._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-5._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-5._nmos-query._tcp
 _nmos-registration._tcp	PTR	reg-api-timeout._nmos-registration._tcp
 _nmos-register._tcp	PTR	reg-api-timeout._nmos-register._tcp
 _nmos-query._tcp	PTR	qry-api-timeout._nmos-query._tcp
-_nmos-registration._tcp	PTR	reg-api-106._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-106._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-106._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-6._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-6._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-6._nmos-query._tcp
 
 ; Next we have a SRV and a TXT record corresponding to each PTR above, first the Registration API
 ; The SRV links the PTR name to a resolvable DNS name (see the A records above) and identify the port which the API runs on
 ; The TXT records indicate additional metadata relevant to the IS-04 spec
-reg-api-101-ver._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 1 }} mocks.{{ domain }}.
-reg-api-101-ver._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 1 }} mocks.{{ domain }}.
-reg-api-101-ver._nmos-registration._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
-reg-api-101-ver._nmos-register._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
-reg-api-101-proto._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 1 }} mocks.{{ domain }}.
-reg-api-101-proto._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 1 }} mocks.{{ domain }}.
-reg-api-101-proto._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
-reg-api-101-proto._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
+reg-api-1-ver._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 1 }} mocks.{{ domain }}.
+reg-api-1-ver._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 1 }} mocks.{{ domain }}.
+reg-api-1-ver._nmos-registration._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
+reg-api-1-ver._nmos-register._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
+reg-api-1-proto._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 1 }} mocks.{{ domain }}.
+reg-api-1-proto._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 1 }} mocks.{{ domain }}.
+reg-api-1-proto._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
+reg-api-1-proto._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
 
-reg-api-102._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 2 }} mocks.{{ domain }}.
-reg-api-102._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 2 }} mocks.{{ domain }}.
-reg-api-102._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
-reg-api-102._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
-reg-api-103._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 3 }} mocks.{{ domain }}.
-reg-api-103._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 3 }} mocks.{{ domain }}.
-reg-api-103._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
-reg-api-103._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
-reg-api-104._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 4 }} mocks.{{ domain }}.
-reg-api-104._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 4 }} mocks.{{ domain }}.
-reg-api-104._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
-reg-api-104._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
-reg-api-105._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 5 }} mocks.{{ domain }}.
-reg-api-105._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 5 }} mocks.{{ domain }}.
-reg-api-105._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
-reg-api-105._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
+reg-api-2._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 2 }} mocks.{{ domain }}.
+reg-api-2._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 2 }} mocks.{{ domain }}.
+reg-api-2._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
+reg-api-2._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
+reg-api-3._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 3 }} mocks.{{ domain }}.
+reg-api-3._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 3 }} mocks.{{ domain }}.
+reg-api-3._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
+reg-api-3._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
+reg-api-4._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 4 }} mocks.{{ domain }}.
+reg-api-4._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 4 }} mocks.{{ domain }}.
+reg-api-4._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
+reg-api-4._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
+reg-api-5._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 5 }} mocks.{{ domain }}.
+reg-api-5._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 5 }} mocks.{{ domain }}.
+reg-api-5._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
+reg-api-5._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
 reg-api-timeout._nmos-registration._tcp	SRV	0 0 444 timeout.{{ domain }}.
 reg-api-timeout._nmos-register._tcp	SRV	0 0 444 timeout.{{ domain }}.
 reg-api-timeout._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
 reg-api-timeout._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
-reg-api-106._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 6 }} mocks.{{ domain }}.
-reg-api-106._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 6 }} mocks.{{ domain }}.
-reg-api-106._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"
-reg-api-106._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"
+reg-api-6._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 6 }} mocks.{{ domain }}.
+reg-api-6._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 6 }} mocks.{{ domain }}.
+reg-api-6._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"
+reg-api-6._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"
 
 ; Finally, the SRV and TXT for the Query API
-qry-api-101-ver._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 1 }} mocks.{{ domain }}.
-qry-api-101-ver._nmos-query._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
-qry-api-101-proto._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 1 }} mocks.{{ domain }}.
-qry-api-101-proto._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
+qry-api-1-ver._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 1 }} mocks.{{ domain }}.
+qry-api-1-ver._nmos-query._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
+qry-api-1-proto._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 1 }} mocks.{{ domain }}.
+qry-api-1-proto._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
 
-qry-api-102._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 2 }} mocks.{{ domain }}.
-qry-api-102._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
-qry-api-103._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 3 }} mocks.{{ domain }}.
-qry-api-103._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
-qry-api-104._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 4 }} mocks.{{ domain }}.
-qry-api-104._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
-qry-api-105._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 5 }} mocks.{{ domain }}.
-qry-api-105._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
+qry-api-2._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 2 }} mocks.{{ domain }}.
+qry-api-2._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
+qry-api-3._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 3 }} mocks.{{ domain }}.
+qry-api-3._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
+qry-api-4._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 4 }} mocks.{{ domain }}.
+qry-api-4._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
+qry-api-5._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 5 }} mocks.{{ domain }}.
+qry-api-5._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
 qry-api-timeout._nmos-query._tcp	SRV	0 0 444 timeout.{{ domain }}.
 qry-api-timeout._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
-qry-api-106._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 6 }} mocks.{{ domain }}.
-qry-api-106._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"
+qry-api-6._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 6 }} mocks.{{ domain }}.
+qry-api-6._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"

--- a/test_data/IS0401/dns_records.zone
+++ b/test_data/IS0401/dns_records.zone
@@ -3,84 +3,84 @@ mocks.{{ domain }}.	IN	A	{{ ip_address }}
 timeout.{{ domain }}.	IN	A	192.0.2.1
 
 ; There should be one PTR record for each instance of the service you wish to advertise.
-_nmos-registration._tcp	PTR	reg-api-5101-ver._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5101-ver._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-5101-ver._nmos-query._tcp
-_nmos-registration._tcp	PTR	reg-api-5101-proto._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5101-proto._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-5101-proto._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-101-ver._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-101-ver._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-101-ver._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-101-proto._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-101-proto._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-101-proto._nmos-query._tcp
 
-_nmos-registration._tcp	PTR	reg-api-5102._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5102._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-5102._nmos-query._tcp
-_nmos-registration._tcp	PTR	reg-api-5103._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5103._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-5103._nmos-query._tcp
-_nmos-registration._tcp	PTR	reg-api-5104._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5104._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-5104._nmos-query._tcp
-_nmos-registration._tcp	PTR	reg-api-5105._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5105._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-5105._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-102._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-102._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-102._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-103._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-103._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-103._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-104._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-104._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-104._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-105._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-105._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-105._nmos-query._tcp
 _nmos-registration._tcp	PTR	reg-api-timeout._nmos-registration._tcp
 _nmos-register._tcp	PTR	reg-api-timeout._nmos-register._tcp
 _nmos-query._tcp	PTR	qry-api-timeout._nmos-query._tcp
-_nmos-registration._tcp	PTR	reg-api-5106._nmos-registration._tcp
-_nmos-register._tcp	PTR	reg-api-5106._nmos-register._tcp
-_nmos-query._tcp	PTR	qry-api-5106._nmos-query._tcp
+_nmos-registration._tcp	PTR	reg-api-106._nmos-registration._tcp
+_nmos-register._tcp	PTR	reg-api-106._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-106._nmos-query._tcp
 
 ; Next we have a SRV and a TXT record corresponding to each PTR above, first the Registration API
 ; The SRV links the PTR name to a resolvable DNS name (see the A records above) and identify the port which the API runs on
 ; The TXT records indicate additional metadata relevant to the IS-04 spec
-reg-api-5101-ver._nmos-registration._tcp	SRV	0 0 5101 mocks.{{ domain }}.
-reg-api-5101-ver._nmos-register._tcp	SRV	0 0 5101 mocks.{{ domain }}.
-reg-api-5101-ver._nmos-registration._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
-reg-api-5101-ver._nmos-register._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
-reg-api-5101-proto._nmos-registration._tcp	SRV	0 0 5101 mocks.{{ domain }}.
-reg-api-5101-proto._nmos-register._tcp	SRV	0 0 5101 mocks.{{ domain }}.
-reg-api-5101-proto._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
-reg-api-5101-proto._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
+reg-api-101-ver._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 1 }} mocks.{{ domain }}.
+reg-api-101-ver._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 1 }} mocks.{{ domain }}.
+reg-api-101-ver._nmos-registration._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
+reg-api-101-ver._nmos-register._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
+reg-api-101-proto._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 1 }} mocks.{{ domain }}.
+reg-api-101-proto._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 1 }} mocks.{{ domain }}.
+reg-api-101-proto._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
+reg-api-101-proto._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
 
-reg-api-5102._nmos-registration._tcp	SRV	0 0 5102 mocks.{{ domain }}.
-reg-api-5102._nmos-register._tcp	SRV	0 0 5102 mocks.{{ domain }}.
-reg-api-5102._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
-reg-api-5102._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
-reg-api-5103._nmos-registration._tcp	SRV	0 0 5103 mocks.{{ domain }}.
-reg-api-5103._nmos-register._tcp	SRV	0 0 5103 mocks.{{ domain }}.
-reg-api-5103._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
-reg-api-5103._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
-reg-api-5104._nmos-registration._tcp	SRV	0 0 5104 mocks.{{ domain }}.
-reg-api-5104._nmos-register._tcp	SRV	0 0 5104 mocks.{{ domain }}.
-reg-api-5104._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
-reg-api-5104._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
-reg-api-5105._nmos-registration._tcp	SRV	0 0 5105 mocks.{{ domain }}.
-reg-api-5105._nmos-register._tcp	SRV	0 0 5105 mocks.{{ domain }}.
-reg-api-5105._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
-reg-api-5105._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
+reg-api-102._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 2 }} mocks.{{ domain }}.
+reg-api-102._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 2 }} mocks.{{ domain }}.
+reg-api-102._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
+reg-api-102._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
+reg-api-103._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 3 }} mocks.{{ domain }}.
+reg-api-103._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 3 }} mocks.{{ domain }}.
+reg-api-103._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
+reg-api-103._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
+reg-api-104._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 4 }} mocks.{{ domain }}.
+reg-api-104._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 4 }} mocks.{{ domain }}.
+reg-api-104._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
+reg-api-104._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
+reg-api-105._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 5 }} mocks.{{ domain }}.
+reg-api-105._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 5 }} mocks.{{ domain }}.
+reg-api-105._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
+reg-api-105._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
 reg-api-timeout._nmos-registration._tcp	SRV	0 0 444 timeout.{{ domain }}.
 reg-api-timeout._nmos-register._tcp	SRV	0 0 444 timeout.{{ domain }}.
 reg-api-timeout._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
 reg-api-timeout._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
-reg-api-5106._nmos-registration._tcp	SRV	0 0 5106 mocks.{{ domain }}.
-reg-api-5106._nmos-register._tcp	SRV	0 0 5106 mocks.{{ domain }}.
-reg-api-5106._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"
-reg-api-5106._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"
+reg-api-106._nmos-registration._tcp	SRV	0 0 {{ reg_port_base + 6 }} mocks.{{ domain }}.
+reg-api-106._nmos-register._tcp	SRV	0 0 {{ reg_port_base + 6 }} mocks.{{ domain }}.
+reg-api-106._nmos-registration._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"
+reg-api-106._nmos-register._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"
 
 ; Finally, the SRV and TXT for the Query API
-qry-api-5101-ver._nmos-query._tcp	SRV	0 0 5101 mocks.{{ domain }}.
-qry-api-5101-ver._nmos-query._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
-qry-api-5101-proto._nmos-query._tcp	SRV	0 0 5101 mocks.{{ domain }}.
-qry-api-5101-proto._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
+qry-api-101-ver._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 1 }} mocks.{{ domain }}.
+qry-api-101-ver._nmos-query._tcp	TXT	"api_ver=v9.0" "api_proto={{ api_proto }}" "pri=0"
+qry-api-101-proto._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 1 }} mocks.{{ domain }}.
+qry-api-101-proto._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto=invalid" "pri=0"
 
-qry-api-5102._nmos-query._tcp	SRV	0 0 5102 mocks.{{ domain }}.
-qry-api-5102._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
-qry-api-5103._nmos-query._tcp	SRV	0 0 5103 mocks.{{ domain }}.
-qry-api-5103._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
-qry-api-5104._nmos-query._tcp	SRV	0 0 5104 mocks.{{ domain }}.
-qry-api-5104._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
-qry-api-5105._nmos-query._tcp	SRV	0 0 5105 mocks.{{ domain }}.
-qry-api-5105._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
+qry-api-102._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 2 }} mocks.{{ domain }}.
+qry-api-102._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=0"
+qry-api-103._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 3 }} mocks.{{ domain }}.
+qry-api-103._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=10"
+qry-api-104._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 4 }} mocks.{{ domain }}.
+qry-api-104._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=20"
+qry-api-105._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 5 }} mocks.{{ domain }}.
+qry-api-105._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=30"
 qry-api-timeout._nmos-query._tcp	SRV	0 0 444 timeout.{{ domain }}.
 qry-api-timeout._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=40"
-qry-api-5106._nmos-query._tcp	SRV	0 0 5106 mocks.{{ domain }}.
-qry-api-5106._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"
+qry-api-106._nmos-query._tcp	SRV	0 0 {{ reg_port_base + 6 }} mocks.{{ domain }}.
+qry-api-106._nmos-query._tcp	TXT	"api_ver={{ api_ver }}" "api_proto={{ api_proto }}" "pri=50"


### PR DESCRIPTION
It would be useful to be able to run the tool as multiple instances on the same host. To do this I need to offset the port ranges used. Use of `ENABLE_DNS_SD` when running multiple instances won't be possible, but it'll help to test things other than discovery.