### PR TITLE
Add API route for automated testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ To execute a test for a remote API, the body of the POST request would look some
 }
 ```
 
+**NOTE**: Much like in non-interactive mode, the testing tool is currently limited to running a _single test suite at a time_.
+
 #### `/config`
 _[GET, PATCH]_
 
@@ -187,6 +189,13 @@ To change the testing tool from using HTTP to using HTTPS, the body of the reque
   "ENABLE_HTTPS": true
 }
 ```
+
+**NOTE**:
+- Changes to the `ENABLE_HTTPS` flag via the API will not configure the Testing Tool's Flask instances correctly for use with
+TLS. This specifically affects the IS-04 test suites. For changes to this parameter, it is advised the Config.py file is
+changed and the service restarted.
+- Changes to the `DNS_SD_MODE` parameter via the API to `unicast` will currently not work as expected. For changes to this
+parameter, it is advised the Config.py file is changed and the service restarted.
 
 ## External Dependencies
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ This is particularly useful for automated testing purposes. The two endpoints pr
 #### `/api`
 _[GET, POST]_
 
-This endpoint accepts (almost) identical inputs as the interactive command line utility, except hyphens (-) are replaced with underscores (\_) for key values.
+This endpoint accepts (almost) identical inputs as the non-interactive command line utility, except hyphens (-) are replaced with underscores (\_) for key values.
 
 - GET - Example page
 - POST - Perform a test for a remote host or list the set of test-suites / tests within a suite.
@@ -159,7 +159,7 @@ For a list of test suites, the body of the POST request would be:
 
 ```json
 {
-	"list_suites": true
+  "list_suites": true
 }
 ```
 
@@ -168,7 +168,7 @@ To execute a test for a remote API, the body of the POST request would look some
 ```json
 {
   "suite": "IS-05-01",
-  "host": ["127.0.0.1"],
+  "host": ["192.168.1.2"],
   "port": [80],
   "version": ["v1.0"]
 }

--- a/README.md
+++ b/README.md
@@ -140,6 +140,54 @@ python3 nmos-test.py -h
 python3 nmos-test.py suite -h
 ```
 
+### Using the API
+
+The testing tool comes with a minimal API for running tests remotely and configuring the testing tool instance dynamically.
+This is particularly useful for automated testing purposes. The two endpoints presented by the API are:
+- `/api` [GET, POST] - this is the primary endpoint for executing tests.
+- `/config` [GET, PATCH] - this endpoint returns the current config and allows dynamic configuration of the testing tool.
+
+#### `/api`
+_[GET, POST]_
+
+This endpoint accepts (almost) identical inputs as the interactive command line utility, except hyphens (-) are replaced with underscores (\_) for key values.
+
+- GET - Example page
+- POST - Perform a test for a remote host or list the set of test-suites / tests within a suite.
+
+For a list of test suites, the body of the POST request would be:
+
+```json
+{
+	"list_suites": true
+}
+```
+
+To execute a test for a remote API, the body of the POST request would look something like:
+
+```json
+{
+  "suite": "IS-05-01",
+  "host": ["127.0.0.1"],
+  "port": [80],
+  "version": ["v1.0"]
+}
+```
+
+#### `/config`
+_[GET, PATCH]_
+
+- GET - render the current loaded config.
+- PATCH - alter the running config.
+
+To change the testing tool from using HTTP to using HTTPS, the body of the request would be:
+
+```json
+{
+  "ENABLE_HTTPS": true
+}
+```
+
 ## External Dependencies
 
 *   Python 3

--- a/nmostesting/CRL.py
+++ b/nmostesting/CRL.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 from flask import Blueprint, make_response
-from .Config import PORT_BASE
+from . import Config as CONFIG
 
 
 class CRLDistributionPoint(object):
     def __init__(self):
-        self.port = PORT_BASE + 7  # cf. test_data/BCP00301/ca/intermediate/openssl.cnf
+        self.port = CONFIG.PORT_BASE + 7  # cf. test_data/BCP00301/ca/intermediate/openssl.cnf
 
 
 CRL = CRLDistributionPoint()

--- a/nmostesting/DNS.py
+++ b/nmostesting/DNS.py
@@ -18,7 +18,7 @@ from jinja2 import Template
 from threading import Event
 
 from .TestHelper import get_default_ip
-from .Config import DNS_DOMAIN, PORT_BASE
+from . import Config as CONFIG
 
 
 class WatchingResolver(ZoneResolver):
@@ -61,7 +61,7 @@ class DNS(object):
         zone_file = open("test_data/IS0401/dns_records.zone").read()
         template = Template(zone_file)
         zone_data = template.render(ip_address=self.default_ip, api_ver=api_version, api_proto=api_protocol,
-                                    domain=DNS_DOMAIN, reg_port_base=PORT_BASE+100)
+                                    domain=CONFIG.DNS_DOMAIN, reg_port_base=CONFIG.PORT_BASE + 100)
         self.resolver = WatchingResolver(self.base_zone_data + zone_data)
         self.stop()
         print(" * Loading DNS zone file with api_ver={}".format(api_version))
@@ -70,7 +70,7 @@ class DNS(object):
     def reset(self):
         zone_file = open("test_data/IS0401/dns_base.zone").read()
         template = Template(zone_file)
-        self.base_zone_data = template.render(ip_address=self.default_ip, domain=DNS_DOMAIN)
+        self.base_zone_data = template.render(ip_address=self.default_ip, domain=CONFIG.DNS_DOMAIN)
         self.resolver = WatchingResolver(self.base_zone_data)
         self.stop()
         print(" * Loading DNS zone base file")

