### PR TITLE
is05: add testing for WebSocket parameter changes

### DIFF
--- a/IS0501Test.py
+++ b/IS0501Test.py
@@ -540,12 +540,12 @@ class IS0501Test(GenericTest):
 
         if len(self.senders) > 0:
             for sender in self.senders:
-                if self.transport_types[sender] == "urn:x-nmos:transport:websocket":
-                    continue
-                valid, values = self.is05_utils.generate_destination_ports("sender", sender)
+                valid, values = self.is05_utils.generate_changeable_param("sender", sender,
+                                                                          self.transport_types[sender])
+                paramName = self.is05_utils.changeable_param_name(self.transport_types[sender])
                 if valid:
                     valid2, response2 = self.is05_utils.check_change_transport_param("sender", self.senders,
-                                                                                     "destination_port", values, sender)
+                                                                                     paramName, values, sender)
                     if valid2:
                         pass
                     else:
@@ -561,13 +561,12 @@ class IS0501Test(GenericTest):
 
         if len(self.receivers) > 0:
             for receiver in self.receivers:
-                if self.transport_types[receiver] == "urn:x-nmos:transport:websocket":
-                    continue
-                valid, values = self.is05_utils.generate_destination_ports("receiver", receiver)
+                valid, values = self.is05_utils.generate_changeable_param("receiver", receiver,
+                                                                          self.transport_types[receiver])
+                paramName = self.is05_utils.changeable_param_name(self.transport_types[receiver])
                 if valid:
                     valid2, response2 = self.is05_utils.check_change_transport_param("receiver", self.receivers,
-                                                                                     "destination_port", values,
-                                                                                     receiver)
+                                                                                     paramName, values, receiver)
                     if valid2:
                         pass
                     else:
@@ -583,10 +582,9 @@ class IS0501Test(GenericTest):
 
         if len(self.senders) > 0:
             for sender in self.is05_utils.sampled_list(self.senders):
-                if self.transport_types[sender] == "urn:x-nmos:transport:websocket":
-                    continue
                 valid, response = self.is05_utils.check_activation("sender", sender,
-                                                                   self.is05_utils.check_perform_immediate_activation)
+                                                                   self.is05_utils.check_perform_immediate_activation,
+                                                                   self.transport_types[sender])
                 if valid:
                     pass
                 else:
@@ -600,10 +598,9 @@ class IS0501Test(GenericTest):
 
         if len(self.receivers) > 0:
             for receiver in self.is05_utils.sampled_list(self.receivers):
-                if self.transport_types[receiver] == "urn:x-nmos:transport:websocket":
-                    continue
                 valid, response = self.is05_utils.check_activation("receiver", receiver,
-                                                                   self.is05_utils.check_perform_immediate_activation)
+                                                                   self.is05_utils.check_perform_immediate_activation,
+                                                                   self.transport_types[receiver])
                 if valid:
                     pass
                 else:
@@ -618,10 +615,9 @@ class IS0501Test(GenericTest):
 
         if len(self.senders) > 0:
             for sender in self.is05_utils.sampled_list(self.senders):
-                if self.transport_types[sender] == "urn:x-nmos:transport:websocket":
-                    continue
                 valid, response = self.is05_utils.check_activation("sender", sender,
-                                                                   self.is05_utils.check_perform_relative_activation)
+                                                                   self.is05_utils.check_perform_relative_activation,
+                                                                   self.transport_types[sender])
                 if valid:
                     pass
                 else:
@@ -635,10 +631,9 @@ class IS0501Test(GenericTest):
 
         if len(self.receivers) > 0:
             for receiver in self.is05_utils.sampled_list(self.receivers):
-                if self.transport_types[receiver] == "urn:x-nmos:transport:websocket":
-                    continue
                 valid, response = self.is05_utils.check_activation("receiver", receiver,
-                                                                   self.is05_utils.check_perform_relative_activation)
+                                                                   self.is05_utils.check_perform_relative_activation,
+                                                                   self.transport_types[receiver])
                 if valid:
                     pass
                 else:
@@ -652,10 +647,9 @@ class IS0501Test(GenericTest):
 
         if len(self.senders) > 0:
             for sender in self.is05_utils.sampled_list(self.senders):
-                if self.transport_types[sender] == "urn:x-nmos:transport:websocket":
-                    continue
                 valid, response = self.is05_utils.check_activation("sender", sender,
-                                                                   self.is05_utils.check_perform_absolute_activation)
+                                                                   self.is05_utils.check_perform_absolute_activation,
+                                                                   self.transport_types[sender])
                 if valid:
                     pass
                 else:
@@ -669,10 +663,9 @@ class IS0501Test(GenericTest):
 
         if len(self.receivers) > 0:
             for receiver in self.is05_utils.sampled_list(self.receivers):
-                if self.transport_types[receiver] == "urn:x-nmos:transport:websocket":
-                    continue
                 valid, response = self.is05_utils.check_activation("receiver", receiver,
-                                                                   self.is05_utils.check_perform_absolute_activation)
+                                                                   self.is05_utils.check_perform_absolute_activation,
+                                                                   self.transport_types[receiver])
                 if valid:
                     pass
                 else:
@@ -936,9 +929,8 @@ class IS0501Test(GenericTest):
         data = []
         ports = {}
         for portInst in portList:
-            if self.transport_types[portInst] == "urn:x-nmos:transport:websocket":
-                continue
-            valid, response = self.is05_utils.generate_destination_ports(port, portInst)
+            valid, response = self.is05_utils.generate_changeable_param(port, portInst, self.transport_types[portInst])
+            paramName = self.is05_utils.changeable_param_name(self.transport_types[portInst])
             if valid:
                 ports[portInst] = response
                 toAdd = {}
@@ -946,7 +938,7 @@ class IS0501Test(GenericTest):
                 toAdd['params'] = {}
                 toAdd['params']['transport_params'] = []
                 for portNum in ports[portInst]:
-                    toAdd['params']['transport_params'].append({"destination_port": portNum})
+                    toAdd['params']['transport_params'].append({paramName: portNum})
                 if len(toAdd["params"]["transport_params"]) == 0:
                     del toAdd["params"]["transport_params"]
                 data.append(toAdd)
@@ -972,22 +964,20 @@ class IS0501Test(GenericTest):
 
         # Check the parameters have actually changed
         for portInst in portList:
-            if self.transport_types[portInst] == "urn:x-nmos:transport:websocket":
-                continue
+            paramName = self.is05_utils.changeable_param_name(self.transport_types[portInst])
             activeUrl = "single/" + port + "s/" + portInst + "/staged/"
 
             valid, response = self.is05_utils.checkCleanRequestJSON("GET", activeUrl)
             if valid:
                 for i in range(0, self.is05_utils.get_num_paths(portInst, port)):
                     try:
-                        value = response['transport_params'][i]['destination_port']
+                        value = response['transport_params'][i][paramName]
                     except KeyError:
-                        return False, "Could not find `destination_port` parameter at {} on leg {}, got{}".format(
-                            activeUrl, i,
-                            response)
+                        return False, "Could not find `{}` parameter at {} on leg {}, got{}".format(
+                            paramName, activeUrl, i, response)
                     portNum = ports[portInst][i]
-                    msg = "Problem updating destination_port value in bulk update, expected {} got {}".format(portNum,
-                                                                                                              value)
+                    msg = "Problem updating {} value in bulk update, expected {} got {}".format(paramName, portNum,
+                                                                                                value)
                     if value == portNum:
                         pass
                     else:

--- a/IS0502Test.py
+++ b/IS0502Test.py
@@ -129,17 +129,16 @@ class IS0502Test(GenericTest):
     def activate_check_version(self, resource_type, resource_list):
         try:
             for is05_resource in resource_list:
-                if self.is05_resources["transport_types"][is05_resource] == "urn:x-nmos:transport:websocket":
-                    continue
                 found_04_resource = False
                 for is04_resource in self.is04_resources[resource_type]:
                     if is04_resource["id"] == is05_resource:
                         found_04_resource = True
                         current_ver = is04_resource["version"]
+                        transport_type = self.is05_resources["transport_types"][is05_resource]
 
                         method = self.is05_utils.check_perform_immediate_activation
                         valid, response = self.is05_utils.check_activation(resource_type.rstrip("s"), is05_resource,
-                                                                           method)
+                                                                           method, transport_type)
                         if not valid:
                             return False, response
 

--- a/IS05Utils.py
+++ b/IS05Utils.py
@@ -416,7 +416,7 @@ class IS05Utils(NMOSUtils):
             return self.generate_destination_ports(port, portId)
 
     def changeable_param_name(self, transportType):
-        """Identify the paramater name which will be used to change IS-05 configuration"""
+        """Identify the parameter name which will be used to change IS-05 configuration"""
         if transportType == "urn:x-nmos:transport:websocket":
             return "connection_uri"
         else:

--- a/IS05Utils.py
+++ b/IS05Utils.py
@@ -451,7 +451,7 @@ class IS05Utils(NMOSUtils):
         else:
             return False, constraints
 
-    def generate_ws_connection_uris(self, port, portId):
+    def generate_connection_uris(self, port, portId):
         """Generates a fake connection URI, or re-uses one from the advertised constraints"""
         url = "single/" + port + "s/" + portId + "/constraints/"
         valid, constraints = self.checkCleanRequestJSON("GET", url)

--- a/IS05Utils.py
+++ b/IS05Utils.py
@@ -20,7 +20,7 @@ import TestHelper
 
 from random import randint
 from NMOSUtils import NMOSUtils, IMMEDIATE_ACTIVATION, SCHEDULED_ABSOLUTE_ACTIVATION, SCHEDULED_RELATIVE_ACTIVATION
-from Config import API_PROCESSING_TIMEOUT
+from Config import API_PROCESSING_TIMEOUT, PORT_BASE, ENABLE_HTTPS
 
 
 class IS05Utils(NMOSUtils):
@@ -130,7 +130,7 @@ class IS05Utils(NMOSUtils):
             code = 202
         return self.checkCleanRequestJSON("PATCH", stagedUrl, data=data, code=code)
 
-    def check_perform_immediate_activation(self, port, portId, stagedParams):
+    def check_perform_immediate_activation(self, port, portId, stagedParams, changedParam):
         # Request an immediate activation
         stagedUrl = "single/" + port + "s/" + portId + "/staged"
         activeUrl = "single/" + port + "s/" + portId + "/active"
@@ -171,18 +171,18 @@ class IS05Utils(NMOSUtils):
                 if valid3:
                     for i in range(0, self.get_num_paths(portId, port)):
                         try:
-                            activePort = response3['transport_params'][i]['destination_port']
+                            activePort = response3['transport_params'][i][changedParam]
                         except KeyError:
-                            return False, "Could not find active destination_port entry on leg {} from {}, " \
-                                          "got {}".format(i, activeUrl, response3)
+                            return False, "Could not find active {} entry on leg {} from {}, " \
+                                          "got {}".format(changedParam, i, activeUrl, response3)
                         except TypeError:
                             return False, "Expected a dict to be returned from {} on leg {}, got a {}: {}".format(
                                 activeUrl, i, type(response3), response3)
                         try:
-                            stagedPort = stagedParams[i]['destination_port']
+                            stagedPort = stagedParams[i][changedParam]
                         except KeyError:
-                            return False, "Could not find staged destination_port entry on leg {} from {}, " \
-                                          "got {}".format(i, stagedUrl, stagedParams)
+                            return False, "Could not find staged {} entry on leg {} from {}, " \
+                                          "got {}".format(changedParam, i, stagedUrl, stagedParams)
                         except TypeError:
                             return False, "Expected a dict to be returned from {} on leg {}, got a {}: {}".format(
                                 stagedUrl, i, type(response3), stagedParams)
@@ -206,7 +206,7 @@ class IS05Utils(NMOSUtils):
             return False, response
         return True, ""
 
-    def check_perform_relative_activation(self, port, portId, stagedParams):
+    def check_perform_relative_activation(self, port, portId, stagedParams, changedParam):
         # Request an relative activation 2 nanoseconds in the future
         stagedUrl = "single/" + port + "s/" + portId + "/staged"
         activeUrl = "single/" + port + "s/" + portId + "/active"
@@ -247,18 +247,18 @@ class IS05Utils(NMOSUtils):
                 if valid2:
                     for i in range(0, self.get_num_paths(portId, port)):
                         try:
-                            activePort = activeParams['transport_params'][i]['destination_port']
+                            activePort = activeParams['transport_params'][i][changedParam]
                         except KeyError:
-                            return False, "Could not find active destination_port entry on leg {} from {}, " \
-                                          "got {}".format(i, activeUrl, activeParams)
+                            return False, "Could not find active {} entry on leg {} from {}, " \
+                                          "got {}".format(changedParam, i, activeUrl, activeParams)
                         except TypeError:
                             return False, "Expected a dict to be returned from {} on leg {}, " \
                                           "got a {}: {}".format(activeUrl, i, type(activeParams), activeParams)
                         try:
-                            stagedPort = stagedParams[i]['destination_port']
+                            stagedPort = stagedParams[i][changedParam]
                         except KeyError:
-                            return False, "Could not find staged destination_port entry on leg {} from {}, " \
-                                          "got {}".format(i, stagedUrl, stagedParams)
+                            return False, "Could not find staged {} entry on leg {} from {}, " \
+                                          "got {}".format(changedParam, i, stagedUrl, stagedParams)
                         except TypeError:
                             return False, "Expected a dict to be returned from {} on leg {}, " \
                                           "got a {}: {}".format(stagedUrl, i, type(activeParams), stagedParams)
@@ -288,7 +288,7 @@ class IS05Utils(NMOSUtils):
         else:
             return False, response
 
-    def check_perform_absolute_activation(self, port, portId, stagedParams):
+    def check_perform_absolute_activation(self, port, portId, stagedParams, changedParam):
         # request an absolute activation
         stagedUrl = "single/" + port + "s/" + portId + "/staged"
         activeUrl = "single/" + port + "s/" + portId + "/active"
@@ -340,18 +340,18 @@ class IS05Utils(NMOSUtils):
                 if valid2:
                     for i in range(0, self.get_num_paths(portId, port)):
                         try:
-                            activePort = activeParams['transport_params'][i]['destination_port']
+                            activePort = activeParams['transport_params'][i][changedParam]
                         except KeyError:
-                            return False, "Could not find active destination_port entry on leg {} from {}, " \
-                                          "got {}".format(i, activeUrl, activeParams)
+                            return False, "Could not find active {} entry on leg {} from {}, " \
+                                          "got {}".format(changedParam, i, activeUrl, activeParams)
                         except TypeError:
                             return False, "Expected a dict to be returned from {} on leg {}, got a {}: " \
                                           "{}".format(activeUrl, i, type(activeParams), activeParams)
                         try:
-                            stagedPort = stagedParams[i]['destination_port']
+                            stagedPort = stagedParams[i][changedParam]
                         except KeyError:
-                            return False, "Could not find staged destination_port entry on leg {} from {}, " \
-                                          "got {}".format(i, stagedUrl, stagedParams)
+                            return False, "Could not find staged {} entry on leg {} from {}, " \
+                                          "got {}".format(changedParam, i, stagedUrl, stagedParams)
                         except TypeError:
                             return False, "Expected a dict to be returned from {} on leg {}, got a {}: " \
                                           "{}".format(stagedUrl, i, type(activeParams), stagedParams)
