### PR TITLE
Adjust build and docs to use fork of SDPoker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk update \
  && tar -xvzf 3.0rc5.tar.gz --strip-components=1 \
  && rm 3.0rc5.tar.gz \
  && npm config set unsafe-perm true \
- && npm install -g sdpoker
+ && npm install -g AMWA-TV/sdpoker
 
 VOLUME /config
 

--- a/docs/1.1. Installation - Local.md
+++ b/docs/1.1. Installation - Local.md
@@ -9,7 +9,7 @@ Please ensure that the following dependencies are installed on your system first
 - [testssl.sh](https://testssl.sh) (required for BCP-003-01 testing, see our [README](../testssl/README.md) for instructions)
 - [OpenSSL](https://www.openssl.org/) (required for BCP-003-01 OCSP testing)
 - libssl-dev (Linux users only, required for IS-10 testing)
-- [SDPoker](https://github.com/Streampunk/sdpoker) (required for IS-05 SDP testing)
+- [SDPoker](https://github.com/AMWA-TV/sdpoker) (required for IS-05 SDP testing)
 
 ## Installation Method
 

--- a/docs/2.4. Usage - Testing of SDP Files.md
+++ b/docs/2.4. Usage - Testing of SDP Files.md
@@ -1,3 +1,3 @@
 # Testing of SDP files
 
-IS-05-01 test_41 checks that SDP files conform to the expectations of SMPTE ST.2110 and various IETF RFCs. In order to enable these tests, please ensure that [SDPoker](https://github.com/Streampunk/sdpoker) is available on your system.
+IS-05-01 test_41 checks that SDP files conform to the expectations of SMPTE ST.2110 and various IETF RFCs. In order to enable these tests, please ensure that [SDPoker](https://github.com/AMWA-TV/sdpoker) is available on your system.


### PR DESCRIPTION
This updates the build and instructions to reference the patched version of SDPoker until a new official release is available via NPM.