--- a/nmostesting/GenericTest.py
+++ b/nmostesting/GenericTest.py
@@ -109,9 +109,8 @@ class GenericTest(object):
         for api in self.apis:
             if "spec_path" not in self.apis[api]:
                 continue
-            self.apis[api]["spec"] = Specification(
-                os.path.join(self.apis[api]["spec_path"] + '/APIs/' + self.apis[api]["raml"])
-            )
+            raml_path = os.path.join(self.apis[api]["spec_path"] + '/APIs/' + self.apis[api]["raml"])
+            self.apis[api]["spec"] = Specification(raml_path)
 
     def execute_tests(self, test_names):
         """Perform tests defined within this class"""
@@ -314,9 +313,7 @@ class GenericTest(object):
         jsonschema.validate(payload, schema, format_checker=checker)
 
     def do_request(self, method, url, **kwargs):
-        return TestHelper.do_request(
-            method=method, url=url, **kwargs
-        )
+        return TestHelper.do_request(method=method, url=url, **kwargs)
 
     def basics(self):
         """Perform basic API read requests (GET etc.) relevant to all API definitions"""

--- a/nmostesting/GenericTest.py
+++ b/nmostesting/GenericTest.py
@@ -23,7 +23,7 @@ import uuid
 from . import TestHelper
 from .Specification import Specification
 from .TestResult import Test
-from .Config import ENABLE_HTTPS
+from . import Config as CONFIG
 
 
 NMOS_WIKI_URL = "https://github.com/AMWA-TV/nmos/wiki"
@@ -66,7 +66,7 @@ class GenericTest(object):
         self.result = list()
         self.protocol = "http"
         self.ws_protocol = "ws"
-        if ENABLE_HTTPS:
+        if CONFIG.ENABLE_HTTPS:
             self.protocol = "https"
             self.ws_protocol = "wss"
 

--- a/nmostesting/GenericTest.py
+++ b/nmostesting/GenericTest.py
@@ -109,8 +109,9 @@ class GenericTest(object):
         for api in self.apis:
             if "spec_path" not in self.apis[api]:
                 continue
-            self.apis[api]["spec"] = Specification(os.path.join(self.apis[api]["spec_path"] + '/APIs/' +
-                                                                self.apis[api]["raml"]))
+            self.apis[api]["spec"] = Specification(
+                os.path.join(self.apis[api]["spec_path"] + '/APIs/' + self.apis[api]["raml"])
+            )
 
     def execute_tests(self, test_names):
         """Perform tests defined within this class"""

--- a/nmostesting/IS05Utils.py
+++ b/nmostesting/IS05Utils.py
@@ -20,7 +20,7 @@ import time
 from random import randint
 from . import TestHelper
 from .NMOSUtils import NMOSUtils, IMMEDIATE_ACTIVATION, SCHEDULED_ABSOLUTE_ACTIVATION, SCHEDULED_RELATIVE_ACTIVATION
-from .Config import API_PROCESSING_TIMEOUT, PORT_BASE, ENABLE_HTTPS
+from . import Config as CONFIG
 
 
 class IS05Utils(NMOSUtils):
@@ -262,7 +262,7 @@ class IS05Utils(NMOSUtils):
                             finished = True
                         else:
                             retries = retries + 1
-                            time.sleep(API_PROCESSING_TIMEOUT)
+                            time.sleep(CONFIG.API_PROCESSING_TIMEOUT)
 
                     if finished:
                         try:
@@ -355,7 +355,7 @@ class IS05Utils(NMOSUtils):
                             finished = True
                         else:
                             retries = retries + 1
-                            time.sleep(API_PROCESSING_TIMEOUT)
+                            time.sleep(CONFIG.API_PROCESSING_TIMEOUT)
 
                     if finished:
                         try:
@@ -467,9 +467,9 @@ class IS05Utils(NMOSUtils):
                         toReturn.append(values[randint(0, len(values) - 1)])
                     else:
                         scheme = "ws"
-                        if ENABLE_HTTPS:
+                        if CONFIG.ENABLE_HTTPS:
                             scheme = "wss"
-                        toReturn.append("{}://{}:{}".format(scheme, TestHelper.get_default_ip(), PORT_BASE))
+                        toReturn.append("{}://{}:{}".format(scheme, TestHelper.get_default_ip(), CONFIG.PORT_BASE))
                 return True, toReturn
             except TypeError:
                 return False, "Expected a dict to be returned from {}, got a {}: {}".format(url, type(constraints),

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -787,7 +787,8 @@ def run_api_tests(args, data_format):
         endpoints.append({"host": args.host[i], "port": args.port[i], "version": args.version[i]})
     results = run_tests(args.suite, endpoints, [args.selection])
     if data_format == "xml":
-        return format_test_results(results, endpoints, "junit", args)
+        test_suite = format_test_results(results, endpoints, "junit", args)
+        return TestSuite.to_xml_string([test_suite], prettyprint=True)
     else:
         return format_test_results(results, endpoints, "json", args)
 

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -399,7 +399,8 @@ def run_tests(test, endpoints, test_selection=["all"]):
                 "spec": None  # Used inside GenericTest
             }
             tested_urls.append(apis[api_key]["url"])
-            if CONFIG.SPECIFICATIONS[spec_key]["repo"] is not None and api_key in CONFIG.SPECIFICATIONS[spec_key]["apis"]:
+            if CONFIG.SPECIFICATIONS[spec_key]["repo"] is not None \
+                    and api_key in CONFIG.SPECIFICATIONS[spec_key]["apis"]:
                 apis[api_key]["name"] = CONFIG.SPECIFICATIONS[spec_key]["apis"][api_key]["name"]
                 apis[api_key]["spec_path"] = CONFIG.CACHE_PATH + '/' + spec_key
                 apis[api_key]["raml"] = CONFIG.SPECIFICATIONS[spec_key]["apis"][api_key]["raml"]
