### PR TITLE
is0501: check SDP files change in line with transport_params

### DIFF
--- a/IS0501Test.py
+++ b/IS0501Test.py
@@ -260,10 +260,10 @@ class IS0501Test(GenericTest):
         if len(self.senders) > 0:
             for sender in self.senders:
                 if self.transport_types[sender] == "urn:x-nmos:transport:rtp":
-                    valid, response = self.is05_utils.check_sdp_matches_params(sender)
+                    valid, result = self.is05_utils.check_sdp_matches_params(sender)
                     if not valid:
                         return test.FAIL("SDP file for Sender {} does not match the transport_params: {}"
-                                         .format(sender, response))
+                                         .format(sender, result))
             return test.PASS()
         else:
             return test.UNCLEAR("Not tested. No resources found.")

--- a/IS0501Test.py
+++ b/IS0501Test.py
@@ -264,7 +264,7 @@ class IS0501Test(GenericTest):
                     if not valid:
                         return test.FAIL("SDP file for Sender {} does not match the transport_params: {}"
                                          .format(sender, response))
-                return test.PASS()
+            return test.PASS()
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 

--- a/IS0501Test.py
+++ b/IS0501Test.py
@@ -254,6 +254,20 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
+    def test_09_01(self, test):
+        """All params listed in /single/senders/{senderId}/active/ match their corresponding SDP files"""
+
+        if len(self.senders) > 0:
+            for sender in self.senders:
+                if self.transport_types[sender] == "urn:x-nmos:transport:rtp":
+                    valid, response = self.is05_utils.check_sdp_matches_params(sender)
+                    if not valid:
+                        return test.FAIL("SDP file for Sender {} does not match the transport_params: {}"
+                                         .format(sender, response))
+                return test.PASS()
+        else:
+            return test.UNCLEAR("Not tested. No resources found.")
+
     def test_10(self, test):
         """All params listed in /single/receivers/{receiverId}/constraints/ matches /staged/ and /active/"""
 
@@ -588,7 +602,11 @@ class IS0501Test(GenericTest):
                 valid, response = self.is05_utils.check_activation("sender", sender,
                                                                    self.is05_utils.check_perform_immediate_activation)
                 if valid:
-                    pass
+                    if self.transport_types[sender] == "urn:x-nmos:transport:rtp":
+                        valid2, response2 = self.is05_utils.check_sdp_matches_params(sender)
+                        if not valid2:
+                            return test.FAIL("SDP file for Sender {} does not match the transport_params: {}"
+                                             .format(sender, response2))
                 else:
                     return test.FAIL(response)
             return test.PASS()
@@ -623,7 +641,11 @@ class IS0501Test(GenericTest):
                 valid, response = self.is05_utils.check_activation("sender", sender,
                                                                    self.is05_utils.check_perform_relative_activation)
                 if valid:
-                    pass
+                    if self.transport_types[sender] == "urn:x-nmos:transport:rtp":
+                        valid2, response2 = self.is05_utils.check_sdp_matches_params(sender)
+                        if not valid2:
+                            return test.FAIL("SDP file for Sender {} does not match the transport_params: {}"
+                                             .format(sender, response2))
                 else:
                     return test.FAIL(response)
             return test.PASS(response)
@@ -657,7 +679,11 @@ class IS0501Test(GenericTest):
                 valid, response = self.is05_utils.check_activation("sender", sender,
                                                                    self.is05_utils.check_perform_absolute_activation)
                 if valid:
-                    pass
+                    if self.transport_types[sender] == "urn:x-nmos:transport:rtp":
+                        valid2, response2 = self.is05_utils.check_sdp_matches_params(sender)
+                        if not valid2:
+                            return test.FAIL("SDP file for Sender {} does not match the transport_params: {}"
+                                             .format(sender, response2))
                 else:
                     return test.FAIL(response)
             return test.PASS(response)

--- a/IS05Utils.py
+++ b/IS05Utils.py
@@ -568,7 +568,7 @@ class IS05Utils(NMOSUtils):
         a_valid, a_response = self.checkCleanRequestJSON("GET", aDest)
         sdp_valid, sdp_response = self.checkCleanRequest("GET", sdpDest)
         if a_valid:
-            if sdp_valid and sdp_response.status_code == 200:
+            if sdp_valid:
                 sdp_sections = sdp_response.text.split("m=")
                 sdp_global = sdp_sections[0]
                 sdp_media_sections = sdp_sections[1:]
@@ -598,10 +598,8 @@ class IS05Utils(NMOSUtils):
                     if filter_line and filter_line.group(2) != transport_params["source_ip"]:
                         return False, "SDP source-filter IP {} does not match transport_params: {}" \
                                       .format(filter_line.group(2), transport_params["source_ip"])
-            elif sdp_valid and sdp_response.status_code == 404:
-                return False, "SDP file could not be tested due to 404 response"
             else:
-                return False, sdp_response.text
+                return False, sdp_response
         else:
             return False, a_response
         return True, ""

--- a/IS05Utils.py
+++ b/IS05Utils.py
@@ -586,15 +586,15 @@ class IS05Utils(NMOSUtils):
                     return False, "SDP groups do not match the length of the 'transport_params' array"
                 for index, sdp_data in enumerate(tp_compare):
                     transport_params = a_response["transport_params"][index]
-                    media_line = re.search("m=([a-z]+) ([0-9]+) RTP/AVP ([0-9]+)", sdp_data)
+                    media_line = re.search(r"m=([a-z]+) ([0-9]+) RTP/AVP ([0-9]+)", sdp_data)
                     if media_line.group(2) != str(transport_params["destination_port"]):
                         return False, "SDP destination port {} does not match transport_params: {}" \
                                       .format(media_line.group(2), transport_params["destination_port"])
