### PR TITLE
IS-07-02: Add initial test suite for integration tests between IS-07, IS-04 and IS-05

### DIFF
--- a/nmostesting/IS04Utils.py
+++ b/nmostesting/IS04Utils.py
@@ -27,6 +27,8 @@ class IS04Utils(NMOSUtils):
         valid_resource, resource = TestHelper.do_request("GET", self.url + "self")
         if valid_resource and resource.status_code == 200:
             return resource.json()
+        else:
+            return None
 
     def get_devices(self, url=None):
         """Get node devices from the Node API"""

--- a/nmostesting/IS04Utils.py
+++ b/nmostesting/IS04Utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from . import TestHelper
 
 from .NMOSUtils import NMOSUtils
 
@@ -19,3 +20,46 @@ from .NMOSUtils import NMOSUtils
 class IS04Utils(NMOSUtils):
     def __init__(self, url):
         NMOSUtils.__init__(self, url)
+
+    def get_node(self):
+        """Get node self resource from the Node API"""
+
+        valid_resource, resource = TestHelper.do_request("GET", self.url + "self")
+        if valid_resource and resource.status_code == 200:
+            return resource.json()
+
+    def get_devices(self):
+        """Get node devices from the Node API"""
+
+        return self.get_resources(self.url + "devices")
+
+    def get_sources(self):
+        """Get node sources from the Node API"""
+
+        return self.get_resources(self.url + "sources")
+
+    def get_flows(self):
+        """Get node flows from the Node API"""
+
+        return self.get_resources(self.url + "flows")
+
+    def get_senders(self):
+        """Get node senders from the Node API"""
+
+        return self.get_resources(self.url + "senders")
+
+    def get_receivers(self):
+        """Get node receivers from the Node API"""
+
+        return self.get_resources(self.url + "receivers")
+
+    def get_resources(self, url):
+        """Get node resources from the Node API"""
+
+        toReturn = {}
+        valid_resources, resources = TestHelper.do_request("GET", url)
+        if valid_resources and resources.status_code == 200:
+            for res in resources.json():
+                toReturn[res["id"]] = res
+
+        return toReturn

--- a/nmostesting/IS04Utils.py
+++ b/nmostesting/IS04Utils.py
@@ -28,36 +28,39 @@ class IS04Utils(NMOSUtils):
         if valid_resource and resource.status_code == 200:
             return resource.json()
 
-    def get_devices(self):
+    def get_devices(self, url=None):
         """Get node devices from the Node API"""
 
-        return self.get_resources(self.url + "devices")
+        return self.get_resources("devices", url)
 
-    def get_sources(self):
+    def get_sources(self, url=None):
         """Get node sources from the Node API"""
 
-        return self.get_resources(self.url + "sources")
+        return self.get_resources("sources", url)
 
-    def get_flows(self):
+    def get_flows(self, url=None):
         """Get node flows from the Node API"""
 
-        return self.get_resources(self.url + "flows")
+        return self.get_resources("flows", url)
 
-    def get_senders(self):
+    def get_senders(self, url=None):
         """Get node senders from the Node API"""
 
-        return self.get_resources(self.url + "senders")
+        return self.get_resources("senders", url)
 
-    def get_receivers(self):
+    def get_receivers(self, url=None):
         """Get node receivers from the Node API"""
 
-        return self.get_resources(self.url + "receivers")
+        return self.get_resources("receivers", url)
 
-    def get_resources(self, url):
+    def get_resources(self, resource, url=None):
         """Get node resources from the Node API"""
 
+        if not url:
+            url = self.url
+
         toReturn = {}
-        valid_resources, resources = TestHelper.do_request("GET", url)
+        valid_resources, resources = TestHelper.do_request("GET", url + resource)
         if valid_resources and resources.status_code == 200:
             for res in resources.json():
                 toReturn[res["id"]] = res

--- a/nmostesting/IS04Utils.py
+++ b/nmostesting/IS04Utils.py
@@ -21,7 +21,7 @@ class IS04Utils(NMOSUtils):
     def __init__(self, url):
         NMOSUtils.__init__(self, url)
 
-    def get_node(self):
+    def get_self(self):
         """Get node self resource from the Node API"""
 
         valid_resource, resource = TestHelper.do_request("GET", self.url + "self")

--- a/nmostesting/IS07Utils.py
+++ b/nmostesting/IS07Utils.py
@@ -1,6 +1,4 @@
-# Copyright 2017 British Broadcasting Corporation
-#
-# Modifications Copyright 2018 Riedel Communications GmbH & Co. KG
+# Copyright (C) 2019 Advanced Media Workflow Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +14,8 @@
 
 from . import TestHelper
 
