### PR TITLE
is0501: ensure senders are enabled before testing SDP files

### DIFF
--- a/nmostesting/IS05Utils.py
+++ b/nmostesting/IS05Utils.py
@@ -376,7 +376,7 @@ class IS05Utils(NMOSUtils):
         else:
             return False, response
 
-    def check_activation(self, port, portId, activationMethod, transportType):
+    def check_activation(self, port, portId, activationMethod, transportType, masterEnable=None):
         """Checks that when an immediate activation is called staged parameters are moved
         to active and the activation is correctly displayed in the /active endpoint"""
         # Set a new value for a transport_param for each leg in staged
@@ -385,6 +385,8 @@ class IS05Utils(NMOSUtils):
         if valid:
             stagedUrl = "single/" + port + "s/" + portId + "/staged"
             data = {"transport_params": []}
+            if masterEnable is not None:
+                data["master_enable"] = masterEnable
             legs = self.get_num_paths(portId, port)
             for i in range(0, legs):
                 data['transport_params'].append({paramName: paramValues[i]})

--- a/nmostesting/suites/IS0501Test.py
+++ b/nmostesting/suites/IS0501Test.py
@@ -471,7 +471,8 @@ class IS0501Test(GenericTest):
             for sender in self.is05_utils.sampled_list(self.senders):
                 valid, response = self.is05_utils.check_activation("sender", sender,
                                                                    self.is05_utils.check_perform_immediate_activation,
-                                                                   self.transport_types[sender])
+                                                                   self.transport_types[sender],
+                                                                   True)
                 if valid:
                     if self.transport_types[sender] == "urn:x-nmos:transport:rtp":
                         valid2, response2 = self.is05_utils.check_sdp_matches_params(sender)
@@ -508,7 +509,8 @@ class IS0501Test(GenericTest):
             for sender in self.is05_utils.sampled_list(self.senders):
                 valid, response = self.is05_utils.check_activation("sender", sender,
                                                                    self.is05_utils.check_perform_relative_activation,
-                                                                   self.transport_types[sender])
+                                                                   self.transport_types[sender],
+                                                                   True)
                 if valid:
                     if self.transport_types[sender] == "urn:x-nmos:transport:rtp":
                         valid2, response2 = self.is05_utils.check_sdp_matches_params(sender)
@@ -544,7 +546,8 @@ class IS0501Test(GenericTest):
             for sender in self.is05_utils.sampled_list(self.senders):
                 valid, response = self.is05_utils.check_activation("sender", sender,
                                                                    self.is05_utils.check_perform_absolute_activation,
-                                                                   self.transport_types[sender])
+                                                                   self.transport_types[sender],
+                                                                   True)
                 if valid:
                     if self.transport_types[sender] == "urn:x-nmos:transport:rtp":
                         valid2, response2 = self.is05_utils.check_sdp_matches_params(sender)


### PR DESCRIPTION
Resolves #434

This ensures that 'master_enable' is set to true for the set of tests which aim to examine resultant SDP files for RTP senders.