@@ -764,6 +765,8 @@ class ExitCodes(IntEnum):
 
 @core_app.route('/api', methods=["GET", "POST"])
 def api():
+    if request.method == "GET":
+        return jsonify("This is the NMOS Testing API"), 200
     if not request.is_json:
         return jsonify("Error: Request mimetype is not set to a JSON specific type with a valid JSON Body"), 400
     if not request.get_json(silent=True):

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -637,8 +637,8 @@ def validate_args(args, access_type="cli"):
             for test_description in tests:
                 msg += test_description + '\n'
         elif getattr(args, "selection", "all") not in enumerate_tests(TEST_DEFINITIONS[args.suite]["class"]):
-            msg = "ERROR: Test with name '{}' does not exist in test suite '{}'".format(
-                args.selection, args.suite)
+            msg = "ERROR: Test with name '{}' does not exist in test suite '{}'".format(args.selection,
+                                                                                        args.suite)
             return_type = ExitCodes.ERROR
         elif not args.host or not args.port or not args.version:
             msg = "ERROR: No Hostname(s)/IP address(es) or Port(s) or Version(s) specified"

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -779,7 +779,9 @@ def api():
             return jsonify(return_message.split('\n')), 200
         else:
             return jsonify(return_message), 400
-    data_format = request.args.get("format", "json")
+    data_format = request_args.get("output") if request_args.get("output") is not None else "json"
+    if "." in data_format:
+        filename, data_format = data_format.split(".")
     try:
         results = run_api_tests(request_args, data_format)
         if data_format == "json":

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -662,7 +662,6 @@ def validate_args(args, access_type="cli"):
 
 def arg_return(access_type, return_type="ok", msg=""):
     if access_type == "http":
-        msg.split('\n')
         return msg, return_type
     elif msg:
         print(msg)
@@ -768,7 +767,7 @@ def api():
     if not request.is_json:
         return "Error: Request mimetype is not set to a JSON specific type with a valid JSON Body", 400
     if not request.get_json(silent=True):
-        return "Ensure the body of the request is valid JSON", 400
+        return "Error: Ensure the body of the request is valid JSON and non-empty", 400
     request_data = dict(DEFAULT_ARGS, **request.json)
     request_args = SimpleNamespace(**request_data)
     return_message, return_type = validate_args(request_args, access_type="http")

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -779,7 +779,7 @@ def api():
             return jsonify(return_message.split('\n')), 200
         else:
             return jsonify(return_message), 400
-    data_format = request_args.get("output") if request_args.get("output") is not None else "json"
+    data_format = request_args.output if request_args.output is not None else "json"
     if "." in data_format:
         filename, data_format = data_format.split(".")
     try:
@@ -794,11 +794,11 @@ def api():
         return results, 400
 
 
-@core_app.route('/config', methods=["GET", "PUT"])
+@core_app.route('/config', methods=["GET", "PATCH"])
 def config():
     if request.method == "GET":
         return jsonify(_export_config())
-    elif request.method == "PUT":
+    elif request.method == "PATCH":
         try:
             if not request.is_json:
                 return jsonify("Error: Request mimetype is not set to a JSON specific type with a valid JSON Body"), 400

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -768,11 +768,11 @@ def api():
     if request.method == "GET":
         example_dict = {}
         example_dict["description"] = "An example of the body to POST to this endpoint might include:"
-        example_dict["suite"] = list(TEST_DEFINITIONS.keys())
+        example_dict["suite"] = "IS-04-01"
         example_dict["host"] = ["127.0.0.1"]
         example_dict["port"] = [80]
         example_dict["version"] = ["v1.2"]
-        example_dict["output"] = "json / xml"
+        example_dict["output"] = "xml"
         example_dict["ignore"] = ["test_23"]
         return jsonify(example_dict), 200
     if not request.is_json:

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -740,7 +740,7 @@ def check_internal_requirements():
                 corrected_req = corrections[requirement_name]
             else:
                 corrected_req = requirement_name.replace("-", "_")
-            if corrected_req not in installed_pkgs:
+            if corrected_req.split(">")[0] not in installed_pkgs:
                 print(" * ERROR: Could not find Python requirement '{}'".format(requirement_name))
                 sys.exit(ExitCodes.ERROR)
 
@@ -766,7 +766,15 @@ class ExitCodes(IntEnum):
 @core_app.route('/api', methods=["GET", "POST"])
 def api():
     if request.method == "GET":
-        return jsonify("This is the NMOS Testing API"), 200
+        example_dict = {}
+        example_dict["description"] = "An example of the body to POST to this endpoint might include:"
+        example_dict["suite"] = list(TEST_DEFINITIONS.keys())
+        example_dict["host"] = ["127.0.0.1"]
+        example_dict["port"] = [80]
+        example_dict["version"] = ["v1.2"]
+        example_dict["output"] = "json / xml"
+        example_dict["ignore"] = ["test_23"]
+        return jsonify(example_dict), 200
     if not request.is_json:
         return jsonify("Error: Request mimetype is not set to a JSON specific type with a valid JSON Body"), 400
     if not request.get_json(silent=True):

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -789,6 +789,26 @@ def api():
         return results, 400
 
 
