### PR TITLE
Check presence of API under test before performing full test suite

### DIFF
--- a/GenericTest.py
+++ b/GenericTest.py
@@ -176,6 +176,12 @@ class GenericTest(object):
 
         # Set up
         test = Test("Test setup")
+        for api in self.apis:
+            if "spec_path" not in self.apis[api]:
+                continue
+            valid, response = self.do_request("GET", self.apis[api]["url"])
+            if not valid or response.status_code != 200:
+                raise NMOSInitException("No API found at {}".format(self.apis[api]["url"]))
         self.set_up_tests()
         self.result.append(test.NA(""))
 

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -364,6 +364,8 @@ def run_tests(test, endpoints, test_selection=["all"]):
         apis = {}
         tested_urls = []
         for index, spec in enumerate(test_def["specs"]):
+            if endpoints[index]["host"] == "" or endpoints[index]["port"] == "":
+                raise NMOSInitException("All IP/Hostname and Port fields must be completed.")
             base_url = "{}://{}:{}".format(protocol, endpoints[index]["host"], str(endpoints[index]["port"]))
             spec_key = spec["spec_key"]
             api_key = spec["api_key"]
@@ -372,15 +374,11 @@ def run_tests(test, endpoints, test_selection=["all"]):
                 ip_address = endpoints[index]["host"]
             except ValueError:
                 ip_address = socket.gethostbyname(endpoints[index]["host"])
-            try:
-                port = int(endpoints[index]["port"])
-            except ValueError:
-                raise NMOSInitException("Port is missing or is not an integer: {}".format(endpoints[index]["port"]))
             apis[api_key] = {
                 "base_url": base_url,
                 "hostname": endpoints[index]["host"],
                 "ip": ip_address,
-                "port": port,
+                "port": int(endpoints[index]["port"]),
                 "url": "{}/x-nmos/{}/{}/".format(base_url, api_key, endpoints[index]["version"]),
                 "version": endpoints[index]["version"],
                 "spec": None  # Used inside GenericTest

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -369,7 +369,7 @@ def run_tests(test, endpoints, test_selection=["all"]):
         tested_urls = []
         for index, spec in enumerate(test_def["specs"]):
             if endpoints[index]["host"] == "" or endpoints[index]["port"] == "":
-                raise NMOSInitException("All IP/Hostname and Port fields must be completed.")
+                raise NMOSInitException("All IP/Hostname and Port fields must be completed")
             base_url = "{}://{}:{}".format(protocol, endpoints[index]["host"], str(endpoints[index]["port"]))
             spec_key = spec["spec_key"]
             api_key = spec["api_key"]

--- a/nmos-test.py
+++ b/nmos-test.py
@@ -372,11 +372,15 @@ def run_tests(test, endpoints, test_selection=["all"]):
                 ip_address = endpoints[index]["host"]
             except ValueError:
                 ip_address = socket.gethostbyname(endpoints[index]["host"])
+            try:
+                port = int(endpoints[index]["port"])
+            except ValueError:
+                raise NMOSInitException("Port is missing or is not an integer: {}".format(endpoints[index]["port"]))
             apis[api_key] = {
                 "base_url": base_url,
                 "hostname": endpoints[index]["host"],
                 "ip": ip_address,
-                "port": int(endpoints[index]["port"]),
+                "port": port,
                 "url": "{}/x-nmos/{}/{}/".format(base_url, api_key, endpoints[index]["version"]),
                 "version": endpoints[index]["version"],
                 "spec": None  # Used inside GenericTest


### PR DESCRIPTION
Resolves #143 

This should avoid cases where the full set of results will come back as fails after a long wait.

Also includes a minor improvement to the message returned when a port is missing from the web form.