### PR TITLE
requirements: add minimum websocket-client version

### DIFF
--- a/docs/1.1. Installation - Local.md
+++ b/docs/1.1. Installation - Local.md
@@ -8,7 +8,7 @@ Please ensure that the following dependencies are installed on your system first
 - Git
 - [testssl.sh](https://testssl.sh) (required for BCP-003-01 testing, see our [README](../testssl/README.md) for instructions)
 - [OpenSSL](https://www.openssl.org/) (required for BCP-003-01 OCSP testing)
-- libssl-dev (Linux users only, required for IS-10 testing)
+- libssl-dev and libffi-dev (Linux users only, required for BCP-003-01/IS-10 testing)
 - [SDPoker](https://github.com/AMWA-TV/sdpoker) (required for IS-05 SDP testing)
 
 ## Installation Method

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -798,12 +798,12 @@ def check_internal_requirements():
     installed_pkgs = [pkg[1] for pkg in pkgutil.iter_modules()]
     with open("requirements.txt") as requirements_file:
         for requirement in requirements_file.readlines():
-            requirement_name = requirement.strip()
+            requirement_name = requirement.strip().split(">")[0]
             if requirement_name in corrections:
                 corrected_req = corrections[requirement_name]
             else:
                 corrected_req = requirement_name.replace("-", "_")
-            if corrected_req.split(">")[0] not in installed_pkgs:
+            if corrected_req not in installed_pkgs:
                 print(" * ERROR: Could not find Python requirement '{}'".format(requirement_name))
                 sys.exit(ExitCodes.ERROR)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ requests
 netifaces
 gitpython
 ramlfications
-websocket-client
+websocket-client>=0.54.0
 jsonref
 dnslib
 jinja2


### PR DESCRIPTION
Related to https://github.com/websocket-client/websocket-client/commit/efcf31b30122e05701fb3f696b029baf8faa6d8e

This sets a minimum websocket-client version to prevent compatibility issues with the callbacks.