### PR TITLE
config: add parameters for IS-05 stream destinations

### DIFF
--- a/nmostesting/Config.py
+++ b/nmostesting/Config.py
@@ -99,8 +99,8 @@ PORT_BASE = 5000
 
 # A valid unicast/multicast IP address on the local network which media streams can be sent to. This will be passed
 # into Sender configuration when testing IS-05.
-UNICAST_STREAM_TARGET = "127.0.0.1"
-MULTICAST_STREAM_TARGET = "239.10.53.5"
+UNICAST_STREAM_TARGET = "192.0.2.1"
+MULTICAST_STREAM_TARGET = "233.252.2.1"
 
 # Definition of each API specification and its versions.
 SPECIFICATIONS = {

--- a/nmostesting/Config.py
+++ b/nmostesting/Config.py
@@ -97,6 +97,11 @@ DNS_DOMAIN = "testsuite.nmos.tv"
 # The mock DNS server port cannot be modified from the default of 53.
 PORT_BASE = 5000
 
+# A valid unicast/multicast IP address on the local network which media streams can be sent to. This will be passed
+# into Sender configuration when testing IS-05.
+UNICAST_STREAM_TARGET = "127.0.0.1"
+MULTICAST_STREAM_TARGET = "239.10.53.5"
+
 # Definition of each API specification and its versions.
 SPECIFICATIONS = {
     "is-04": {

--- a/nmostesting/IS05Utils.py
+++ b/nmostesting/IS05Utils.py
@@ -745,9 +745,9 @@ class IS05Utils(NMOSUtils):
 
         for i in range(0, self.get_num_paths(resource_id, resource_type.rstrip("s"))):
             if multicast:
-                data['transport_params'].append({param: "239.10.53.5"})
+                data['transport_params'].append({param: CONFIG.MULTICAST_STREAM_TARGET})
             else:
-                data['transport_params'].append({param: "127.0.0.1"})
+                data['transport_params'].append({param: CONFIG.UNICAST_STREAM_TARGET})
 
         if len(data["transport_params"]) == 0:
             del data["transport_params"]


### PR DESCRIPTION
This minor PR adds parameters to allow alternative unicast/multicast destinations to be used for IS-05 testing. This is mainly intended to allow something more sensible to be configured for unicast testing.