-from requests.compat import json
-
 from .NMOSUtils import NMOSUtils
+
 
 class IS07Utils(NMOSUtils):
     def __init__(self, url):
@@ -27,9 +24,9 @@ class IS07Utils(NMOSUtils):
     def get_sources_states_and_types(self):
         """Gets a list of the available source objects with state and type on the API"""
         toReturn = {}
-        sources_url = self.url + "sources/"        
+        sources_url = self.url + "sources/"
         valid_sources, sources = TestHelper.do_request("GET", sources_url)
-        if valid_sources:            
+        if valid_sources:
             for source in sources.json():
                 source_id = source[:-1]
                 toReturn[source_id] = {}

--- a/nmostesting/IS07Utils.py
+++ b/nmostesting/IS07Utils.py
@@ -32,7 +32,6 @@ class IS07Utils(NMOSUtils):
                 toReturn[source_id] = {}
                 for sub_path in ["state", "type"]:
                     valid_sub, sub = TestHelper.do_request("GET", "{}/{}/{}".format(sources_url, source_id, sub_path))
-                    if not valid_sub or sub.status_code != 200:
-                        pass
-                    toReturn[source_id][sub_path] = sub.json()
+                    if valid_sub:
+                        toReturn[source_id][sub_path] = sub.json()
         return toReturn

--- a/nmostesting/IS07Utils.py
+++ b/nmostesting/IS07Utils.py
@@ -32,6 +32,6 @@ class IS07Utils(NMOSUtils):
                 toReturn[source_id] = {}
                 for sub_path in ["state", "type"]:
                     valid_sub, sub = TestHelper.do_request("GET", "{}/{}/{}".format(sources_url, source_id, sub_path))
-                    if valid_sub:
+                    if valid_sub and sub.status == 200:
                         toReturn[source_id][sub_path] = sub.json()
         return toReturn

--- a/nmostesting/IS07Utils.py
+++ b/nmostesting/IS07Utils.py
@@ -32,6 +32,6 @@ class IS07Utils(NMOSUtils):
                 toReturn[source_id] = {}
                 for sub_path in ["state", "type"]:
                     valid_sub, sub = TestHelper.do_request("GET", "{}/{}/{}".format(sources_url, source_id, sub_path))
-                    if valid_sub and sub.status == 200:
+                    if valid_sub and sub.status_code == 200:
                         toReturn[source_id][sub_path] = sub.json()
         return toReturn

--- a/nmostesting/IS07Utils.py
+++ b/nmostesting/IS07Utils.py
@@ -1,0 +1,41 @@
+# Copyright 2017 British Broadcasting Corporation
+#
+# Modifications Copyright 2018 Riedel Communications GmbH & Co. KG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import TestHelper
+
+from requests.compat import json
+
+from .NMOSUtils import NMOSUtils
+
+class IS07Utils(NMOSUtils):
+    def __init__(self, url):
+        NMOSUtils.__init__(self, url)
+
+    def get_sources_states_and_types(self):
+        """Gets a list of the available source objects with state and type on the API"""
+        toReturn = {}
+        sources_url = self.url + "sources/"        
+        valid_sources, sources = TestHelper.do_request("GET", sources_url)
+        if valid_sources:            
+            for source in sources.json():
+                source_id = source[:-1]
+                toReturn[source_id] = {}
+                for sub_path in ["state", "type"]:
+                    valid_sub, sub = TestHelper.do_request("GET", "{}/{}/{}".format(sources_url, source_id, sub_path))
+                    if not valid_sub or sub.status_code != 200:
+                        pass
+                    toReturn[source_id][sub_path] = sub.json()
+        return toReturn

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -67,7 +67,7 @@ from .suites import IS0501Test
 from .suites import IS0502Test
 from .suites import IS0601Test
 from .suites import IS0701Test
-from .suites import IS0703Test
+from .suites import IS0702Test
 from .suites import IS0801Test
 from .suites import IS0802Test
 from .suites import IS0901Test
@@ -184,8 +184,8 @@ TEST_DEFINITIONS = {
         }],
         "class": IS0701Test.IS0701Test
     },
