### PR TITLE
Use local timestamps in testing Query API pagination cursors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,5 @@ Detailed instructions can be found in the [documentation](docs/)
 
 ## Important Notes
 *   The IS-04 Node and IS-09 Discovery tests create mock mDNS announcements on the network unless the `nmostesting/Config.py` `ENABLE_DNS_SD` parameter is set to `False`, or the `DNS_SD_MODE` parameter is set to `'unicast'`. It is critical that these tests are only run in isolated network segments away from production Nodes and registries. Only one Node can be tested at a single time. If `ENABLE_DNS_SD` is set to `False`, make sure to update the Query API hostname/IP and port via `QUERY_API_HOST` and `QUERY_API_PORT` in the `nmostesting/Config.py`.
+*   For IS-04 Registry tests of Query API pagination, make sure the time of the test device and the time of the device hosting the tests is synchronized.
 *   For IS-05 tests #29 and #30, and IS-08 test #4 (absolute activation), make sure the time of the test device and the time of the device hosting the tests is synchronized.

--- a/nmostesting/IS05Utils.py
+++ b/nmostesting/IS05Utils.py
@@ -19,8 +19,12 @@ import time
 
 from random import randint
 from . import TestHelper
-from .NMOSUtils import NMOSUtils, IMMEDIATE_ACTIVATION, SCHEDULED_ABSOLUTE_ACTIVATION, SCHEDULED_RELATIVE_ACTIVATION
+from .NMOSUtils import NMOSUtils
 from . import Config as CONFIG
+
+IMMEDIATE_ACTIVATION = 'activate_immediate'
+SCHEDULED_ABSOLUTE_ACTIVATION = 'activate_scheduled_absolute'
+SCHEDULED_RELATIVE_ACTIVATION = 'activate_scheduled_relative'
 
 
 class IS05Utils(NMOSUtils):

--- a/nmostesting/NMOSUtils.py
+++ b/nmostesting/NMOSUtils.py
@@ -71,16 +71,13 @@ DEFAULT_ARGS = {
     "selection": "all"
 }
 
-IMMEDIATE_ACTIVATION = 'activate_immediate'
-SCHEDULED_ABSOLUTE_ACTIVATION = 'activate_scheduled_absolute'
-SCHEDULED_RELATIVE_ACTIVATION = 'activate_scheduled_relative'
-
 
 class NMOSUtils(object):
     def __init__(self, url):
         self.url = url
 
-    def from_UTC(self, secs, nanos, is_leap=False):
+    @staticmethod
+    def from_UTC(secs, nanos, is_leap=False):
         """Convert a UTC time into a TAI time"""
         leap_sec = 0
         for tbl_sec, tbl_tai_sec_minus_1 in UTC_LEAP:
@@ -89,15 +86,17 @@ class NMOSUtils(object):
                 break
         return secs + leap_sec + is_leap, nanos
 
-    def get_TAI_time(self, offset=0.0):
+    @staticmethod
+    def get_TAI_time(offset=0.0):
         """Get the current TAI time as a colon-separated string"""
         myTime = time.time() + offset
         secs = int(myTime)
         nanos = int((myTime - secs) * 1e9)
-        ippTime = self.from_UTC(secs, nanos)
+        ippTime = NMOSUtils.from_UTC(secs, nanos)
         return str(ippTime[0]) + ":" + str(ippTime[1])
 
-    def compare_resource_version(self, ver1, ver2):
+    @staticmethod
+    def compare_resource_version(ver1, ver2):
         """Returns 1 if ver1>ver2, 0 if ver1=ver2, and -1 if ver1<ver2"""
         ver1_bits = ver1.split(":")
         ver2_bits = ver2.split(":")
@@ -116,7 +115,8 @@ class NMOSUtils(object):
         else:
             return 0
 
-    def compare_api_version(self, ver1, ver2):
+    @staticmethod
+    def compare_api_version(ver1, ver2):
         """Returns 1 if ver1>ver2, 0 if ver1=ver2, and -1 if ver1<ver2"""
         ver1_bits = ver1.strip("v").split(".")
         ver2_bits = ver2.strip("v").split(".")
