### PR TITLE
is05-sdp-check: Regex improvement

### DIFF
--- a/IS05Utils.py
+++ b/IS05Utils.py
@@ -628,7 +628,7 @@ class IS05Utils(NMOSUtils):
                     if media_line.group(2) != str(transport_params["destination_port"]):
                         return False, "SDP destination port {} does not match transport_params: {}" \
                                       .format(media_line.group(2), transport_params["destination_port"])
-                    connection_line = re.search(r"c=IN IP[4,6] (\S[^/]*)(/[0-9]+)?", sdp_data)
+                    connection_line = re.search(r"c=IN IP[4,6] ([^/\r\n]*)(?:/[0-9]+){0,2}", sdp_data)
                     if connection_line.group(1) != transport_params["destination_ip"]:
                         return False, "SDP destination IP {} does not match transport_params: {}" \
                                       .format(connection_line.group(1), transport_params["destination_ip"])


### PR DESCRIPTION
Suggesting this regex improvement regarding #375 .

Old: `c=IN IP[4,6] (\S[^/]*)(/[0-9]+)?`
New: `c=IN IP[4,6] ([^/\r\n]*)(?:/[0-9]+){0,2}`

Couple comments:
- Regex for Ipv4 _and_ Ipv6 can be as much as complicated as we want,.. but as we only want to compare the values, this very relaxed RE should do the job
- Not sure what the reason for the `\S` was in the initial RE
- `<TTL>` and `<number of addresses>` _may_ follow (or _must_ for multicast), but are not of interest, therefore non-capturing