-                    connection_line = re.search("c=IN IP[4,6] (\S[^/]*)(/[0-9]+)?", sdp_data)
+                    connection_line = re.search(r"c=IN IP[4,6] (\S[^/]*)(/[0-9]+)?", sdp_data)
                     if connection_line.group(1) != transport_params["destination_ip"]:
                         return False, "SDP destination IP {} does not match transport_params: {}" \
                                       .format(connection_line.group(1), transport_params["destination_ip"])
-                    filter_line = re.search("a=source-filter: incl IN IP[4,6] (\S*) (\S*)", sdp_data)
+                    filter_line = re.search(r"a=source-filter: incl IN IP[4,6] (\S*) (\S*)", sdp_data)
                     if filter_line and filter_line.group(2) != transport_params["source_ip"]:
                         return False, "SDP source-filter IP {} does not match transport_params: {}" \
                                       .format(filter_line.group(2), transport_params["source_ip"])

--- a/IS05Utils.py
+++ b/IS05Utils.py
@@ -561,6 +561,49 @@ class IS05Utils(NMOSUtils):
                 return False, r_response
         return True, ""
 
+    def check_sdp_matches_params(self, portId):
+        """Checks that the SDP file for an RTP Sender matches the transport_params"""
+        aDest = "single/senders/" + portId + "/active/"
+        sdpDest = "single/senders/" + portId + "/transportfile/"
+        a_valid, a_response = self.checkCleanRequestJSON("GET", aDest)
+        sdp_valid, sdp_response = self.checkCleanRequest("GET", sdpDest)
+        if a_valid:
+            if sdp_valid:
+                sdp_sections = sdp_response.text.split("m=")
+                sdp_global = sdp_sections[0]
+                sdp_media_sections = sdp_sections[1:]
+                sdp_groups_line = re.search("^a=group:DUP", sdp_global)
+                tp_compare = []
+                if sdp_groups_line:
+                    sdp_group_names = sdp_groups_line.split()[1:]
+                    for sdp_media in sdp_media_sections:
+                        group_name = re.search("^a=mid:", sdp_media)
+                        if group_name.split()[1] in sdp_group_names:
+                            tp_compare.append("m=" + sdp_media)
+                else:
+                    tp_compare.append("m=" + sdp_media_sections[0])
+                if len(tp_compare) != len(a_response["transport_params"]):
+                    return False, "SDP groups do not match the length of the 'transport_params' array"
+                for index, sdp_data in enumerate(tp_compare):
+                    transport_params = a_response["transport_params"][index]
+                    media_line = re.search("m=([a-z]+) ([0-9]+) RTP/AVP ([0-9]+)", sdp_data)
+                    if media_line.group(2) != str(transport_params["destination_port"]):
+                        return False, "SDP destination port {} does not match transport_params: {}" \
+                                      .format(media_line.group(2), transport_params["destination_port"])
+                    connection_line = re.search("c=IN IP[4,6] (\S[^/]*)(/[0-9]+)?", sdp_data)
+                    if connection_line.group(1) != transport_params["destination_ip"]:
+                        return False, "SDP destination IP {} does not match transport_params: {}" \
+                                      .format(connection_line.group(1), transport_params["destination_ip"])
+                    filter_line = re.search("a=source-filter: incl IN IP[4,6] (\S*) (\S*)", sdp_data)
+                    if filter_line and filter_line.group(2) != transport_params["source_ip"]:
+                        return False, "SDP source-filter IP {} does not match transport_params: {}" \
+                                      .format(filter_line.group(2), transport_params["source_ip"])
+            else:
+                return False, sdp_response
+        else:
+            return False, a_response
+        return True, ""
+
     def get_senders(self):
         """Gets a list of the available senders on the API"""
         toReturn = []

--- a/IS05Utils.py
+++ b/IS05Utils.py
@@ -572,18 +572,18 @@ class IS05Utils(NMOSUtils):
                 sdp_sections = sdp_response.text.split("m=")
                 sdp_global = sdp_sections[0]
                 sdp_media_sections = sdp_sections[1:]
-                sdp_groups_line = re.search(r"a=group:DUP", sdp_global)
+                sdp_groups_line = re.search(r"a=group:DUP (.+)", sdp_global)
                 tp_compare = []
                 if sdp_groups_line:
-                    sdp_group_names = sdp_groups_line.split()[1:]
+                    sdp_group_names = sdp_groups_line.group(1).split()
                     for sdp_media in sdp_media_sections:
-                        group_name = re.search(r"a=mid:", sdp_media)
-                        if group_name.split()[1] in sdp_group_names:
+                        group_name = re.search(r"a=mid:(\S+)", sdp_media)
+                        if group_name.group(1) in sdp_group_names:
                             tp_compare.append("m=" + sdp_media)
                 else:
                     tp_compare.append("m=" + sdp_media_sections[0])
                 if len(tp_compare) != len(a_response["transport_params"]):
-                    return False, "SDP groups do not match the length of the 'transport_params' array"
+                    return False, "Number of SDP groups do not match the length of the 'transport_params' array"
                 for index, sdp_data in enumerate(tp_compare):
                     transport_params = a_response["transport_params"][index]
                     media_line = re.search(r"m=([a-z]+) ([0-9]+) RTP/AVP ([0-9]+)", sdp_data)


### PR DESCRIPTION
This is a starting point for #342 

In the absence of an obvious Python SDP parser (and without wanting to bring in all that comes with https://github.com/bbc/nmos-device-connection-management-ri/tree/master/nmosconnection) I've stuck to regexes for now, but we'll see how that goes.

At present this doesn't take account of the fact SDP files may be unavailable for disabled Senders.