@@ -135,7 +135,8 @@ class NMOSUtils(object):
         else:
             return 0
 
-    def compare_urls(self, url1, url2):
+    @staticmethod
+    def compare_urls(url1, url2):
         """Check that two URLs to a given API are sufficiently similar"""
 
         url1_parsed = urlparse(url1.rstrip("/"))
@@ -160,11 +161,13 @@ class NMOSUtils(object):
 
         return True
 
-    def sampled_list(self, resource_list):
+    @staticmethod
+    def sampled_list(resource_list):
         if CONFIG.MAX_TEST_ITERATIONS > 0:
             return sample(resource_list, min(CONFIG.MAX_TEST_ITERATIONS, len(resource_list)))
         else:
             return resource_list
 
-    def sort_versions(self, versions_list):
-        return sorted(versions_list, key=functools.cmp_to_key(self.compare_api_version))
+    @staticmethod
+    def sort_versions(versions_list):
+        return sorted(versions_list, key=functools.cmp_to_key(NMOSUtils.compare_api_version))

--- a/nmostesting/suites/IS0402Test.py
+++ b/nmostesting/suites/IS0402Test.py
@@ -333,18 +333,24 @@ class IS0402Test(GenericTest):
             # For debugging
             node_data["tags"]["index"] = [str(_)]
 
+            # Add a little delay between the POST requests, and record the local timestamps
+            # before the request and after the response, in order to test pagination cursors
+            # (unfortunately the required timestamp is unknowable via the registry APIs)
+
+            # Note: In order to be able to accomplish 20 of these registration post requests
+            # well before the default garbage collection interval of 12s, the delay can't be
+            # much more than 0.1 seconds...
+            PAGING_TIMESTAMP_DELAY = 0.1
+
+            before = self.is04_query_utils.get_TAI_time()
+            sleep(PAGING_TIMESTAMP_DELAY)
+
             self.post_resource(test, "node", node_data, codes=[201])
 
-            # Perform a Query API request to get the update timestamp of the most recently POSTed node
-            # Wish there was a better way, as this puts the cart before the horse!
-            # Another alternative would be to use local timestamps, provided clocks were synchronised?
+            sleep(PAGING_TIMESTAMP_DELAY)
+            after = self.is04_query_utils.get_TAI_time()
 
-            response = self.do_paged_request(limit=1)
-            self.do_test_paged_response(test, response,
-                                        expected_ids=[node_data["id"]],
-                                        expected_since=None, expected_until=None)
-            valid, r, query_parameters = response
-            update_timestamps.append(r.headers["X-Paging-Until"])
+            update_timestamps.append(TS.permitted(before, after))
 
         # Bear in mind that the returned arrays are in forward order
         # whereas Query API responses are required to be in reverse order
@@ -358,10 +364,10 @@ class IS0402Test(GenericTest):
 
         if limit is not None:
             query_parameters.append("paging.limit=" + str(limit))
-        if since is not None:
-            query_parameters.append("paging.since=" + since)
-        if until is not None:
-            query_parameters.append("paging.until=" + until)
+        if since is not None and TS.upper_TAI(since) is not None:
+            query_parameters.append("paging.since=" + TS.upper_TAI(since))
+        if until is not None and TS.upper_TAI(until) is not None:
+            query_parameters.append("paging.until=" + TS.upper_TAI(until))
 
         if description is not None:
             query_parameters.append("description=" + description)
@@ -445,21 +451,22 @@ class IS0402Test(GenericTest):
 
         # check *values* of paging headers after body
 
-        def compare_timestamp(expected, actual):
-            return expected is None or self.is04_query_utils.compare_resource_version(expected, actual) == 0
-
         try:
             since = response.headers["X-Paging-Since"]
             until = response.headers["X-Paging-Until"]
             limit = response.headers["X-Paging-Limit"]
 