@@ -380,16 +380,17 @@ class IS05Utils(NMOSUtils):
         else:
             return False, response
 
-    def check_activation(self, port, portId, activationMethod):
+    def check_activation(self, port, portId, activationMethod, transportType):
         """Checks that when an immediate activation is called staged parameters are moved
         to active and the activation is correctly displayed in the /active endpoint"""
         # Set a new destination port in staged
-        valid, destinationPort = self.generate_destination_ports(port, portId)
+        valid, paramValues = self.generate_changeable_param(port, portId, transportType)
+        paramName = self.changeable_param_name(transportType)
         if valid:
             stagedUrl = "single/" + port + "s/" + portId + "/staged"
             data = {"transport_params": []}
             for i in range(0, self.get_num_paths(portId, port)):
-                data['transport_params'].append({"destination_port": destinationPort[i]})
+                data['transport_params'].append({paramName: paramValues[i]})
             if len(data["transport_params"]) == 0:
                 del data["transport_params"]
             valid2, r = self.checkCleanRequestJSON("PATCH", stagedUrl, data=data)
@@ -401,11 +402,25 @@ class IS05Utils(NMOSUtils):
                 except TypeError:
                     return False, "Expected a dict to be returned from {}, got a {}".format(stagedUrl,
                                                                                             type(stagedParams))
-                return activationMethod(port, portId, stagedParams)
+                return activationMethod(port, portId, stagedParams, paramName)
             else:
                 return False, r
         else:
-            return False, destinationPort
+            return False, paramValues
+
+    def generate_changeable_param(self, port, portId, transportType):
+        """Use a port's constraints to generate a changeable parameter"""
+        if transportType == "urn:x-nmos:transport:websocket":
+            return self.generate_connection_uris(port, portId)
+        else:
+            return self.generate_destination_ports(port, portId)
+
+    def changeable_param_name(self, transportType):
+        """Identify the paramater name which will be used to change IS-05 configuration"""
+        if transportType == "urn:x-nmos:transport:websocket":
+            return "connection_uri"
+        else:
+            return "destination_port"
 
     def generate_destination_ports(self, port, portId):
         """Uses a port's constraints to generate an allowable destination
@@ -429,6 +444,29 @@ class IS05Utils(NMOSUtils):
                         else:
                             max = 49151
                         toReturn.append(randint(min, max))
+                return True, toReturn
+            except TypeError:
+                return False, "Expected a dict to be returned from {}, got a {}: {}".format(url, type(constraints),
+                                                                                            constraints)
+        else:
+            return False, constraints
+
+    def generate_ws_connection_uris(self, port, portId):
+        """Generates a fake connection URI, or re-uses one from the advertised constraints"""
+        url = "single/" + port + "s/" + portId + "/constraints/"
+        valid, constraints = self.checkCleanRequestJSON("GET", url)
+        if valid:
+            toReturn = []
+            try:
+                for entry in constraints:
+                    if "enum" in entry['connection_uri']:
+                        values = entry['connection_uri']['enum']
+                        toReturn.append(values[randint(0, len(values) - 1)])
+                    else:
+                        scheme = "ws"
+                        if ENABLE_HTTPS:
+                            scheme = "wss"
+                        toReturn.append("{}://{}:{}".format(scheme, TestHelper.get_default_ip(), PORT_BASE))
                 return True, toReturn
             except TypeError:
                 return False, "Expected a dict to be returned from {}, got a {}: {}".format(url, type(constraints),


### PR DESCRIPTION
This is intended to complete #152, but is as yet untested on a WebSocket implementation.

The hope is that for Senders where the 'connection_uri' is not changeable, this will be advertised via a single entry in an enum and will be staged/activated to the same value it was previously. For Receivers a fake 'connection_uri' is generated using the current IP and port of the testing tool.