### PR TITLE
is0801: prevent testing tool accessing out of range indexes

### DIFF
--- a/nmostesting/suites/IS0801Test.py
+++ b/nmostesting/suites/IS0801Test.py
@@ -72,6 +72,9 @@ class IS0801Test(GenericTest):
         globalConfig.test = test
 
         outputList = getOutputList()
+        if len(outputList) == 0:
+            return test.UNCLEAR("Not tested. No resources found.")
+
         testRouteAction = outputList[0].findAcceptableTestRoute()
         activation = Activation()
         activation.addAction(testRouteAction)
@@ -105,6 +108,9 @@ class IS0801Test(GenericTest):
 
         Active().unrouteAll()
         outputList = getOutputList()
+        if len(outputList) == 0:
+            return test.UNCLEAR("Not tested. No resources found.")
+
         testRouteAction = outputList[0].findAcceptableTestRoute()
         activation = Activation()
         activation.addAction(testRouteAction)
@@ -127,6 +133,9 @@ class IS0801Test(GenericTest):
         globalConfig.test = test
 
         outputList = getOutputList()
+        if len(outputList) == 0:
+            return test.UNCLEAR("Not tested. No resources found.")
+
         testRouteAction = outputList[0].findAcceptableTestRoute()
         activation = Activation()
         activation.addAction(testRouteAction)
@@ -384,6 +393,10 @@ class IS0801Test(GenericTest):
         preActivationState = active.buildJSONObject()
 
         outputList = getOutputList()
+        if len(outputList) == 0:
+            msg = globalConfig.test.UNCLEAR("Not tested. No resources found.")
+            raise NMOSTestException(msg)
+
         testRouteAction = outputList[0].findAcceptableTestRoute()
         activation = Activation()
         activation.addAction(testRouteAction)

--- a/nmostesting/suites/IS0801Test.py
+++ b/nmostesting/suites/IS0801Test.py
@@ -246,7 +246,7 @@ class IS0801Test(GenericTest):
         """Attempting to violate routing constraints results in an HTTP 400 response"""
         globalConfig.test = test
 
-        outputList = getOutputList()        
+        outputList = getOutputList()
         inputList = getInputList()
 
         if len(inputList) == 0 and len(outputList) == 0:

--- a/nmostesting/suites/IS0801Test.py
+++ b/nmostesting/suites/IS0801Test.py
@@ -154,6 +154,9 @@ class IS0801Test(GenericTest):
         activeInstance = Active()
 
         outputList = getOutputList()
+        if len(outputList) == 0:
+            return test.UNCLEAR("Not tested. No resources found.")
+
         for outputInstance in outputList:
             channelList = outputInstance.getChannelList()
             for channelID in range(0, len(channelList)):
@@ -181,6 +184,9 @@ class IS0801Test(GenericTest):
         forbiddenRoutes = []
         outputList = getOutputList()
         inputList = getInputList()
+        if len(inputList) == 0 or len(outputList) == 0:
+            return test.UNCLEAR("Not tested. No resources found.")
+
         for outputInstance in outputList:
             sourceID = outputInstance.getSourceID()
             for inputInstance in inputList:
@@ -216,6 +222,8 @@ class IS0801Test(GenericTest):
         """Inputs have at least one channel represented in their channels resource"""
         globalConfig.test = test
         inputList = getInputList()
+        if len(inputList) == 0:
+            return test.UNCLEAR("Not tested. No resources found.")
         for inputInstance in inputList:
             channels = inputInstance.getChannelList()
             if len(channels) == 0:
@@ -225,8 +233,9 @@ class IS0801Test(GenericTest):
     def test_12(self, test):
         """Outputs have at least one channel represented in their channels resource"""
         globalConfig.test = test
-
         outputList = getOutputList()
+        if len(outputList) == 0:
+            return test.UNCLEAR("Not tested. No resources found.")
         for outputInstance in outputList:
             channels = outputInstance.getChannelList()
             if len(channels) == 0:
@@ -237,7 +246,12 @@ class IS0801Test(GenericTest):
         """Attempting to violate routing constraints results in an HTTP 400 response"""
         globalConfig.test = test
 
-        outputList = getOutputList()
+        outputList = getOutputList()        
+        inputList = getInputList()
+
+        if len(inputList) == 0 and len(outputList) == 0:
+            return test.UNCLEAR("Not tested. No resources found.")
+
         constrainedOutputList = []
         for outputInstance in outputList:
             constraints = outputInstance.getCaps()
@@ -256,7 +270,6 @@ class IS0801Test(GenericTest):
         if len(constrainedOutputList) == 0:
             return test.NA("Could not test - no outputs have routing constraints set.")
 
-        inputList = getInputList()
         inputIDList = []
         for inputInstance in inputList:
             inputIDList.append(inputInstance.id)
@@ -289,6 +302,8 @@ class IS0801Test(GenericTest):
         globalConfig.test = test
 
         inputList = getInputList()
+        if len(inputList) == 0:
+            return test.UNCLEAR("Not tested. No resources found.")
 
         constrainedInputs = []
         constraintSet = False
@@ -362,6 +377,9 @@ class IS0801Test(GenericTest):
         globalConfig.test = test
 
         inputList = getInputList()
+        if len(inputList) == 0:
+            return test.UNCLEAR("Not tested. No resources found.")
+
         constraintSet = False
         constrainedInputs = []
         for inputInstance in inputList:


### PR DESCRIPTION
Resolves #445 

Whilst writing this I noted there are some other tests which do things like:

```
for outputInstance in outputList:
    ...
```

This won't cause an unhandled exception, but it may result in tests passing when there wasn't actually anything tested. I'm not familiar enough with the tests (and don't have an implementation), but it would be good if similar 'UNCLEAR' messages could be added for these tests if there simply isn't enough data exposed by the API to perform the test properly.