-            if not compare_timestamp(expected_since, since):
-                raise NMOSTestException(test.FAIL("Query API response did not include the correct X-Paging-Since "
-                                                  "header, for query: {}".format(query_string)))
+            if not TS.compare(expected_since, since):
+                raise NMOSTestException(test.FAIL("Query API response header X-Paging-Since '{}' is outside the "
+                                                  "expected range {}, for query: {}. This could just indicate the "
+                                                  "API and Testing Tool clocks are not synchronized."
+                                                  .format(since, TS.str(expected_since), query_string)))
 
-            if not compare_timestamp(expected_until, until):
-                raise NMOSTestException(test.FAIL("Query API response did not include the correct X-Paging-Until "
-                                                  "header, for query: {}".format(query_string)))
+            if not TS.compare(expected_until, until):
+                raise NMOSTestException(test.FAIL("Query API response header X-Paging-Until '{}' is outside the "
+                                                  "expected range {}, for query: {}. This could just indicate the "
+                                                  "API and Testing Tool clocks are not synchronized."
+                                                  .format(until, TS.str(expected_until), query_string)))
 
             if not (expected_limit is None or str(expected_limit) == limit):
                 raise NMOSTestException(test.FAIL("Query API response did not include the correct X-Paging-Limit "
@@ -562,6 +569,11 @@ class IS0402Test(GenericTest):
         ts.insert(0, None)
         ids.insert(0, None)
 
+        # Definitely covers the timestamps that are after the i-th post and before the following one
+        # (but also covers shortly before the i-th or shortly after the following one unfortunately)
+        def TS_recommended(i):
+            return TS.extended(ts[i], ts[i], ts[i + 1] if len(ts) > i + 1 else None)
+
         # "Implementations may specify their own default and maximum for the limit"
         # so theoretically, if a Query API had a very low maximum limit, that number could be returned
         # rather than the requested limit, for many of the following tests.
@@ -573,35 +585,37 @@ class IS0402Test(GenericTest):
         response = self.do_paged_request(description=description, limit=10)
         self.do_test_paged_response(test, response,
                                     expected_ids=ids[11:20 + 1],
-                                    expected_since=ts[10], expected_until=ts[20], expected_limit=10)
+                                    expected_since=TS_recommended(10), expected_until=TS_recommended(20),
+                                    expected_limit=10)
 
         # Example 2: Request With Custom Limit
 
         response = self.do_paged_request(description=description, limit=5)
         self.do_test_paged_response(test, response,
                                     expected_ids=ids[16:20 + 1],
-                                    expected_since=ts[15], expected_until=ts[20], expected_limit=5)
+                                    expected_since=TS_recommended(15), expected_until=TS_recommended(20),
+                                    expected_limit=5)
 
         # Example 3: Request With Since Parameter
 
         response = self.do_paged_request(description=description, since=ts[4], limit=10)
         self.do_test_paged_response(test, response,
                                     expected_ids=ids[5:14 + 1],
-                                    expected_since=ts[4], expected_until=ts[14], expected_limit=10)
+                                    expected_since=ts[4], expected_until=TS_recommended(14), expected_limit=10)
 
         # Example 4: Request With Until Parameter
 
         response = self.do_paged_request(description=description, until=ts[16], limit=10)
         self.do_test_paged_response(test, response,
                                     expected_ids=ids[7:16 + 1],
-                                    expected_since=ts[6], expected_until=ts[16], expected_limit=10)
+                                    expected_since=TS_recommended(6), expected_until=ts[16], expected_limit=10)
 
         # Example 5: Request With Since & Until Parameters
 
         response = self.do_paged_request(description=description, since=ts[4], until=ts[16], limit=10)
         self.do_test_paged_response(test, response,
                                     expected_ids=ids[5:14 + 1],
-                                    expected_since=ts[4], expected_until=ts[14], expected_limit=10)
+                                    expected_since=ts[4], expected_until=TS_recommended(14), expected_limit=10)
 
         return test.PASS()
 
@@ -614,36 +628,36 @@ class IS0402Test(GenericTest):
         # Some additional test cases based on Basecamp discussion
         # See https://basecamp.com/1791706/projects/10192586/messages/70545892
 
