### PR TITLE
is0501: check error schema for test_34/35

### DIFF
--- a/GenericTest.py
+++ b/GenericTest.py
@@ -269,7 +269,7 @@ class GenericTest(object):
     def check_error_response(self, method, response, code):
         """Confirm that a given Requests response conforms to the 4xx/5xx error schema and has any expected headers"""
         schema = TestHelper.load_resolved_schema("test_data/core", "error.json", path_prefix=False)
-        valid, message = self.check_response(schema, "GET", response)
+        valid, message = self.check_response(schema, method, response)
         if valid:
             if response.json()["code"] != code:
                 return False, "Error JSON 'code' was not set to {}".format(code)

--- a/IS0501Test.py
+++ b/IS0501Test.py
@@ -735,11 +735,8 @@ class IS0501Test(GenericTest):
         error_code = 405
         valid, response = self.is05_utils.checkCleanRequest("GET", url, code=error_code)
         if valid:
-            schema = load_resolved_schema("test_data/core", "error.json", path_prefix=False)
-            valid, message = self.check_response(schema, "GET", response)
+            valid, message = self.check_error_response("GET", response, error_code)
             if valid:
-                if response.json()["code"] != error_code:
-                    return test.FAIL("Error JSON 'code' was not set to {}".format(error_code))
                 return test.PASS()
             else:
                 return test.FAIL(message)
@@ -753,11 +750,8 @@ class IS0501Test(GenericTest):
         error_code = 405
         valid, response = self.is05_utils.checkCleanRequest("GET", url, code=error_code)
         if valid:
-            schema = load_resolved_schema("test_data/core", "error.json", path_prefix=False)
-            valid, message = self.check_response(schema, "GET", response)
+            valid, message = self.check_error_response("GET", response, error_code)
             if valid:
-                if response.json()["code"] != error_code:
-                    return test.FAIL("Error JSON 'code' was not set to {}".format(error_code))
                 return test.PASS()
             else:
                 return test.FAIL(message)

--- a/IS0501Test.py
+++ b/IS0501Test.py
@@ -732,9 +732,17 @@ class IS0501Test(GenericTest):
         """GET on /bulk/senders returns 405"""
 
         url = "bulk/senders"
-        valid, response = self.is05_utils.checkCleanRequestJSON("GET", url, code=405)
+        error_code = 405
+        valid, response = self.is05_utils.checkCleanRequest("GET", url, code=error_code)
         if valid:
-            return test.PASS()
+            schema = load_resolved_schema("test_data/core", "error.json", path_prefix=False)
+            valid, message = self.check_response(schema, "GET", response)
+            if valid:
+                if response.json()["code"] != error_code:
+                    return test.FAIL("Error JSON 'code' was not set to {}".format(error_code))
+                return test.PASS()
+            else:
+                return test.FAIL(message)
         else:
             return test.FAIL(response)
 
@@ -742,9 +750,17 @@ class IS0501Test(GenericTest):
         """GET on /bulk/receivers returns 405"""
 
         url = "bulk/receivers"
-        valid, response = self.is05_utils.checkCleanRequestJSON("GET", url, code=405)
+        error_code = 405
+        valid, response = self.is05_utils.checkCleanRequest("GET", url, code=error_code)
         if valid:
-            return test.PASS()
+            schema = load_resolved_schema("test_data/core", "error.json", path_prefix=False)
+            valid, message = self.check_response(schema, "GET", response)
+            if valid:
+                if response.json()["code"] != error_code:
+                    return test.FAIL("Error JSON 'code' was not set to {}".format(error_code))
+                return test.PASS()
+            else:
+                return test.FAIL(message)
         else:
             return test.FAIL(response)
 


### PR DESCRIPTION
Leaving this one until after next week's event to avoid being unfair to pre-tested implementations.

This adds schema checking to the 405 responses from the IS-05 API.