### PR TITLE
config: update discovery default to ease unicast testing

### DIFF
--- a/nmostesting/Config.py
+++ b/nmostesting/Config.py
@@ -28,7 +28,7 @@ ENABLE_DNS_SD = True
 DNS_SD_MODE = 'multicast'
 
 # Number of seconds to wait after a DNS-SD advert is created for a client to notice and perform an action
-DNS_SD_ADVERT_TIMEOUT = 5
+DNS_SD_ADVERT_TIMEOUT = 30
 
 # Number of seconds to wait after browsing for a DNS-SD advert before checking the results
 DNS_SD_BROWSE_TIMEOUT = 2


### PR DESCRIPTION
Now that the tests will proceed without waiting after a successful query/request, it seems safe to increase the default DNS-SD advert timeout. This should make testing unicast discovery a little more likely to succeed with the defaults.