### PR TITLE
IS-07: catch type-error exeception in test_06_02 (string payload type)

### DIFF
--- a/nmostesting/suites/IS0701Test.py
+++ b/nmostesting/suites/IS0701Test.py
@@ -287,6 +287,8 @@ class IS0701Test(GenericTest):
             return test.FAIL("Source {} JSON data did not include the expected key: {}".format(source_id, e))
         except re.error:
             return test.FAIL("Source {} type pattern is invalid".format(source_id))
+        except TypeError as e:
+            return test.FAIL("Source {} JSON type error: {}".format(source_id, e))
 
         if not found_string:
             return test.UNCLEAR("No 'string' sources were returned from Events API")


### PR DESCRIPTION
This PR adds a exception handler for a type error in test_06_02 of IS-07-01