+@core_app.route('/config', methods=["GET", "PUT"])
+def config():
+    if request.method == "GET":
+        return jsonify(_export_config())
+    elif request.method == "PUT":
+        try:
+            if not request.is_json:
+                return jsonify("Error: Request mimetype is not set to a JSON specific type with a valid JSON Body"), 400
+            if not request.get_json(silent=True):
+                return jsonify("Error: Ensure the body of the request is valid JSON and non-empty"), 400
+            request_data = request.json
+            if not isinstance(request_data, dict):
+                return jsonify("Error: Body must be of type object/dict"), 400
+            for config_param in request_data:
+                setattr(CONFIG, config_param, request_data[config_param])
+            return jsonify(_export_config()), 200
+        except Exception:
+            return jsonify("Error: Config Update Failed"), 400
+
+
 def run_api_tests(args, data_format):
     endpoints = []
     for i in range(len(args.host)):

--- a/nmostesting/NMOSUtils.py
+++ b/nmostesting/NMOSUtils.py
@@ -57,6 +57,19 @@ UTC_LEAP = [
     (63072000, 63072009),  # 1 Jan 1972, 10 leap seconds
 ]
 
+DEFAULT_ARGS = {
+    "list_suites": False,
+    "describe_suites": False,
+    "list_tests": False,
+    "describe_tests": False,
+    "host": [],
+    "port": [],
+    "version": [],
+    "ignore": [],
+    "output": None,
+    "selection": "all"
+}
+
 IMMEDIATE_ACTIVATION = 'activate_immediate'
 SCHEDULED_ABSOLUTE_ACTIVATION = 'activate_scheduled_absolute'
 SCHEDULED_RELATIVE_ACTIVATION = 'activate_scheduled_relative'

--- a/nmostesting/NMOSUtils.py
+++ b/nmostesting/NMOSUtils.py
@@ -17,7 +17,7 @@ import functools
 from urllib.parse import urlparse
 from random import sample
 
-from .Config import MAX_TEST_ITERATIONS
+from . import Config as CONFIG
 
 # The UTC leap seconds table below was extracted from the information provided at
 # http://www.ietf.org/timezones/data/leap-seconds.list
@@ -160,8 +160,8 @@ class NMOSUtils(object):
         return True
 
     def sampled_list(self, resource_list):
-        if MAX_TEST_ITERATIONS > 0:
-            return sample(resource_list, min(MAX_TEST_ITERATIONS, len(resource_list)))
+        if CONFIG.MAX_TEST_ITERATIONS > 0:
+            return sample(resource_list, min(CONFIG.MAX_TEST_ITERATIONS, len(resource_list)))
         else:
             return resource_list
 

--- a/nmostesting/OCSP.py
+++ b/nmostesting/OCSP.py
@@ -15,12 +15,12 @@
 import subprocess
 
 from flask import Blueprint, make_response, request, abort
-from .Config import PORT_BASE
+from . import Config as CONFIG
 
 
 class OCSPDistributionPoint(object):
     def __init__(self):
-        self.port = PORT_BASE + 8  # cf. test_data/BCP00301/ca/intermediate/openssl.cnf
+        self.port = CONFIG.PORT_BASE + 8  # cf. test_data/BCP00301/ca/intermediate/openssl.cnf
 
 
 OCSP = OCSPDistributionPoint()

--- a/nmostesting/Specification.py
+++ b/nmostesting/Specification.py
@@ -18,7 +18,6 @@ import ramlfications
 from .Patches import _parse_json
 from .TestHelper import load_resolved_schema
 
-
 try:
     # Patch ramlfications for Windows support
     ramlfications.loader.RAMLLoader._parse_json = _parse_json

--- a/nmostesting/suites/BCP00301Test.py
+++ b/nmostesting/suites/BCP00301Test.py
@@ -46,24 +46,18 @@ class BCP00301Test(GenericTest):
             return self.report_json[arg_key]
         else:
             try:
-                ret = subprocess.run(
-                    [
-                        "testssl/testssl.sh",
-                        "--jsonfile",
-                        TMPFILE,
-                        "--warnings",
-                        "off",
-                        "--openssl-timeout",
-                        str(CONFIG.HTTP_TIMEOUT),
-                        "--add-ca",
-                        CONFIG.CERT_TRUST_ROOT_CA
-                    ] + args + [
-                        "{}:{}".format(
-                            self.apis[BCP_API_KEY]["hostname"],
-                            self.apis[BCP_API_KEY]["port"]
-                        )
-                    ]
-                )
+                ret = subprocess.run(["testssl/testssl.sh",
+                                      "--jsonfile",
+                                      TMPFILE,
+                                      "--warnings",
+                                      "off",
+                                      "--openssl-timeout",
+                                      str(CONFIG.HTTP_TIMEOUT),
+                                      "--add-ca",
+                                      CONFIG.CERT_TRUST_ROOT_CA
+                                      ] + args + ["{}:{}".format(self.apis[BCP_API_KEY]["hostname"],
+                                                                 self.apis[BCP_API_KEY]["port"])]
+                                     )
                 if ret.returncode == 0:
                     with open(TMPFILE) as tls_data:
                         self.report_json[arg_key] = json.load(tls_data)

--- a/nmostesting/suites/IS0403Test.py
+++ b/nmostesting/suites/IS0403Test.py
@@ -19,7 +19,7 @@ from zeroconf_monkey import ServiceBrowser, Zeroconf
 from ..MdnsListener import MdnsListener
 from ..GenericTest import GenericTest, NMOS_WIKI_URL
 from ..IS04Utils import IS04Utils
-from ..Config import DNS_SD_BROWSE_TIMEOUT
+from .. import Config as CONFIG
 
 NODE_API_KEY = "node"
 
