### PR TITLE
is0401: don't fail test_16 if a resource update happens during test

### DIFF
--- a/IS0401Test.py
+++ b/IS0401Test.py
@@ -831,9 +831,11 @@ class IS0401Test(GenericTest):
                 return test.FAIL("Node never made contact with registry {} advertised on port {}"
                                  .format(index + 1, registry_data.port))
 
-            if index > 0 and len(registry_data.posts) > 0:
-                return test.FAIL("Node re-registered its resources when it failed over to a new registry, when it "
-                                 "should only have issued a heartbeat")
+            if index > 0:
+                for resource in registry_data.posts:
+                    if resource[1]["payload"]["type"] == "node":
+                        return test.FAIL("Node re-registered its resources when it failed over to a new registry, when "
+                                         "it should only have issued a heartbeat")
 
         return test.PASS()
 
@@ -852,9 +854,10 @@ class IS0401Test(GenericTest):
             return test.WARNING("Node never made contact with registry {} advertised on port {}"
                                 .format(len(self.registry_basics_data), registry_data.port))
 
-        if len(registry_data.posts) > 0:
-            return test.WARNING("Node re-registered its resources when it failed over to a new registry, when it "
-                                "should only have issued a heartbeat")
+        for resource in registry_data.posts:
+            if resource[1]["payload"]["type"] == "node":
+                return test.WARNING("Node re-registered its resources when it failed over to a new registry, when it "
+                                    "should only have issued a heartbeat")
 
         return test.PASS()
 


### PR DESCRIPTION
Whilst unlikely, if one of a Node's resources was updated during the registry failover tests, it could quite correctly issue a heartbeat followed by a POST to /resource. It would be hard to detect this accurately if the updated resource was the 'node' but this should handle the case where the issue is with any other sub-resource.