### PR TITLE
If the schema itself is faulty, log that in the console but don't let the SchemaError cause a FAIL

### DIFF
--- a/nmostesting/GenericTest.py
+++ b/nmostesting/GenericTest.py
@@ -309,8 +309,11 @@ class GenericTest(object):
         Validate the payload under the given schema.
         Raises an exception if the payload (or schema itself) is invalid
         """
-        checker = jsonschema.FormatChecker(["ipv4", "ipv6", "uri"])
-        jsonschema.validate(payload, schema, format_checker=checker)
+        try:
+            checker = jsonschema.FormatChecker(["ipv4", "ipv6", "uri"])
+            jsonschema.validate(payload, schema, format_checker=checker)
+        except jsonschema.exceptions.SchemaError as e:
+            print(" * ERROR: Schema is faulty so cannot be validated: {}".format(e))
 
     def do_request(self, method, url, **kwargs):
         return TestHelper.do_request(


### PR DESCRIPTION
Can't decide if this is a good idea or not?

Related to e.g. https://github.com/AMWA-TV/nmos-discovery-registration/pull/127