@@ -47,7 +47,7 @@ class IS0403Test(GenericTest):
         in the absence of a Registration API"""
 
         ServiceBrowser(self.zc, "_nmos-node._tcp.local.", self.zc_listener)
-        time.sleep(DNS_SD_BROWSE_TIMEOUT)
+        time.sleep(CONFIG.DNS_SD_BROWSE_TIMEOUT)
         node_list = self.zc_listener.get_service_list()
         for node in node_list:
             address = socket.inet_ntoa(node.address)

--- a/nmostesting/suites/IS0501Test.py
+++ b/nmostesting/suites/IS0501Test.py
@@ -1093,10 +1093,8 @@ class IS0501Test(GenericTest):
                 except FileNotFoundError:
                     schema = load_resolved_schema(self.apis[CONN_API_KEY]["spec_path"],
                                                   "v1.0_" + port + file_suffix)
-                constraints_valid, constraints_response = self.is05_utils.checkCleanRequestJSON(
-                    "GET",
-                    "single/" + port + "s/" + myPort + "/constraints/"
-                )
+                url = "single/" + port + "s/" + myPort + "/constraints/"
+                constraints_valid, constraints_response = self.is05_utils.checkCleanRequestJSON("GET", url)
 
                 if constraints_valid:
                     count = 0

--- a/nmostesting/suites/IS0501Test.py
+++ b/nmostesting/suites/IS0501Test.py
@@ -1086,16 +1086,18 @@ class IS0501Test(GenericTest):
                     schema_items = load_resolved_schema(self.apis[CONN_API_KEY]["spec_path"],
                                                         port + file_suffix)
                     schema = {
-                      "$schema": "http://json-schema.org/draft-04/schema#",
-                      "type": "array",
-                      "items": schema_items
+                        "$schema": "http://json-schema.org/draft-04/schema#",
+                        "type": "array",
+                        "items": schema_items
                     }
                 except FileNotFoundError:
                     schema = load_resolved_schema(self.apis[CONN_API_KEY]["spec_path"],
                                                   "v1.0_" + port + file_suffix)
-                constraints_valid, constraints_response = self.is05_utils.checkCleanRequestJSON("GET", "single/" +
-                                                                                                port + "s/" + myPort +
-                                                                                                "/constraints/")
+                constraints_valid, constraints_response = self.is05_utils.checkCleanRequestJSON(
+                    "GET",
+                    "single/" + port + "s/" + myPort + "/constraints/"
+                )
+
                 if constraints_valid:
                     count = 0
                     try:

--- a/nmostesting/suites/IS0502Test.py
+++ b/nmostesting/suites/IS0502Test.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from requests.compat import json
 import time
 import uuid
+from requests.compat import json
 
 from ..GenericTest import GenericTest
 from ..IS05Utils import IS05Utils
-from ..Config import API_PROCESSING_TIMEOUT
+from .. import Config as CONFIG
 
 NODE_API_KEY = "node"
 CONN_API_KEY = "connection"
@@ -142,7 +142,7 @@ class IS0502Test(GenericTest):
                         if not valid:
                             return False, response
 
-                        time.sleep(API_PROCESSING_TIMEOUT)
+                        time.sleep(CONFIG.API_PROCESSING_TIMEOUT)
 
                         valid, response = self.do_request("GET", self.node_url + resource_type + "/" + is05_resource)
                         if not valid:
@@ -170,7 +170,7 @@ class IS0502Test(GenericTest):
             if not valid:
                 return False, response
 
-        time.sleep(API_PROCESSING_TIMEOUT)
+        time.sleep(CONFIG.API_PROCESSING_TIMEOUT)
 
         valid, result = self.refresh_is04_resources(resource_type)
         if not valid:
@@ -222,7 +222,7 @@ class IS0502Test(GenericTest):
             if not valid:
                 return False, response
 
-        time.sleep(API_PROCESSING_TIMEOUT)
+        time.sleep(CONFIG.API_PROCESSING_TIMEOUT)
 
         valid, result = self.refresh_is04_resources(resource_type)
         if not valid:
@@ -543,8 +543,9 @@ class IS0502Test(GenericTest):
                         continue
 
                     bindings_length = len(resource["interface_bindings"])
-                    valid, result = self.do_request("GET", self.connection_url + "single/" + resource_type + "/" +
-                                                    resource["id"] + "/active")
+                    valid, result = self.do_request(
+                        "GET",
+                        self.connection_url + "single/" + resource_type + "/" + resource["id"] + "/active")
                     if not valid:
                         return test.FAIL("Connection API returned unexpected result "
                                          "for {} '{}'".format(resource_type.capitalize(), resource["id"]))
@@ -581,8 +582,10 @@ class IS0502Test(GenericTest):
                     if valid and result.status_code != 404:
                         is04_transport_file = result.text
 
-                valid, result = self.do_request("GET", self.connection_url + "single/senders/" +
-                                                resource["id"] + "/transportfile")
+                valid, result = self.do_request(
+                    "GET",
+                    self.connection_url + "single/senders/" + resource["id"] + "/transportfile"
+                )
                 if valid and result.status_code != 404:
                     is05_transport_file = result.text
 

--- a/nmostesting/suites/IS0502Test.py
+++ b/nmostesting/suites/IS0502Test.py
@@ -543,9 +543,8 @@ class IS0502Test(GenericTest):
                         continue
 
                     bindings_length = len(resource["interface_bindings"])
-                    valid, result = self.do_request(
-                        "GET",
-                        self.connection_url + "single/" + resource_type + "/" + resource["id"] + "/active")
+                    url_path = self.connection_url + "single/" + resource_type + "/" + resource["id"] + "/active"
+                    valid, result = self.do_request("GET", url_path)
                     if not valid:
                         return test.FAIL("Connection API returned unexpected result "
                                          "for {} '{}'".format(resource_type.capitalize(), resource["id"]))
@@ -581,11 +580,8 @@ class IS0502Test(GenericTest):
                     valid, result = self.do_request("GET", resource["manifest_href"])
                     if valid and result.status_code != 404:
                         is04_transport_file = result.text
-
-                valid, result = self.do_request(
-                    "GET",
-                    self.connection_url + "single/senders/" + resource["id"] + "/transportfile"
-                )
+                url_path = self.connection_url + "single/senders/" + resource["id"] + "/transportfile"
+                valid, result = self.do_request("GET", url_path)
                 if valid and result.status_code != 404:
                     is05_transport_file = result.text
 

--- a/nmostesting/suites/IS0801Test.py
+++ b/nmostesting/suites/IS0801Test.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+import copy
+
 from ..GenericTest import GenericTest, NMOSTestException
 from ..TestHelper import compare_json
 from ..NMOSUtils import NMOSUtils, SCHEDULED_ABSOLUTE_ACTIVATION, SCHEDULED_RELATIVE_ACTIVATION
@@ -22,8 +25,7 @@ from .is08.outputs import getOutputList
 from .is08.active import Active
 from .is08.io import IO
 from .is08.testConfig import globalConfig
-import time
-import copy
+
 
 MAPPING_API_KEY = "channelmapping"
 

--- a/nmostesting/suites/IS0802Test.py
+++ b/nmostesting/suites/IS0802Test.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 
+from requests.compat import json
+
 from ..GenericTest import GenericTest
 from .is08.testConfig import globalConfig
 from .is08.activation import Activation
 from .is08.outputs import getOutputList
 from .is08.inputs import getInputList
 from ..NMOSUtils import NMOSUtils
-from requests.compat import json
 
 MAPPING_API_KEY = "channelmapping"
 NODE_API_KEY = "node"

--- a/nmostesting/suites/IS1001Test.py
+++ b/nmostesting/suites/IS1001Test.py
@@ -86,9 +86,8 @@ class IS1001Test(GenericTest):
             password = self.client_data["client_secret"]
         else:
             username = password = None
-        return self.do_request(
-            method=method, url=self.url + url_path, data=data, auth=(username, password), params=params
-        )
+        return self.do_request(method=method, url=self.url + url_path,
+                               data=data, auth=(username, password), params=params)
 
     def _post_to_authorize_endpoint(self, data, parameters, auth="user"):
         """Post to /authorize endpoint, not allowing redirects to be automatically followed"""
@@ -100,14 +99,8 @@ class IS1001Test(GenericTest):
             password = self.client_data["client_secret"]
         else:
             username = password = None
-        return requests.post(
-            url=self.url + 'authorize',
-            data=data,
-            params=parameters,
-            allow_redirects=False,
-            auth=(username, password),
-            verify=CONFIG.CERT_TRUST_ROOT_CA
-        )
+        return requests.post(url=self.url + 'authorize', data=data, params=parameters,
+                             allow_redirects=False, auth=(username, password), verify=CONFIG.CERT_TRUST_ROOT_CA)
 
     def _raise_nmos_exception(self, test, response, string=''):
         """Raise NMOS Exception with HTTP Response Information"""
@@ -132,8 +125,7 @@ class IS1001Test(GenericTest):
 
         elif isinstance(response, str):
             raise NMOSTestException(test.FAIL(
-                "Request to Auth Server failed due to: {}".format(response)
-            ))
+                "Request to Auth Server failed due to: {}".format(response)))
 
         if response.status_code != expected_status:
             self._raise_nmos_exception(test, response, "Expected status_code: {}".format(expected_status))
@@ -172,25 +164,21 @@ class IS1001Test(GenericTest):
 
         if redirect_uri != input_params["redirect_uri"]:
             raise NMOSTestException(test.FAIL(
-                "Expected {} but got {}".format(input_params["redirect_uri"], redirect_uri)
-            ))
+                "Expected {} but got {}".format(input_params["redirect_uri"], redirect_uri)))
 
         if state != input_params["state"]:
             raise NMOSTestException(test.FAIL(
-                "Expected {} but got {}".format(input_params["state"], state)
-            ))
+                "Expected {} but got {}".format(input_params["state"], state)))
 
         if query_key != "code":
             if expected_query_value is None:
                 if actual_query_value != input_params[query_key]:
                     raise NMOSTestException(test.FAIL(
-                        "Expected {} but got {}".format(input_params[query_key], actual_query_value)
-                    ))
+                        "Expected {} but got {}".format(input_params[query_key], actual_query_value)))
             else:
                 if actual_query_value != expected_query_value:
                     raise NMOSTestException(test.FAIL(
-                        "Expected {} but got {}".format(expected_query_value, actual_query_value)
-                    ))
+                        "Expected {} but got {}".format(expected_query_value, actual_query_value)))
         else:
             return actual_query_value
 
@@ -215,9 +203,8 @@ class IS1001Test(GenericTest):
                     if priority < 0:
                         return test.FAIL("Priority ('pri') TXT record must be greater than zero.")
                     elif priority >= 100:
-                        return test.WARNING("""
-                            Priority ('pri') TXT record must be less than 100 for a production instance.
-                        """)
+                        return test.WARNING(
+                            "Priority ('pri') TXT record must be less than 100 for a production instance.")
                 except Exception:
                     return test.FAIL("Priority ('pri') TXT record is not an integer.")
 
@@ -225,14 +212,11 @@ class IS1001Test(GenericTest):
                     return test.FAIL("No 'api_ver' TXT record found in {} advertisement.".format(api["name"]))
                 elif api["version"] not in properties["api_ver"].split(","):
                     return test.FAIL("Auth Server does not claim to support version under test.")
-
                 if "api_proto" not in properties:
                     return test.FAIL("No 'api_proto' TXT record found in {} advertisement.".format(api["name"]))
                 elif properties["api_proto"] != "https":
-                    return test.FAIL("""
-                        API protocol ('api_proto') TXT record is {} and not 'https'
-                    """.format(properties["api_proto"]))
-
+                    return test.FAIL("API protocol ('api_proto') TXT record is {} and not 'https'".format(
+                        properties["api_proto"]))
                 return test.PASS()
         return test.FAIL("No matching mDNS announcement found for {} with IP/Port {}:{}."
                          .format(api["name"], api["ip"], api["port"]))
@@ -256,9 +240,8 @@ class IS1001Test(GenericTest):
         with open("test_data/IS1001/register_client_request_data.json") as resource_data:
             request_data = json.load(resource_data)
 
-        status, response = self._make_auth_request(
-            method="POST", url_path='register_client', data=request_data, auth="user"
-        )
+        status, response = self._make_auth_request(method="POST", url_path='register_client',
+                                                   data=request_data, auth="user")
 
         try:
             self._verify_response(test=test, expected_status=201, response=response)
@@ -323,9 +306,7 @@ class IS1001Test(GenericTest):
                     'grant_type': 'password',
                     'scope': scope
                 }
-                status, response = self._make_auth_request(
-                    "POST", 'token', data=request_data, auth="client"
-                )
+                status, response = self._make_auth_request("POST", 'token', data=request_data, auth="client")
 
                 self._verify_response(test=test, expected_status=200, response=response)
 
@@ -335,9 +316,8 @@ class IS1001Test(GenericTest):
                     self.bearer_tokens.append(response.json())
                     return test.PASS()
                 except Exception as e:
-                    return test.FAIL(
-                        "Status code was {} and Schema validation failed. {}".format(response.status_code, e)
-                    )
+                    return test.FAIL("Status code was {} and Schema validation failed. {}"
+                                     .format(response.status_code, e))
         else:
             return test.DISABLED("No Client Data available")
 
@@ -360,9 +340,7 @@ class IS1001Test(GenericTest):
                 with open("test_data/IS1001/authorization_request_data.json") as resource_data:
                     request_data = json.load(resource_data)
 
-                response = self._post_to_authorize_endpoint(
-                    data=request_data, parameters=parameters, auth="user"
-                )
+                response = self._post_to_authorize_endpoint(data=request_data, parameters=parameters, auth="user")
 
                 self._verify_response(test=test, expected_status=302, response=response)
                 auth_code = self._verify_redirect(test, response, parameters, "code")
@@ -386,9 +364,8 @@ class IS1001Test(GenericTest):
                     "client_id": self.client_data["client_id"]
                 }
 
-                status, response = self._make_auth_request(
-                    method="POST", url_path="token", data=request_data, auth="client"
-                )
+                status, response = self._make_auth_request(method="POST", url_path="token",
+                                                           data=request_data, auth="client")
 
                 self._verify_response(test=test, expected_status=200, response=response)
 
@@ -413,9 +390,7 @@ class IS1001Test(GenericTest):
                     "refresh_token": refresh_token
                 }
 
-                status, response = self._make_auth_request(
-                    "POST", url_path="token", data=request_data, auth="client"
-                )
+                status, response = self._make_auth_request("POST", url_path="token", data=request_data, auth="client")
 
                 self._verify_response(test=test, expected_status=200, response=response)
 
@@ -431,9 +406,7 @@ class IS1001Test(GenericTest):
 
     def test_07(self, test):
         """Test '/certs' endpoint for valid certificate"""
-        status, response = self.do_request(
-            method="GET", url=self.url + 'certs'
-        )
+        status, response = self.do_request(method="GET", url=self.url + 'certs')
 
         self._verify_response(test=test, expected_status=200, response=response)
 
@@ -459,9 +432,8 @@ class IS1001Test(GenericTest):
                     "token_type_hint": "access_token"
                 }
 
-                status, response = self._make_auth_request(
-                    method="POST", url_path='revoke', data=request_data, auth="client"
-                )
+                status, response = self._make_auth_request(method="POST", url_path='revoke',
+                                                           data=request_data, auth="client")
 
                 self._verify_response(test=test, expected_status=200, response=response)
 
@@ -485,9 +457,8 @@ class IS1001Test(GenericTest):
     def _verify_error_response(self, test, response, status_code, error_value):
 
         if response.status_code != status_code:
-            self._raise_nmos_exception(
-                test, response, string="Incorrect Status Code Returned. Expected {}".format(status_code)
-            )
+            self._raise_nmos_exception(test, response,
+                                       string="Incorrect Status Code Returned. Expected {}".format(status_code))
 
         ctype_valid, ctype_message = self.check_content_type(response.headers)
         if not ctype_valid:
@@ -522,46 +493,37 @@ class IS1001Test(GenericTest):
 
             response = self._post_to_authorize_endpoint(request_data, parameters)
             if response.status_code != 302:
-                return test.FAIL(
-                    "Correct Request Data didn't return 302 status code. Got {}"
-                    .format(response.status_code))
+                return test.FAIL("Correct Request Data didn't return 302 status code. Got {}"
+                                 .format(response.status_code))
 
             # Incorrect Redirect URI should result in error response
-            response = self._bad_post_to_authorize_endpoint(
-                data=request_data, params=parameters, key="redirect_uri", value="http://www.bogus.com"
-            )
+            response = self._bad_post_to_authorize_endpoint(data=request_data, params=parameters,
+                                                            key="redirect_uri", value="http://www.bogus.com")
             self._verify_error_response(test, response, 400, "invalid_request")
 
             # Incorrect Response Type should result in error response
-            response = self._bad_post_to_authorize_endpoint(
-                data=request_data, params=parameters, key="response_type", value="password"
-            )
+            response = self._bad_post_to_authorize_endpoint(data=request_data, params=parameters,
+                                                            key="response_type", value="password")
             self._verify_error_response(test, response, 400, "invalid_grant")
 
             # No Authorization Header should result in Access Denied error in redirect
-            response = self._bad_post_to_authorize_endpoint(
-                data=request_data, params=parameters, key="scope", value="is-04", auth=None
-            )
+            response = self._bad_post_to_authorize_endpoint(data=request_data, params=parameters,
+                                                            key="scope", value="is-04", auth=None)
             self._verify_redirect(test, response, parameters, "error", "access_denied")
 
             # Invalid scope should result in Bad Scope error in redirect
-            response = self._bad_post_to_authorize_endpoint(
-                data=request_data, params=parameters, key="scope", value="bad_scope"
-            )
+            response = self._bad_post_to_authorize_endpoint(data=request_data, params=parameters,
+                                                            key="scope", value="bad_scope")
             self._verify_redirect(test, response, parameters, "error", "invalid_scope")
 
             # Invalid client should result in Bad Client error in redirect
-            response = self._bad_post_to_authorize_endpoint(
-                data=request_data, params=parameters, key="client_id", value="bad_client"
-            )
+            response = self._bad_post_to_authorize_endpoint(data=request_data, params=parameters,
+                                                            key="client_id", value="bad_client")
             self._verify_redirect(test, response, parameters, "error", "invalid_client")
 
             # Lack of Resource Owner consent should result in Access Denied error in redirect
-            response = self._bad_post_to_authorize_endpoint(
-                data=None, params=parameters, key="scope", value="is-04"
-            )
+            response = self._bad_post_to_authorize_endpoint(data=None, params=parameters, key="scope", value="is-04")
             self._verify_redirect(test, response, parameters, "error", "access_denied")
-
             return test.PASS()
         else:
             return test.DISABLED("No Client Data available")
@@ -577,9 +539,8 @@ class IS1001Test(GenericTest):
                 "redirect_uri": self.client_data["redirect_uris"][0],
                 "client_id": self.client_data["client_id"]
             }
-            status, response = self._make_auth_request(
-                method="POST", url_path="token", data=request_data, auth="client"
-            )
+            status, response = self._make_auth_request(method="POST", url_path="token",
+                                                       data=request_data, auth="client")
             self._verify_error_response(test, response, 400, "invalid_request")
 
             # Use Pasword Grant flow wih incorrect credentials
@@ -590,26 +551,18 @@ class IS1001Test(GenericTest):
                 'scope': "is-04"
             }
 
-            status, response = self._bad_post_to_token_endpoint(
-                data=request_data, key="username", value="bad_username"
-            )
+            status, response = self._bad_post_to_token_endpoint(data=request_data, key="username", value="bad_username")
             self._verify_error_response(test, response, 400, "invalid_request")
 
-            status, response = self._bad_post_to_token_endpoint(
-                data=request_data, key="grant_type", value="bad_grant"
-            )
+            status, response = self._bad_post_to_token_endpoint(data=request_data, key="grant_type", value="bad_grant")
             self._verify_error_response(test, response, 400, "invalid_grant")
 
-            status, response = self._bad_post_to_token_endpoint(
-                data=request_data, key="scope", value="bad_scope"
-            )
+            status, response = self._bad_post_to_token_endpoint(data=request_data, key="scope", value="bad_scope")
             self._verify_error_response(test, response, 400, "invalid_scope")
 
-            status, response = self._bad_post_to_token_endpoint(
-                data=request_data, key="scope", value="is-04", auth=None
-            )
+            status, response = self._bad_post_to_token_endpoint(data=request_data, key="scope",
+                                                                value="is-04", auth=None)
             self._verify_error_response(test, response, 401, "invalid_client")
-
             return test.PASS()
         else:
             return test.DISABLED("No Client Data or Auth Codes available")

--- a/nmostesting/suites/IS1001Test.py
+++ b/nmostesting/suites/IS1001Test.py
@@ -50,6 +50,8 @@ class IS1001Test(GenericTest):
 
     def __init__(self, apis):
         super(IS1001Test, self).__init__(apis)
+        if not ENABLE_HTTPS:
+            raise NMOSInitException("IS-10 can only be tested when ENABLE_HTTPS is set to True in Config.py")
         self.url = self.apis[AUTH_API_KEY]["url"]
         self.bearer_tokens = []
         self.client_data = {}

--- a/nmostesting/suites/IS1001Test.py
+++ b/nmostesting/suites/IS1001Test.py
@@ -50,8 +50,6 @@ class IS1001Test(GenericTest):
 
     def __init__(self, apis):
         super(IS1001Test, self).__init__(apis)
-        if not ENABLE_HTTPS:
-            raise NMOSInitException("IS-10 can only be tested when ENABLE_HTTPS is set to True in Config.py")
         self.url = self.apis[AUTH_API_KEY]["url"]
         self.bearer_tokens = []
         self.client_data = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flask
+flask>=1.0.0
 wtforms
 jsonschema
 zeroconf-monkey


### PR DESCRIPTION
The top half of changes are linting / tidying changes, but the bottom half adds a route (`/api`) that allows the sending of a JSON body that contains the same parameters that the command line consumes, and returns a `json` or `xml` output, depending on the presence of a `format=json/xml` query parameter.