### PR TITLE
Add flag to disable pre-validation of API in case Node is rebooting

### DIFF
--- a/nmostesting/Config.py
+++ b/nmostesting/Config.py
@@ -102,6 +102,9 @@ PORT_BASE = 5000
 UNICAST_STREAM_TARGET = "192.0.2.1"
 MULTICAST_STREAM_TARGET = "233.252.2.1"
 
+# Perform a GET against the submitted API before carrying out any tests to avoid wasting time if it doesn't exist
+PREVALIDATE_API = True
+
 # Definition of each API specification and its versions.
 SPECIFICATIONS = {
     "is-04": {

--- a/nmostesting/GenericTest.py
+++ b/nmostesting/GenericTest.py
@@ -176,12 +176,13 @@ class GenericTest(object):
 
         # Set up
         test = Test("Test setup", "set_up_tests")
-        for api in self.apis:
-            if "spec_path" not in self.apis[api] or self.apis[api]["url"] is None:
-                continue
-            valid, response = self.do_request("GET", self.apis[api]["url"])
-            if not valid or response.status_code != 200:
-                raise NMOSInitException("No API found at {}".format(self.apis[api]["url"]))
+        if CONFIG.PREVALIDATE_API:
+            for api in self.apis:
+                if "spec_path" not in self.apis[api] or self.apis[api]["url"] is None:
+                    continue
+                valid, response = self.do_request("GET", self.apis[api]["url"])
+                if not valid or response.status_code != 200:
+                    raise NMOSInitException("No API found at {}".format(self.apis[api]["url"]))
         self.set_up_tests()
         self.result.append(test.NA(""))
 


### PR DESCRIPTION
Reported by @mjeras

If a Node is being rebooted in order to test IS-04 discovery, the API won't be up when the pre-validation GET is performed. This flag allows it to be disabled in select circumstances to avoid this problem.