### PR TITLE
is0401: add a test for the presence of Receiver caps

### DIFF
--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -1445,6 +1445,8 @@ class IS0401Test(GenericTest):
                                                     "docs/4.3._Behaviour_-_Nodes.html#all-resources")
             except json.JSONDecodeError:
                 return test.FAIL("Non-JSON response returned from Node API")
+            except KeyError as e:
+                return test.FAIL("Unable to find expected key in the Receiver: {}".format(e))
 
         if no_receivers:
             return test.UNCLEAR("No Receivers were found on the Node")

--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -1431,8 +1431,8 @@ class IS0401Test(GenericTest):
                     if "media_types" not in receiver["caps"]:
                         return test.WARNING("Receiver 'caps' should include a list of accepted 'media_types', unless "
                                             "this Receiver can handle any 'media_type'",
-                                            "https://amwa-tv.github.io/nmos-discovery-registration/tags/v1.3/docs/"
-                                            "4.3._Behaviour_-_Nodes.html#all-resources")
+                                            "https://amwa-tv.github.io/nmos-discovery-registration/branches/{}/docs/"
+                                            "4.3._Behaviour_-_Nodes.html#all-resources".format(api["spec_branch"]))
                     if self.is04_utils.compare_api_version(api["version"], "v1.3") >= 0:
                         if receiver["format"] == "urn:x-nmos:format:data" and \
                                receiver["transport"] in ["urn:x-nmos:transport:websocket", "urn:x-nmos:transport:mqtt"]:
@@ -1441,8 +1441,9 @@ class IS0401Test(GenericTest):
                                 return test.WARNING("Receiver 'caps' should include a list of accepted 'event_types' "
                                                     "if the Receiver accepts IS-07 events, unless this Receiver can "
                                                     "handle any 'event_type'",
-                                                    "https://amwa-tv.github.io/nmos-discovery-registration/tags/v1.3/"
-                                                    "docs/4.3._Behaviour_-_Nodes.html#all-resources")
+                                                    "https://amwa-tv.github.io/nmos-discovery-registration/branches/{}/"
+                                                    "docs/4.3._Behaviour_-_Nodes.html#all-resources"
+                                                    .format(api["spec_branch"]))
             except json.JSONDecodeError:
                 return test.FAIL("Non-JSON response returned from Node API")
             except KeyError as e:


### PR DESCRIPTION
Adds a test which emits warnings only if expected 'caps' are missing for different types of Receivers.