### PR TITLE
is0401: improve other results if Node fails to pick correct registry

### DIFF
--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -147,7 +147,8 @@ class IS0401Test(GenericTest):
             time.sleep(0.2)
 
         # Wait until we're sure the Node has registered everything it intends to, and we've had at least one heartbeat
-        while (time.time() - self.primary_registry.last_time) < HEARTBEAT_INTERVAL + 1:
+        while (time.time() - self.primary_registry.last_time) < HEARTBEAT_INTERVAL + 1 and \
+              (time.time() - self.invalid_registry.last_time) < HEARTBEAT_INTERVAL + 1:
             time.sleep(0.2)
 
         # Ensure we have two heartbeats from the Node, assuming any are arriving (for test_05)

--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -152,9 +152,10 @@ class IS0401Test(GenericTest):
             time.sleep(0.2)
 
         # Ensure we have two heartbeats from the Node, assuming any are arriving (for test_05)
-        if len(self.primary_registry.get_data().heartbeats) > 0:
+        if len(self.primary_registry.get_data().heartbeats) > 0 or len(self.invalid_registry.get_data().heartbeats) > 0:
             # It is heartbeating, but we don't have enough of them yet
-            while len(self.primary_registry.get_data().heartbeats) < 2:
+            while len(self.primary_registry.get_data().heartbeats) < 2 and \
+                  len(self.invalid_registry.get_data().heartbeats) < 2:
                 time.sleep(0.2)
 
             # Once registered, advertise all other registries at different (ascending) priorities

--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -45,6 +45,7 @@ class IS0401Test(GenericTest):
         self.node_url = self.apis[NODE_API_KEY]["url"]
         self.registry_basics_done = False
         self.registry_basics_data = []
+        self.registry_primary_data = None
         self.registry_invalid_data = None
         self.is04_utils = IS04Utils(self.node_url)
         self.zc = None
@@ -207,6 +208,13 @@ class IS0401Test(GenericTest):
             self.registry_basics_data.append(registry.get_data())
         self.registry_invalid_data = self.invalid_registry.get_data()
 
+        # If the Node preferred the invalid registry, don't penalise it for other tests which check the general
+        # interactions are correct
+        if len(self.registry_invalid_data.posts) > 0:
+            self.registry_primary_data = self.registry_invalid_data
+        else:
+            self.registry_primary_data = self.registry_basics_data[0]
+
     def test_01(self, test):
         """Node can discover network registration service via multicast DNS"""
 
@@ -216,7 +224,7 @@ class IS0401Test(GenericTest):
 
         self.do_registry_basics_prereqs()
 
-        registry_data = self.registry_basics_data[0]
+        registry_data = self.registry_primary_data
         if len(registry_data.posts) > 0:
             return test.PASS()
 
@@ -249,7 +257,7 @@ class IS0401Test(GenericTest):
 
         self.do_registry_basics_prereqs()
 
-        registry_data = self.registry_basics_data[0]
+        registry_data = self.registry_primary_data
         if len(registry_data.posts) > 0:
             return test.PASS()
 
@@ -281,7 +289,7 @@ class IS0401Test(GenericTest):
 
         self.do_registry_basics_prereqs()
 
-        registry_data = self.registry_basics_data[0]
+        registry_data = self.registry_primary_data
         if len(registry_data.posts) == 0:
             return test.FAIL("No registrations found")
 
@@ -303,7 +311,7 @@ class IS0401Test(GenericTest):
 
         self.do_registry_basics_prereqs()
 
-        registry_data = self.registry_basics_data[0]
+        registry_data = self.registry_primary_data
         if len(registry_data.posts) == 0:
             return test.FAIL("No registrations found")
 
@@ -328,7 +336,7 @@ class IS0401Test(GenericTest):
         found_resource = None
         if ENABLE_DNS_SD:
             # Look up data in local mock registry
-            registry_data = self.registry_basics_data[0]
+            registry_data = self.registry_primary_data
             for resource in registry_data.posts:
                 if resource[1]["payload"]["type"] == res_type and resource[1]["payload"]["data"]["id"] == res_id:
                     found_resource = resource[1]["payload"]["data"]
@@ -397,7 +405,7 @@ class IS0401Test(GenericTest):
 
     def check_matching_parents(self, test, res_type):
         # Look up data in local mock registry
-        registry_data = self.registry_basics_data[0]
+        registry_data = self.registry_primary_data
         parent_type = self.parent_resource_type(res_type)
         registered_parents = []
         found_resource = False
@@ -438,7 +446,7 @@ class IS0401Test(GenericTest):
 
         self.do_registry_basics_prereqs()
 
-        registry_data = self.registry_basics_data[0]
+        registry_data = self.registry_primary_data
         if len(registry_data.heartbeats) < 2:
             return test.FAIL("Not enough heartbeats were made in the time period.")
 

--- a/Registry.py
+++ b/Registry.py
@@ -50,7 +50,6 @@ class Registry(object):
         self.common.reset()
         self.enabled = False
         self.test_first_reg = False
-        self.test_invalid_reg = False
         self.event.clear()
 
     def add(self, headers, payload, version):
@@ -82,14 +81,12 @@ class Registry(object):
     def get_resources(self):
         return self.common.resources
 
-    def enable(self, first_reg=False, invalid_reg=False):
+    def enable(self, first_reg=False):
         self.test_first_reg = first_reg
-        self.test_invalid_reg = invalid_reg
         self.enabled = True
 
     def disable(self):
         self.test_first_reg = False
-        self.test_invalid_reg = False
         self.enabled = False
 
     def wait_for_registration(self, timeout):
@@ -124,9 +121,6 @@ def post_resource(version):
     registry = REGISTRIES[flask.current_app.config["REGISTRY_INSTANCE"]]
     if not registry.enabled:
         abort(500)
-    if registry.test_invalid_reg:
-        print(" * DEBUG: Node attempted registration with a registry using invalid DNS-SD TXT records")
-        registry.disable()
     if not registry.test_first_reg:
         registered = False
         try:


### PR DESCRIPTION
I haven't tested this out yet but will be doing so early next week.

Due to the fact we don't want the tests to take any longer than necessary, some tests run at the same time as each other. At present if a Node fails `test_01_01` or `test_02_01` it may be unfairly penalised in other tests (such as `test_03`, `test_04` etc). This change intends to check both the primary registry and invalid registry when performing these basic registration tests so that this discovery failure isn't recorded as a failure in multiple places.