-        timestamps, ids = self.post_sample_nodes(test, 20, description)
+        ts, ids = self.post_sample_nodes(test, 20, description)
 
-        after = "{}:0".format(int(timestamps[-1].split(":")[0]) + 1)
-        before = "{}:0".format(int(timestamps[0].split(":")[0]) - 1)
+        # Specifies a precise timestamp that is definitely after the last registration
+        after = TS.upper(ts[-1])
+        # Specifies a precise timestamp that is definitely before the first registration
+        before = TS.lower(ts[0])
 
         # Check the header values when a client specifies a paging.since value after the newest resource's timestamp
 
         self.do_test_paged_response(test, self.do_paged_request(description=description, since=after),
                                     expected_ids=[],
-                                    expected_since=after, expected_until=after)
+                                    expected_since=after, expected_until=TS.ge(after))
 
         # Check the header values when a client specifies a paging.until value before the oldest resource's timestamp
 
         self.do_test_paged_response(test, self.do_paged_request(description=description, until=before),
                                     expected_ids=[],
-                                    expected_since="0:0", expected_until=before)
+                                    expected_since=TS.epoch(), expected_until=before)
 
         # Check the header values for a query that results in only one resource, without any paging parameters
 
-        # expected_until check could be more forgiving, i.e. >= timestamps[-1] and <= 'now'
         self.do_test_paged_response(test, self.do_paged_request(id=ids[12]),
                                     expected_ids=[ids[12]],
-                                    expected_since="0:0", expected_until=timestamps[-1])
+                                    expected_since=TS.epoch(), expected_until=TS.ge(ts[-1]))
 
         # Check the header values for a query that results in no resources, without any paging parameters
 
-        # expected_until check could be more forgiving, i.e. >= timestamps[-1] and <= 'now'
         self.do_test_paged_response(test, self.do_paged_request(id=str(uuid.uuid4())),
                                     expected_ids=[],
-                                    expected_since="0:0", expected_until=timestamps[-1])
+                                    expected_since=TS.epoch(), expected_until=TS.ge(ts[-1]))
 
         return test.PASS()
 
@@ -702,11 +716,10 @@ class IS0402Test(GenericTest):
         #          request      (                                                                      ]
         #          response           (       ^  ^  ^        ^   ^   ^           ^   ^   ^           ^ ]
 
-        # expected_until check could be more forgiving, i.e. >= ts[19] and <= 'now'
-        # expected_since check could be more forgiving, i.e. >= ts[1] and < ts[4]
         self.do_test_paged_response(test, self.do_paged_request(label="foo", limit=10),
                                     expected_ids=[ids[i] for i in range(len(ids)) if foo(i)][-10:],
-                                    expected_since=ts[1], expected_until=ts[19], expected_limit=10)
+                                    expected_since=TS.extended(ts[1], ts[1], ts[4]), expected_until=TS.ge(ts[19]),
+                                    expected_limit=10)
 
         # Query 2: 'prev' of Query 1
         #          filter         0, 1, -, -, 4, 5, 6, -, -, 9, 10, 11, --, --, 14, 15, 16, --, --, 19
@@ -715,7 +728,8 @@ class IS0402Test(GenericTest):
 
         self.do_test_paged_response(test, self.do_paged_request(label="foo", until=ts[1], limit=10),
                                     expected_ids=[ids[i] for i in range(len(ids)) if foo(i)][0:-10],
-                                    expected_since="0:0", expected_until=ts[1], expected_limit=10)
+                                    expected_since=TS.epoch(), expected_until=TS.gt(ts[1]),
+                                    expected_limit=10)
 
         # Query 3: 'next' of Query 1
         #          filter         0, 1, -, -, 4, 5, 6, -, -, 9, 10, 11, --, --, 14, 15, 16, --, --, 19
