### PR TITLE
ui: display descriptions alongside test names in selection box

### DIFF
--- a/nmos-test.py
+++ b/nmos-test.py
@@ -290,7 +290,8 @@ class DataForm(Form):
     for test_id in TEST_DEFINITIONS:
         test_data[test_id] = copy.deepcopy(TEST_DEFINITIONS[test_id])
         test_data[test_id].pop("class")
-        test_data[test_id]["tests"] = enumerate_tests(TEST_DEFINITIONS[test_id]["class"])
+        test_data[test_id]["test_methods"] = enumerate_tests(TEST_DEFINITIONS[test_id]["class"])
+        test_data[test_id]["test_descriptions"] = enumerate_tests(TEST_DEFINITIONS[test_id]["class"], describe=True)
 
     hidden_options = HiddenField(default=max_endpoints)
     hidden_tests = HiddenField(default=json.dumps(test_data))

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -34,8 +34,8 @@ function updateDropdown() {
     // Update the test selection dropdown
     var testDropdown = document.getElementById("test_selection");
     testDropdown.options.length = 0;
-    for (var i=0; i<testData["tests"].length; i++) {
-      testDropdown.options[i] = new Option(testData["tests"][i], testData["tests"][i]);
+    for (var i=0; i<testData["test_methods"].length; i++) {
+      testDropdown.options[i] = new Option(testData["test_descriptions"][i], testData["test_methods"][i]);
     }
 }
 


### PR DESCRIPTION
Requested by @bgilmer77 

This makes it possible to see test descriptions before picking them. The alternative would be to finish https://github.com/AMWA-TV/nmos-testing/issues/24, but there's only so much description you can get into 31 characters. I suspect that issue may become less relevant as a result and existing names in methods could be removed.