-    "IS-07-03": {
-        "name": "IS-07 Interaction with IS-05",
+    "IS-07-02": {
+        "name": "IS-07 Interaction with IS-04 and IS-05",
         "specs": [{
             "spec_key": 'is-07',
             "api_key": "events"
@@ -196,7 +196,7 @@ TEST_DEFINITIONS = {
             "spec_key": "is-04",
             "api_key": "node"
         }],
-        "class": IS0703Test.IS0703Test
+        "class": IS0702Test.IS0702Test
     },
     "IS-08-01": {
         "name": "IS-08 Channel Mapping API",

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -192,6 +192,9 @@ TEST_DEFINITIONS = {
         }, {
             "spec_key": "is-05",
             "api_key": "connection"
+        }, {
+            "spec_key": "is-04",
+            "api_key": "node"
         }],
         "class": IS0703Test.IS0703Test
     },
@@ -298,8 +301,8 @@ class DataForm(Form):
     specs_per_test = sorted(specs_per_test, key=lambda x: x[0])
     max_endpoints = 0
     for spec in specs_per_test:
-        if len(spec) > max_endpoints:
-            max_endpoints = len(spec)
+        if len(spec[1]) > max_endpoints:
+            max_endpoints = len(spec[1])
     endpoints = FieldList(FormField(EndpointForm, label=""), min_entries=max_endpoints)
 
     # Define the secondary test selection dropdown

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -152,7 +152,7 @@ TEST_DEFINITIONS = {
     "IS-05-01": {
         "name": "IS-05 Connection Management API",
         "specs": [{
-            "spec_key": 'is-05',
+            "spec_key": "is-05",
             "api_key": "connection"
         }],
         "class": IS0501Test.IS0501Test
@@ -171,7 +171,7 @@ TEST_DEFINITIONS = {
     "IS-06-01": {
         "name": "IS-06 Network Control API",
         "specs": [{
-            "spec_key": 'is-06',
+            "spec_key": "is-06",
             "api_key": "netctrl"
         }],
         "class": IS0601Test.IS0601Test
@@ -179,7 +179,7 @@ TEST_DEFINITIONS = {
     "IS-07-01": {
         "name": "IS-07 Event & Tally API",
         "specs": [{
-            "spec_key": 'is-07',
+            "spec_key": "is-07",
             "api_key": "events"
         }],
         "class": IS0701Test.IS0701Test
@@ -187,21 +187,21 @@ TEST_DEFINITIONS = {
     "IS-07-02": {
         "name": "IS-07 Interaction with IS-04 and IS-05",
         "specs": [{
-            "spec_key": 'is-07',
-            "api_key": "events"
+            "spec_key": "is-04",
+            "api_key": "node"
         }, {
             "spec_key": "is-05",
             "api_key": "connection"
         }, {
-            "spec_key": "is-04",
-            "api_key": "node"
+            "spec_key": "is-07",
+            "api_key": "events"
         }],
         "class": IS0702Test.IS0702Test
     },
     "IS-08-01": {
         "name": "IS-08 Channel Mapping API",
         "specs": [{
-            "spec_key": 'is-08',
+            "spec_key": "is-08",
             "api_key": "channelmapping"
         }],
         "class": IS0801Test.IS0801Test
@@ -209,18 +209,18 @@ TEST_DEFINITIONS = {
     "IS-08-02": {
         "name": "IS-08 Interaction with Node API",
         "specs": [{
-            "spec_key": 'is-08',
-            "api_key": "channelmapping"
-        }, {
             "spec_key": "is-04",
             "api_key": "node"
+        }, {
+            "spec_key": "is-08",
+            "api_key": "channelmapping"
         }],
         "class": IS0802Test.IS0802Test
     },
     "IS-09-01": {
         "name": "IS-09 System API",
         "specs": [{
-            "spec_key": 'is-09',
+            "spec_key": "is-09",
             "api_key": "system"
         }],
         "class": IS0901Test.IS0901Test
@@ -228,7 +228,7 @@ TEST_DEFINITIONS = {
     "IS-10-01": {
         "name": "IS-10 Authorization API",
         "specs": [{
-            "spec_key": 'is-10',
+            "spec_key": "is-10",
             "api_key": "auth"
         }],
         "class": IS1001Test.IS1001Test

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -67,6 +67,7 @@ from .suites import IS0501Test
 from .suites import IS0502Test
 from .suites import IS0601Test
 from .suites import IS0701Test
+from .suites import IS0703Test
 from .suites import IS0801Test
 from .suites import IS0802Test
 from .suites import IS0901Test
@@ -182,6 +183,17 @@ TEST_DEFINITIONS = {
             "api_key": "events"
         }],
         "class": IS0701Test.IS0701Test
+    },
+    "IS-07-03": {
+        "name": "IS-07 Interaction with IS-05",
+        "specs": [{
+            "spec_key": 'is-07',
+            "api_key": "events"
+        }, {
+            "spec_key": "is-05",
+            "api_key": "connection"
+        }],
+        "class": IS0703Test.IS0703Test
     },
     "IS-08-01": {
         "name": "IS-08 Channel Mapping API",

--- a/nmostesting/suites/IS0702Test.py
+++ b/nmostesting/suites/IS0702Test.py
@@ -95,24 +95,33 @@ class IS0702Test(GenericTest):
             return test.UNCLEAR("Not tested. No resources found.")
 
     def test_02(self, test):
-        """Each Source has a corresponding IS-05 sender"""
+        """Each Source has a corresponding sender in IS-04 and IS-05"""
 
         if len(self.is07_sources) > 0:
-            for source in self.is07_sources:
-                if source in self.sources_to_test:
-                    found_source = False
-                    for sender in self.senders_to_test:
-                        if sender in self.sender_active_params:
+            for source_id in self.is07_sources:
+                if source_id in self.sources_to_test:
+                    found_sender = None
+                    for sender_id in self.senders_to_test:
+                        flow_id = self.senders_to_test[sender_id]["flow_id"]
+                        if flow_id in self.is04_flows:
+                            if source_id == self.is04_flows[flow_id]["source_id"]:
+                                found_sender = sender_id
+                                break
+                    if found_sender is not None:
+                        if found_sender in self.sender_active_params:
                             try:
-                                if self.sender_active_params[sender]["ext_is_07_source_id"] == source:
-                                    found_source = True
+                                if self.sender_active_params[found_sender]["ext_is_07_source_id"] == source_id:
+                                    return test.PASS()
+                                else:
+                                    return test.FAIL("Source {} has no associated IS-05 sender".format(source_id))
                             except KeyError as e:
                                 return test.FAIL("Sender {} parameters do not contain expected key: {}"
-                                                 .format(sender, e))
-                    if not found_source:
-                        return test.FAIL("Source {} has no associated IS-05 sender".format(source))
+                                                 .format(found_sender, e))
+                        else:
+                            return test.FAIL("Source {} has no associated IS-05 sender".format(source_id))
+                    else:
+                        return test.FAIL("Source {} has no associated IS-04 sender".format(source_id))
                 else:
-                    return test.FAIL("Source {} not found in Node API".format(source))
-                return test.PASS()
+                    return test.FAIL("Source {} not found in Node API".format(source_id))
         else:
             return test.UNCLEAR("Not tested. No resources found.")

--- a/nmostesting/suites/IS0702Test.py
+++ b/nmostesting/suites/IS0702Test.py
@@ -98,22 +98,21 @@ class IS0702Test(GenericTest):
         """Each Source has a corresponding IS-05 sender"""
 
         if len(self.is07_sources) > 0:
-            if len(self.sources_to_test.keys()) > 0:
-                for source in self.is07_sources:
-                    if source in self.sources_to_test:
-                        found_source = False
-                        for sender in self.senders_to_test:
-                            if sender in self.sender_active_params:
-                                try:
-                                    if self.sender_active_params[sender]["ext_is_07_source_id"] == source:
-                                        found_source = True
-                                except KeyError as e:
-                                    return test.FAIL("Sender {} parameters do not contain expected key: {}"
-                                                     .format(sender, e))
-                        if not found_source:
-                            return test.FAIL("Source {} has no associated IS-05 sender".format(source))
+            for source in self.is07_sources:
+                if source in self.sources_to_test:
+                    found_source = False
+                    for sender in self.senders_to_test:
+                        if sender in self.sender_active_params:
+                            try:
+                                if self.sender_active_params[sender]["ext_is_07_source_id"] == source:
+                                    found_source = True
+                            except KeyError as e:
+                                return test.FAIL("Sender {} parameters do not contain expected key: {}"
+                                                 .format(sender, e))
+                    if not found_source:
+                        return test.FAIL("Source {} has no associated IS-05 sender".format(source))
+                else:
+                    return test.FAIL("Source {} not found in Node API".format(source))
                 return test.PASS()
-            else:
-                return test.FAIL("No sources found in IS-04 Node API")
         else:
             return test.UNCLEAR("Not tested. No resources found.")

--- a/nmostesting/suites/IS0702Test.py
+++ b/nmostesting/suites/IS0702Test.py
@@ -22,9 +22,9 @@ NODE_API_KEY = "node"
 CONN_API_KEY = "connection"
 
 
-class IS0703Test(GenericTest):
+class IS0702Test(GenericTest):
     """
-    Runs IS-07-03-Test
+    Runs IS-07-02-Test
     """
     def __init__(self, apis):
         GenericTest.__init__(self, apis)

--- a/nmostesting/suites/IS0703Test.py
+++ b/nmostesting/suites/IS0703Test.py
@@ -41,7 +41,7 @@ class IS0703Test(GenericTest):
             if self.is05_utils.compare_api_version(self.apis[CONN_API_KEY]["version"], "v1.1") >= 0:
                 self.transport_types[sender] = self.is05_utils.get_transporttype(sender, "sender")
             else:
-                self.transport_types[sender] = "unknown"
+                self.transport_types[sender] = "urn:x-nmos:transport:rtp"
 
         if len(self.senders) > 0:
             for sender in self.senders:

--- a/nmostesting/suites/IS0703Test.py
+++ b/nmostesting/suites/IS0703Test.py
@@ -76,8 +76,6 @@ class IS0703Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
-        return test.PASS()
-
     def test_02(self, test):
         """Each Source has a corresponding IS-05 sender"""
 
@@ -93,5 +91,5 @@ class IS0703Test(GenericTest):
 
                 if not found_source:
                     return test.FAIL("Source {} has no associated IS-05 sender".format(source))
-
-        return test.PASS()
+        else:
+            return test.UNCLEAR("Not tested. No resources found.")

--- a/nmostesting/suites/IS0703Test.py
+++ b/nmostesting/suites/IS0703Test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 British Broadcasting Corporation
+# Copyright (C) 2019 Advanced Media Workflow Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from requests.compat import json
-
-from ..GenericTest import GenericTest, NMOSTestException
+from ..GenericTest import GenericTest
 from ..IS05Utils import IS05Utils
 from ..IS07Utils import IS07Utils
 
 EVENTS_API_KEY = "events"
 CONN_API_KEY = "connection"
+
 
 class IS0703Test(GenericTest):
     """
@@ -48,7 +47,7 @@ class IS0703Test(GenericTest):
             for sender in self.senders:
                 dest = "single/senders/" + sender + "/active/"
                 valid, response = self.is05_utils.checkCleanRequestJSON("GET", dest)
-                if valid:                        
+                if valid:
                     if len(response) > 0 and isinstance(response["transport_params"][0], dict):
                         self.sender_active_params[sender] = response["transport_params"][0]
 
@@ -88,8 +87,8 @@ class IS0703Test(GenericTest):
                             found_source = True
                     except KeyError as e:
                         return test.FAIL("Sender {} parameters do not contain expected key: {}".format(sender, e))
-                
-                if found_source == False:
-                    return test.FAIL("Source: {} has no associated IS-05 sender".format(source))
+
+                if not found_source:
+                    return test.FAIL("Source {} has no associated IS-05 sender".format(source))
 
         return test.PASS()

--- a/nmostesting/suites/IS0703Test.py
+++ b/nmostesting/suites/IS0703Test.py
@@ -88,6 +88,8 @@ class IS0703Test(GenericTest):
                             valid_params = True
                     if not valid_params:
                         return test.FAIL("Missing required ext parameters for Sender {}".format(sender))
+                else:
+                    return test.FAIL("Sender {} not found in Connection API".format(sender))
             return test.PASS()
         else:
             return test.UNCLEAR("Not tested. No resources found.")
@@ -112,6 +114,6 @@ class IS0703Test(GenericTest):
                             return test.FAIL("Source {} has no associated IS-05 sender".format(source))
                 return test.PASS()
             else:
-                return test.UNCLEAR("Not tested. No resources found.")
+                return test.FAIL("No sources found in IS-04 Node API")
         else:
             return test.UNCLEAR("Not tested. No resources found.")

--- a/nmostesting/suites/IS0703Test.py
+++ b/nmostesting/suites/IS0703Test.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 from ..GenericTest import GenericTest
+from ..IS04Utils import IS04Utils
 from ..IS05Utils import IS05Utils
 from ..IS07Utils import IS07Utils
 
 EVENTS_API_KEY = "events"
+NODE_API_KEY = "node"
 CONN_API_KEY = "connection"
 
 
@@ -28,23 +30,41 @@ class IS0703Test(GenericTest):
         GenericTest.__init__(self, apis)
         self.events_url = self.apis[EVENTS_API_KEY]["url"]
         self.connection_url = self.apis[CONN_API_KEY]["url"]
+        self.node_url = self.apis[NODE_API_KEY]["url"]
+        self.is04_utils = IS04Utils(self.node_url)
         self.is05_utils = IS05Utils(self.connection_url)
         self.is07_utils = IS07Utils(self.events_url)
 
     def set_up_tests(self):
-        self.senders = self.is05_utils.get_senders()
-        self.sources = self.is07_utils.get_sources_states_and_types()
+        self.is05_senders = self.is05_utils.get_senders()
+        self.is07_sources = self.is07_utils.get_sources_states_and_types()
+        self.is04_sources = self.is04_utils.get_sources()
+        self.is04_flows = self.is04_utils.get_flows()
+        self.is04_senders = self.is04_utils.get_senders()
         self.transport_types = {}
         self.sender_active_params = {}
+        self.senders_to_test = {}
+        self.sources_to_test = {}
 
-        for sender in self.senders:
+        for sender in self.is04_senders:
+            for flow in self.is04_flows:
+                if flow == self.is04_senders[sender]["flow_id"]:
+                    for source in self.is04_sources:
+                        if source == self.is04_flows[flow]["source_id"]:
+                            if 'event_type' in self.is04_sources[source]:
+                                self.senders_to_test[sender] = self.is04_senders[sender]
+                                self.sources_to_test[source] = self.is04_sources[source]
+                            break
+                    break
+
+        for sender in self.is05_senders:
             if self.is05_utils.compare_api_version(self.apis[CONN_API_KEY]["version"], "v1.1") >= 0:
                 self.transport_types[sender] = self.is05_utils.get_transporttype(sender, "sender")
             else:
                 self.transport_types[sender] = "urn:x-nmos:transport:rtp"
 
-        if len(self.senders) > 0:
-            for sender in self.senders:
+        if len(self.is05_senders) > 0:
+            for sender in self.is05_senders:
                 dest = "single/senders/" + sender + "/active"
                 valid, response = self.is05_utils.checkCleanRequestJSON("GET", dest)
                 if valid:
@@ -56,22 +76,20 @@ class IS0703Test(GenericTest):
 
         ext_params_websocket = ['ext_is_07_source_id', 'ext_is_07_rest_api_url']
         ext_params_mqtt = ['ext_is_07_rest_api_url']
-        if len(self.senders) > 0:
-            for sender in self.senders:
+        if len(self.senders_to_test.keys()) > 0:
+            for sender in self.senders_to_test:
                 if sender in self.sender_active_params:
                     all_params = self.sender_active_params[sender].keys()
                     params = [param for param in all_params if param.startswith("ext_")]
-                    if (self.transport_types[sender] == "urn:x-nmos:transport:websocket" or
-                            self.transport_types[sender] == "urn:x-nmos:transport:mqtt"):
-                        valid_params = False
-                        if self.transport_types[sender] == "urn:x-nmos:transport:websocket":
-                            if sorted(params) == sorted(ext_params_websocket):
-                                valid_params = True
-                        elif self.transport_types[sender] == "urn:x-nmos:transport:mqtt":
-                            if sorted(params) == sorted(ext_params_mqtt):
-                                valid_params = True
-                        if not valid_params:
-                            return test.FAIL("Missing required ext parameters for Sender {}".format(sender))
+                    valid_params = False
+                    if self.transport_types[sender] == "urn:x-nmos:transport:websocket":
+                        if sorted(params) == sorted(ext_params_websocket):
+                            valid_params = True
+                    elif self.transport_types[sender] == "urn:x-nmos:transport:mqtt":
+                        if sorted(params) == sorted(ext_params_mqtt):
+                            valid_params = True
+                    if not valid_params:
+                        return test.FAIL("Missing required ext parameters for Sender {}".format(sender))
             return test.PASS()
         else:
             return test.UNCLEAR("Not tested. No resources found.")
@@ -79,17 +97,23 @@ class IS0703Test(GenericTest):
     def test_02(self, test):
         """Each Source has a corresponding IS-05 sender"""
 
-        if len(self.sources) > 0:
-            for source in self.sources:
-                found_source = False
-                for sender in self.sender_active_params:
-                    try:
-                        if self.sender_active_params[sender]["ext_is_07_source_id"] == source:
-                            found_source = True
-                    except KeyError as e:
-                        return test.FAIL("Sender {} parameters do not contain expected key: {}".format(sender, e))
-
-                if not found_source:
-                    return test.FAIL("Source {} has no associated IS-05 sender".format(source))
+        if len(self.is07_sources) > 0:
+            if len(self.sources_to_test.keys()) > 0:
+                for source in self.is07_sources:
+                    if source in self.sources_to_test:
+                        found_source = False
+                        for sender in self.senders_to_test:
+                            if sender in self.sender_active_params:
+                                try:
+                                    if self.sender_active_params[sender]["ext_is_07_source_id"] == source:
+                                        found_source = True
+                                except KeyError as e:
+                                    return test.FAIL("Sender {} parameters do not contain expected key: {}"
+                                                     .format(sender, e))
+                        if not found_source:
+                            return test.FAIL("Source {} has no associated IS-05 sender".format(source))
+                return test.PASS()
+            else:
+                return test.UNCLEAR("Not tested. No resources found.")
         else:
             return test.UNCLEAR("Not tested. No resources found.")

--- a/nmostesting/suites/IS0703Test.py
+++ b/nmostesting/suites/IS0703Test.py
@@ -1,0 +1,95 @@
+# Copyright (C) 2018 British Broadcasting Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from requests.compat import json
+
+from ..GenericTest import GenericTest, NMOSTestException
+from ..IS05Utils import IS05Utils
+from ..IS07Utils import IS07Utils
+
+EVENTS_API_KEY = "events"
+CONN_API_KEY = "connection"
+
+class IS0703Test(GenericTest):
+    """
+    Runs IS-07-03-Test
+    """
+    def __init__(self, apis):
+        GenericTest.__init__(self, apis)
+        self.events_url = self.apis[EVENTS_API_KEY]["url"]
+        self.connection_url = self.apis[CONN_API_KEY]["url"]
+        self.is05_utils = IS05Utils(self.connection_url)
+        self.is07_utils = IS07Utils(self.events_url)
+
+    def set_up_tests(self):
+        self.senders = self.is05_utils.get_senders()
+        self.sources = self.is07_utils.get_sources_states_and_types()
+        self.transport_types = {}
+        self.sender_active_params = {}
+
+        for sender in self.senders:
+            if self.is05_utils.compare_api_version(self.apis[CONN_API_KEY]["version"], "v1.1") >= 0:
+                self.transport_types[sender] = self.is05_utils.get_transporttype(sender, "sender")
+            else:
+                self.transport_types[sender] = "unknown"
+
+        if len(self.senders) > 0:
+            for sender in self.senders:
+                dest = "single/senders/" + sender + "/active/"
+                valid, response = self.is05_utils.checkCleanRequestJSON("GET", dest)
+                if valid:                        
+                    if len(response) > 0 and isinstance(response["transport_params"][0], dict):
+                        self.sender_active_params[sender] = response["transport_params"][0]
+
+    def test_01(self, test):
+        """Each Sender has ext_is_07_source_id and ext_is_07_rest_api_url parameters"""
+
+        extParams = ['ext_is_07_source_id', 'ext_is_07_rest_api_url']
+        if len(self.senders) > 0:
+            for sender in self.senders:
+                if sender in self.sender_active_params:
+                    all_params = self.sender_active_params[sender].keys()
+                    params = [param for param in all_params if param.startswith("ext_")]
+                    valid_params = False
+                    if self.transport_types[sender] == "urn:x-nmos:transport:websocket":
+                        if sorted(params) == sorted(extParams):
+                            valid_params = True
+                    elif self.transport_types[sender] == "urn:x-nmos:transport:mqtt":
+                        if sorted(params) == sorted(extParams):
+                            valid_params = True
+                    if not valid_params:
+                        return test.FAIL("Missing common ext parameters")
+            return test.PASS()
+        else:
+            return test.UNCLEAR("Not tested. No resources found.")
+
+        return test.PASS()
+
+    def test_02(self, test):
+        """Each Source has a corresponding IS-05 sender"""
+
+        if len(self.sources) > 0:
+            for source in self.sources:
+                found_source = False
+                for sender in self.sender_active_params:
+                    try:
+                        if self.sender_active_params[sender]["ext_is_07_source_id"] == source:
+                            found_source = True
+                    except KeyError as e:
+                        return test.FAIL("Sender {} parameters do not contain expected key: {}".format(sender, e))
+                
+                if found_source == False:
+                    return test.FAIL("Source: {} has no associated IS-05 sender".format(source))
+
+        return test.PASS()

--- a/nmostesting/suites/IS0703Test.py
+++ b/nmostesting/suites/IS0703Test.py
@@ -45,30 +45,33 @@ class IS0703Test(GenericTest):
 
         if len(self.senders) > 0:
             for sender in self.senders:
-                dest = "single/senders/" + sender + "/active/"
+                dest = "single/senders/" + sender + "/active"
                 valid, response = self.is05_utils.checkCleanRequestJSON("GET", dest)
                 if valid:
                     if len(response) > 0 and isinstance(response["transport_params"][0], dict):
                         self.sender_active_params[sender] = response["transport_params"][0]
 
     def test_01(self, test):
-        """Each Sender has ext_is_07_source_id and ext_is_07_rest_api_url parameters"""
+        """Each Sender has the required ext parameters"""
 
-        extParams = ['ext_is_07_source_id', 'ext_is_07_rest_api_url']
+        ext_params_websocket = ['ext_is_07_source_id', 'ext_is_07_rest_api_url']
+        ext_params_mqtt = ['ext_is_07_rest_api_url']
         if len(self.senders) > 0:
             for sender in self.senders:
                 if sender in self.sender_active_params:
                     all_params = self.sender_active_params[sender].keys()
                     params = [param for param in all_params if param.startswith("ext_")]
-                    valid_params = False
-                    if self.transport_types[sender] == "urn:x-nmos:transport:websocket":
-                        if sorted(params) == sorted(extParams):
-                            valid_params = True
-                    elif self.transport_types[sender] == "urn:x-nmos:transport:mqtt":
-                        if sorted(params) == sorted(extParams):
-                            valid_params = True
-                    if not valid_params:
-                        return test.FAIL("Missing common ext parameters")
+                    if (self.transport_types[sender] == "urn:x-nmos:transport:websocket" or 
+                        self.transport_types[sender] == "urn:x-nmos:transport:mqtt"):
+                        valid_params = False
+                        if self.transport_types[sender] == "urn:x-nmos:transport:websocket":
+                            if sorted(params) == sorted(ext_params_websocket):
+                                valid_params = True
+                        elif self.transport_types[sender] == "urn:x-nmos:transport:mqtt":
+                            if sorted(params) == sorted(ext_params_mqtt):
+                                valid_params = True
+                        if not valid_params:
+                            return test.FAIL("Missing required ext parameters")
             return test.PASS()
         else:
             return test.UNCLEAR("Not tested. No resources found.")

--- a/nmostesting/suites/IS0703Test.py
+++ b/nmostesting/suites/IS0703Test.py
@@ -71,7 +71,7 @@ class IS0703Test(GenericTest):
                             if sorted(params) == sorted(ext_params_mqtt):
                                 valid_params = True
                         if not valid_params:
-                            return test.FAIL("Missing required ext parameters")
+                            return test.FAIL("Missing required ext parameters for Sender {}".format(sender))
             return test.PASS()
         else:
             return test.UNCLEAR("Not tested. No resources found.")

--- a/nmostesting/suites/IS0703Test.py
+++ b/nmostesting/suites/IS0703Test.py
@@ -47,15 +47,13 @@ class IS0703Test(GenericTest):
         self.sources_to_test = {}
 
         for sender in self.is04_senders:
-            for flow in self.is04_flows:
-                if flow == self.is04_senders[sender]["flow_id"]:
-                    for source in self.is04_sources:
-                        if source == self.is04_flows[flow]["source_id"]:
-                            if 'event_type' in self.is04_sources[source]:
-                                self.senders_to_test[sender] = self.is04_senders[sender]
-                                self.sources_to_test[source] = self.is04_sources[source]
-                            break
-                    break
+            flow = self.is04_senders[sender]["flow_id"]
+            if flow in self.is04_flows:
+                source = self.is04_flows[flow]["source_id"]
+                if source in self.is04_sources:
+                    if 'event_type' in self.is04_sources[source]:
+                        self.senders_to_test[sender] = self.is04_senders[sender]
+                        self.sources_to_test[source] = self.is04_sources[source]
 
         for sender in self.is05_senders:
             if self.is05_utils.compare_api_version(self.apis[CONN_API_KEY]["version"], "v1.1") >= 0:

--- a/nmostesting/suites/IS0703Test.py
+++ b/nmostesting/suites/IS0703Test.py
@@ -61,8 +61,8 @@ class IS0703Test(GenericTest):
                 if sender in self.sender_active_params:
                     all_params = self.sender_active_params[sender].keys()
                     params = [param for param in all_params if param.startswith("ext_")]
-                    if (self.transport_types[sender] == "urn:x-nmos:transport:websocket" or 
-                        self.transport_types[sender] == "urn:x-nmos:transport:mqtt"):
+                    if (self.transport_types[sender] == "urn:x-nmos:transport:websocket" or
+                            self.transport_types[sender] == "urn:x-nmos:transport:mqtt"):
                         valid_params = False
                         if self.transport_types[sender] == "urn:x-nmos:transport:websocket":
                             if sorted(params) == sorted(ext_params_websocket):


### PR DESCRIPTION
This creates a new test suite IS-07-02 which will be handling all of the integration tests between IS-07, IS-04 and IS-05. Transport tests will be added here as well.

Currently just 2 tests have been added:

- test 01 - checks the ext parameters exist (ext_is_07_source_id, ext_is_07_rest_api_url)
- test 02 - checks if the sources have a corresponding IS-05 sender and if not return a warning