@@ -724,38 +738,38 @@ class IS0402Test(GenericTest):
 
         self.do_test_paged_response(test, self.do_paged_request(label="foo", since=ts[19], limit=10),
                                     expected_ids=[],
-                                    expected_since=ts[19], expected_until=ts[19], expected_limit=10)
+                                    expected_since=TS.upper(ts[19]), expected_until=TS.gt(ts[19]),
+                                    expected_limit=10)
 
         # Query 4: "bar", default paging parameters
         #          filter         -, -, 2, 3, -, -, -, 7, 8, -, --, --, 12, 13, --, --, --, 17, 18, --
         #          request      (                                                                      ]
         #          response     (       ^  ^           ^  ^              ^   ^               ^   ^     ]
 
-        # expected_until check could be more forgiving, i.e. >= ts[19] and <= 'now'
         self.do_test_paged_response(test, self.do_paged_request(label="bar", limit=10),
                                     expected_ids=[ids[i] for i in range(len(ids)) if bar(i)],
-                                    expected_since="0:0", expected_until=ts[19], expected_limit=10)
+                                    expected_since=TS.epoch(), expected_until=TS.ge(ts[19]),
+                                    expected_limit=10)
 
         # Query 5: "bar", limited to 3
         #          filter         -, -, 2, 3, -, -, -, 7, 8, -, --, --, 12, 13, --, --, --, 17, 18, --
         #          request      (                                                                      ]
         #          response                                               (  ^               ^   ^     ]
 
-        # expected_until check could be more forgiving, i.e. >= ts[18] and <= 'now'
-        # expected_since check could be more forgiving, i.e. >= ts[12] and < ts[13]
         self.do_test_paged_response(test, self.do_paged_request(label="bar", limit=3),
                                     expected_ids=[ids[13], ids[17], ids[18]],
-                                    expected_since=ts[12], expected_until=ts[19], expected_limit=3)
+                                    expected_since=TS.extended(ts[12], ts[12], ts[13]), expected_until=TS.ge(ts[18]),
+                                    expected_limit=3)
 
         # Query 6: 'prev' of Query 5
         #          filter         -, -, 2, 3, -, -, -, 7, 8, -, --, --, 12, 13, --, --, --, 17, 18, --
         #          request      (                                          ]
         #          response                 (          ^  ^              ^ ]
 
-        # expected_since check could be more forgiving, i.e. >= ts[3] and < ts[7]
         self.do_test_paged_response(test, self.do_paged_request(label="bar", until=ts[12], limit=3),
                                     expected_ids=[ids[7], ids[8], ids[12]],
-                                    expected_since=ts[3], expected_until=ts[12], expected_limit=3)
+                                    expected_since=TS.extended(ts[3], ts[3], ts[7]), expected_until=TS.upper(ts[12]),
+                                    expected_limit=3)
 
         # Query 7: like Query 5, with paging.since specified, but still enough matches
         #          filter         -, -, 2, 3, -, -, -, 7, 8, -, --, --, 12, 13, --, --, --, 17, 18, --
@@ -764,7 +778,8 @@ class IS0402Test(GenericTest):
 
         self.do_test_paged_response(test, self.do_paged_request(label="bar", since=ts[4], until=ts[12], limit=3),
                                     expected_ids=[ids[7], ids[8], ids[12]],
-                                    expected_since=ts[4], expected_until=ts[12], expected_limit=3)
+                                    expected_since=TS.upper(ts[4]), expected_until=TS.upper(ts[12]),
+                                    expected_limit=3)
 
         # Query 8: like Query 5, with paging.since specified, and not enough matches
         #          filter         -, -, 2, 3, -, -, -, 7, 8, -, --, --, 12, 13, --, --, --, 17, 18, --
@@ -773,7 +788,8 @@ class IS0402Test(GenericTest):
 
         self.do_test_paged_response(test, self.do_paged_request(label="bar", since=ts[9], until=ts[12], limit=3),
                                     expected_ids=[ids[12]],
-                                    expected_since=ts[9], expected_until=ts[12], expected_limit=3)
+                                    expected_since=TS.upper(ts[9]), expected_until=TS.upper(ts[12]),
+                                    expected_limit=3)
 
         # Query 9: like Query 5, but no matches
         #          filter         -, -, 2, 3, -, -, -, 7, 8, -, --, --, 12, 13, --, --, --, 17, 18, --
