### PR TITLE
Make ANSI escape character sequences (for producing coloured terminal text) work under Windows

### DIFF
--- a/nmos-test.py
+++ b/nmos-test.py
@@ -47,6 +47,13 @@ import ipaddress
 import socket
 import ssl
 
+# Make ANSI escape character sequences (for producing coloured terminal text) work under Windows
+try:
+    import colorama
+    colorama.init()
+except ImportError:
+    pass
+
 import IS0401Test
 import IS0402Test
 import IS0403Test


### PR DESCRIPTION
This makes the request logging look as intended.

I haven't noted colorama in requirements.txt because it's only necessary on Windows.