### PR TITLE
is0502: remove check for exact match in transport_file of Receiver

### DIFF
--- a/nmostesting/suites/IS0502Test.py
+++ b/nmostesting/suites/IS0502Test.py
@@ -1123,7 +1123,8 @@ class IS0502Test(GenericTest):
             if response["sender_id"] != data["sender_id"]:
                 return test.FAIL("Receiver {} did not set 'sender_id' to '{}' in staged response"
                                  .format(receiver["id"], data["sender_id"]))
-            if response["transport_file"]["data"] != data["transport_file"]["data"]:
+            # TODO: Ensure the returned SDP has sufficiently similar contents to those submitted, if not identical
+            if response["transport_file"]["data"] is None or response["transport_file"]["data"] == "":
                 return test.FAIL("Receiver {} did not set 'data' to requested SDP file contents in staged response"
                                  .format(receiver["id"]))
             if response["transport_file"]["type"] != data["transport_file"]["type"]:


### PR DESCRIPTION
This removes a check for an exact match between a submitted SDP file and what is returned from a configured Receiver. Whilst these should ideally be an exact match, it is possible that the Receiver may dynamically re-generate the contents of this attribute from its active media and transport parameters.