@@ -782,7 +798,8 @@ class IS0402Test(GenericTest):
 
         self.do_test_paged_response(test, self.do_paged_request(label="bar", since=ts[9], until=ts[11], limit=3),
                                     expected_ids=[],
-                                    expected_since=ts[9], expected_until=ts[11], expected_limit=3)
+                                    expected_since=TS.upper(ts[9]), expected_until=TS.upper(ts[11]),
+                                    expected_limit=3)
 
         return test.PASS()
 
@@ -791,8 +808,8 @@ class IS0402Test(GenericTest):
 
         self.do_test_paged_trait(test)
 
-        before = self.is04_query_utils.get_TAI_time()
-        after = self.is04_query_utils.get_TAI_time(1)
+        before = TS.required(self.is04_query_utils.get_TAI_time())
+        after = TS.required(self.is04_query_utils.get_TAI_time(1))
 
         # Specifying since after until is a bad request
         valid, response, query_parameters = self.do_paged_request(since=after, until=before)
@@ -840,7 +857,7 @@ class IS0402Test(GenericTest):
         response = self.do_paged_request(description=description, limit=count)
         self.do_test_paged_response(test, response,
                                     expected_ids=ids,
-                                    expected_since="0:0", expected_until=ts[-1], expected_limit=count)
+                                    expected_since=TS.epoch(), expected_until=TS.ge(ts[-1]), expected_limit=count)
 
         resources = response[1].json()  # valid json guaranteed by do_test_paged_response
         resources.reverse()
@@ -850,14 +867,14 @@ class IS0402Test(GenericTest):
         response = self.do_paged_request(description=description, limit=count, since=ts[-1])
         self.do_test_paged_response(test, response,
                                     expected_ids=[],
-                                    expected_since=ts[-1], expected_until=None, expected_limit=count)
+                                    expected_since=TS.upper(ts[-1]), expected_until=None, expected_limit=count)
 
         # 'current' page should be same as initial response
 
         response = self.do_paged_request(description=description, limit=count, until=ts[-1])
         self.do_test_paged_response(test, response,
                                     expected_ids=ids,
-                                    expected_since=None, expected_until=ts[-1], expected_limit=count)
+                                    expected_since=None, expected_until=TS.ge(ts[-1]), expected_limit=count)
 
         # after an update, the 'next' page should now contain only the updated resource
 
@@ -866,14 +883,14 @@ class IS0402Test(GenericTest):
         response = self.do_paged_request(description=description, limit=count, since=ts[-1])
         self.do_test_paged_response(test, response,
                                     expected_ids=[ids[1]],
-                                    expected_since=ts[-1], expected_until=None, expected_limit=count)
+                                    expected_since=TS.upper(ts[-1]), expected_until=None, expected_limit=count)
 
         # and what was the 'current' page should now contain only the unchanged resources
 
         response = self.do_paged_request(description=description, limit=count, until=ts[-1])
         self.do_test_paged_response(test, response,
                                     expected_ids=[ids[0], ids[2]],
-                                    expected_since=None, expected_until=ts[-1], expected_limit=count)
+                                    expected_since=None, expected_until=TS.upper(ts[-1]), expected_limit=count)
 
         # after the other resources are also updated, what was the 'current' page should now be empty
 
@@ -883,14 +900,14 @@ class IS0402Test(GenericTest):
         response = self.do_paged_request(description=description, limit=count, until=ts[-1])
         self.do_test_paged_response(test, response,
                                     expected_ids=[],
-                                    expected_since=None, expected_until=ts[-1], expected_limit=count)
+                                    expected_since=None, expected_until=TS.upper(ts[-1]), expected_limit=count)
 
         # and what was the 'next' page should now contain all the resources in the update order
 
         response = self.do_paged_request(description=description, limit=count, since=ts[-1])
         self.do_test_paged_response(test, response,
                                     expected_ids=[ids[1], ids[2], ids[0]],
-                                    expected_since=ts[-1], expected_until=None, expected_limit=count)
+                                    expected_since=TS.upper(ts[-1]), expected_until=None, expected_limit=count)
 
         return test.PASS()
 
