### PR TITLE
http: log web server port number for each request

### DIFF
--- a/nmos-test.py
+++ b/nmos-test.py
@@ -602,10 +602,10 @@ def validate_args(args):
 
 class PortLoggingHandler(WSGIRequestHandler):
     def log(self, type, message, *args):
-        # Conform to Combined Log Format, replacing Referer with the local server address
+        # Conform to Combined Log Format, replacing Referer with the Host header or the local server address
         url_scheme = "http" if self.server.ssl_context is None else "https"
-        referer = "{}://{}:{}{}".format(url_scheme, self.server.server_address[0],
-                                        self.server.server_address[1], self.path)
+        host = self.headers.get("Host", "{}:{}".format(self.server.server_address[0], self.server.server_address[1]))
+        referer = "{}://{}".format(url_scheme, host)
         message += ' "{}" "{}"'.format(referer, self.headers.get("User-Agent", ""))
         super().log(type, message, *args)
 

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -601,12 +601,13 @@ def validate_args(args):
 
 
 class PortLoggingHandler(WSGIRequestHandler):
-    def address_string(self):
-        address = super().address_string()
-        port = self.server.server_address[1]
-        if not address.endswith(":{}".format(port)):
-            address += ":{}".format(port)
-        return address
+    def log(self, type, message, *args):
+        # Conform to Combined Log Format, replacing Referer with the local server address
+        url_scheme = "http" if self.server.ssl_context is None else "https"
+        referer = "{}://{}:{}{}".format(url_scheme, self.server.server_address[0],
+                                        self.server.server_address[1], self.path)
+        message += ' "{}" "{}"'.format(referer, self.headers.get("User-Agent", ""))
+        super().log(type, message, *args)
 
 
 def start_web_servers():


### PR DESCRIPTION
This commit should make it a little easier to debug some of the IS-04 mock registry tests. It should ensure that the mock servers' port numbers get logged each time a request comes in.