### PR TITLE
dns: add watcher to DNS server to notify upon queries

### DIFF
--- a/Config.py
+++ b/Config.py
@@ -59,10 +59,6 @@ HTTP_TIMEOUT = 1
 # 0 = unlimited for a really thorough test!
 MAX_TEST_ITERATIONS = 0
 
-# Number of seconds to wait after selecting a test to run before carrying it out
-# Useful for unicast DNS testing where the device under test needs to restart in order to observe the new DNS records
-TEST_START_DELAY = 0
-
 # Test using HTTPS rather than HTTP as per AMWA BCP-003-01
 ENABLE_HTTPS = False
 

--- a/DNS.py
+++ b/DNS.py
@@ -15,9 +15,35 @@
 from dnslib.server import DNSServer
 from dnslib.zoneresolver import ZoneResolver
 from jinja2 import Template
+from threading import Event
 
 from TestHelper import get_default_ip
 from Config import DNS_DOMAIN, PORT_BASE
+
+
+class WatchingResolver(ZoneResolver):
+    def __init__(self, zone, glob=False):
+        ZoneResolver.__init__(self, zone, glob)
+        self.watching = {}
+
+    def wait_for_query(self, record_type, record_names, timeout):
+        wait_event = Event()
+        if record_type not in self.watching:
+            self.watching[record_type] = {}
+        for record_name in record_names:
+            self.watching[record_type][record_name] = wait_event
+        wait_event.wait(timeout)
+        for record_name in record_names:
+            self.watching[record_type][record_name] = None
+
+    def resolve(self, request, handler):
+        qtype = request.q.qtype
+        qname = str(request.q.qname)
+        try:
+            self.watching[qtype][qname].set()
+        except (KeyError, AttributeError):
+            pass
+        return ZoneResolver.resolve(self, request, handler)
 
 
 class DNS(object):
@@ -28,12 +54,15 @@ class DNS(object):
         self.base_zone_data = None
         self.reset()
 
+    def wait_for_query(self, record_type, record_name, timeout):
+        self.resolver.wait_for_query(record_type, record_name, timeout)
+
     def load_zone(self, api_version, api_protocol):
         zone_file = open("test_data/IS0401/dns_records.zone").read()
         template = Template(zone_file)
         zone_data = template.render(ip_address=self.default_ip, api_ver=api_version, api_proto=api_protocol,
                                     domain=DNS_DOMAIN, reg_port_base=PORT_BASE+100)
-        self.resolver = ZoneResolver(self.base_zone_data + zone_data)
+        self.resolver = WatchingResolver(self.base_zone_data + zone_data)
         self.stop()
         print(" * Loading DNS zone file with api_ver={}".format(api_version))
         self.start()
@@ -42,7 +71,7 @@ class DNS(object):
         zone_file = open("test_data/IS0401/dns_base.zone").read()
         template = Template(zone_file)
         self.base_zone_data = template.render(ip_address=self.default_ip, domain=DNS_DOMAIN)
-        self.resolver = ZoneResolver(self.base_zone_data)
+        self.resolver = WatchingResolver(self.base_zone_data)
         self.stop()
         print(" * Loading DNS zone base file")
         self.start()

--- a/GenericTest.py
+++ b/GenericTest.py
@@ -20,11 +20,10 @@ import TestHelper
 import traceback
 import inspect
 import uuid
-import time
 
 from Specification import Specification
 from TestResult import Test
-from Config import ENABLE_HTTPS, TEST_START_DELAY
+from Config import ENABLE_HTTPS
 
 
 NMOS_WIKI_URL = "https://github.com/AMWA-TV/nmos/wiki"
@@ -178,10 +177,6 @@ class GenericTest(object):
         test = Test("Test setup")
         self.set_up_tests()
         self.result.append(test.NA(""))
-
-        if TEST_START_DELAY > 0:
-            print(" * Waiting for {} seconds before executing tests".format(TEST_START_DELAY))
-        time.sleep(TEST_START_DELAY)
 
         # Run tests
         self.execute_tests(test_name)


### PR DESCRIPTION
Adds a watcher to the DNS server so that tests can proceed immediately upon a relevant query being received. This should remove the need for 'TEST_START_DELAY'.

Relates to #252 