@@ -2469,3 +2486,93 @@ class IS0402Test(GenericTest):
         api = self.apis[REG_API_KEY]
         if not self.is04_reg_utils.compare_api_version(api["version"], "v2.0") < 0:
             raise NMOSTestException(test.FAIL("Version > 1 not supported yet."))
+
+
+class TS:
+    """
+    Timestamp Specifications represented as a tuple of TAI values, the first and last of which indicate the
+    lower and upper bounds, either of which may be None to indicate the range continues in that direction.
+    A middle element, when present and not None, indicates the expected value.
+    """
+
+    # Factory functions
+
+    @staticmethod
+    def required(required_TAI):
+        return (required_TAI,)
+
+    @staticmethod
+    def recommended(lower_TAI, recommended_TAI, upper_TAI):
+        return (lower_TAI, recommended_TAI, upper_TAI)
+
+    @staticmethod
+    def permitted(lower_TAI, upper_TAI):
+        return (lower_TAI, upper_TAI)
+
+    @staticmethod
+    def epoch():
+        return TS.required("0:0")
+
+    # Accessors
+
+    @staticmethod
+    def lower_TAI(ts):
+        return ts[0]
+
+    @staticmethod
+    def recommended_TAI(ts):
+        return ts[len(ts) // 2] if 1 == len(ts) % 2 else None
+
+    @staticmethod
+    def upper_TAI(ts):
+        return ts[-1]
+
+    # Transformations
+
+    @staticmethod
+    def lower(ts):
+        return TS.required(TS.lower_TAI(ts))
+
+    @staticmethod
+    def upper(ts):
+        return TS.required(TS.upper_TAI(ts))
+
+    @staticmethod
+    def lt(ts):
+        return (None, TS.lower_TAI(ts))
+
+    @staticmethod
+    def le(ts):
+        return (None, TS.upper_TAI(ts))
+
+    @staticmethod
+    def gt(ts):
+        return (TS.upper_TAI(ts), None)
+
+    @staticmethod
+    def ge(ts):
+        return (TS.lower_TAI(ts), None)
+
+    @staticmethod
+    def extended(lower, recommended, upper):
+        return (
+            TS.lower_TAI(lower) if lower is not None else None,
+            TS.recommended_TAI(recommended) if recommended is not None else None,
+            TS.upper_TAI(upper) if upper is not None else None
+        )
+
+    # Operations
+
+    @staticmethod
+    def compare(ts, TAI):
+        cmp = IS04Utils.compare_resource_version
+        return ts is None or \
+            ((TS.lower_TAI(ts) is None or cmp(TS.lower_TAI(ts), TAI) <= 0) and
+             (TS.upper_TAI(ts) is None or cmp(TS.upper_TAI(ts), TAI) >= 0))
+
+    @staticmethod
+    def str(ts):
+        if TS.recommended_TAI(ts) is None:
+            return "{} - {}".format(TS.lower_TAI(ts) or '', TS.upper_TAI(ts) or '')
+        else:
+            return "{} -({})- {}".format(TS.lower_TAI(ts) or '', TS.recommended_TAI(ts), TS.upper_TAI(ts) or '')

--- a/nmostesting/suites/IS0402Test.py
+++ b/nmostesting/suites/IS0402Test.py
@@ -609,21 +609,24 @@ class IS0402Test(GenericTest):
         response = self.do_paged_request(description=description, since=ts[4], limit=10)
         self.do_test_paged_response(test, response,
                                     expected_ids=ids[5:14 + 1],
-                                    expected_since=ts[4], expected_until=TS_recommended(14), expected_limit=10)
+                                    expected_since=TS.upper(ts[4]), expected_until=TS_recommended(14),
+                                    expected_limit=10)
 
         # Example 4: Request With Until Parameter
 
         response = self.do_paged_request(description=description, until=ts[16], limit=10)
         self.do_test_paged_response(test, response,
                                     expected_ids=ids[7:16 + 1],
-                                    expected_since=TS_recommended(6), expected_until=ts[16], expected_limit=10)
+                                    expected_since=TS_recommended(6), expected_until=TS.upper(ts[16]),
+                                    expected_limit=10)
 
         # Example 5: Request With Since & Until Parameters
 
         response = self.do_paged_request(description=description, since=ts[4], until=ts[16], limit=10)
         self.do_test_paged_response(test, response,
                                     expected_ids=ids[5:14 + 1],
-                                    expected_since=ts[4], expected_until=TS_recommended(14), expected_limit=10)
+                                    expected_since=TS.upper(ts[4]), expected_until=TS_recommended(14),
+                                    expected_limit=10)
 
         return test.PASS()
 
