### PR TITLE
is0401: fix failure in api_auth TXT record checks

### DIFF
--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -605,7 +605,8 @@ class IS0401Test(GenericTest):
                 if self.is04_utils.compare_api_version(api["version"], "v1.3") >= 0:
                     if "api_auth" not in properties:
                         return test.FAIL("No 'api_auth' TXT record found in Node API advertisement.")
-                    elif properties["api_auth"] not in ["true", "false"]:
+                    elif not isinstance(properties["api_auth"], bool):
+                        # zeroconf translates 'true' to True and 'false' to False automatically
                         return test.FAIL("API authorization ('api_auth') TXT record is not one of 'true' or 'false'.")
 
                 return test.PASS()

--- a/IS0402Test.py
+++ b/IS0402Test.py
@@ -106,7 +106,8 @@ class IS0402Test(GenericTest):
                 if self.is04_reg_utils.compare_api_version(api["version"], "v1.3") >= 0:
                     if "api_auth" not in properties:
                         return test.FAIL("No 'api_auth' TXT record found in {} advertisement.".format(api["name"]))
-                    elif properties["api_auth"] not in ["true", "false"]:
+                    elif not isinstance(properties["api_auth"], bool):
+                        # zeroconf translates 'true' to True and 'false' to False automatically
                         return test.FAIL("API authorization ('api_auth') TXT record is not one of 'true' or 'false'.")
 
                 return test.PASS()

--- a/IS0403Test.py
+++ b/IS0403Test.py
@@ -83,7 +83,8 @@ class IS0403Test(GenericTest):
                 if self.is04_utils.compare_api_version(api["version"], "v1.3") >= 0:
                     if "api_auth" not in properties:
                         return test.FAIL("No 'api_auth' TXT record found in Node API advertisement.")
-                    elif properties["api_auth"] not in ["true", "false"]:
+                    elif not isinstance(properties["api_auth"], bool):
+                        # zeroconf translates 'true' to True and 'false' to False automatically
                         return test.FAIL("API authorization ('api_auth') TXT record is not one of 'true' or 'false'.")
 
                 return test.PASS()


### PR DESCRIPTION
Resolves #314 

I stopped short of patching zeroconf given it does just handle these values. The only edge case may be  a TXT record with an empty value which could evaluate to `False`, but I'm not sure it's worth the potential for the patch to fail in the future to cover that case.