@@ -677,7 +680,7 @@ class IS0402Test(GenericTest):
 
         timestamps, ids = self.post_sample_nodes(test, 20, description)
 
-        ts = timestamps[12]
+        ts = TS.upper(timestamps[12])
 
         # Check paging.since == paging.until
 

--- a/nmostesting/suites/IS0801Test.py
+++ b/nmostesting/suites/IS0801Test.py
@@ -17,7 +17,7 @@ import copy
 
 from ..GenericTest import GenericTest, NMOSTestException
 from ..TestHelper import compare_json
-from ..NMOSUtils import NMOSUtils, SCHEDULED_ABSOLUTE_ACTIVATION, SCHEDULED_RELATIVE_ACTIVATION
+from ..IS05Utils import IS05Utils, SCHEDULED_ABSOLUTE_ACTIVATION, SCHEDULED_RELATIVE_ACTIVATION
 from .is08.action import Action
 from .is08.activation import Activation
 from .is08.inputs import getInputList
@@ -97,7 +97,7 @@ class IS0801Test(GenericTest):
         """Absolute offset activations can be called on the API"""
         globalConfig.test = test
 
-        timestamp = NMOSUtils(globalConfig.apiUrl).get_TAI_time(offset=2.0)
+        timestamp = IS05Utils.get_TAI_time(offset=2.0)
         self.check_delayed_activation(timestamp, SCHEDULED_ABSOLUTE_ACTIVATION)
 
         return test.PASS()

--- a/nmostesting/suites/IS0802Test.py
+++ b/nmostesting/suites/IS0802Test.py
@@ -43,7 +43,6 @@ class IS0802Test(GenericTest):
         self.is05_resources = {"senders": [], "receivers": [], "devices": [], "sources": [], "_requested": []}
         self.is04_resources = {"senders": [], "receivers": [], "devices": [], "sources": [], "_requested": []}
         self.node_url = self.apis[NODE_API_KEY]["url"]
-        self.nmos_utils = NMOSUtils(globalConfig.apiUrl)
 
     def test_01(self, test):
         """ Activations result in a Device version number increment"""
@@ -173,7 +172,7 @@ class IS0802Test(GenericTest):
                     if not alreadyAdded:
                         devicesWithAdvertisements.append(device)
                         alreadyAdded = True
-                        if self.nmos_utils.compare_urls(globalConfig.apiUrl, control["href"]):
+                        if NMOSUtils.compare_urls(globalConfig.apiUrl, control["href"]):
                             found_api_match = True
 
         if len(devicesWithAdvertisements) > 0 and not found_api_match:

--- a/nmostesting/suites/is08/activation.py
+++ b/nmostesting/suites/is08/activation.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from ...GenericTest import NMOSTestException
-from ...NMOSUtils import IMMEDIATE_ACTIVATION
+from ...IS05Utils import IMMEDIATE_ACTIVATION
 from .calls import Call
 from .testConfig import globalConfig
 import re


### PR DESCRIPTION
Resolves #472, though requires the clocks of the Testing Tool and the Registry under test to be synchronized within ±100ms.
