### PR TITLE
is08: fix missing method when caps array empty

### DIFF
--- a/nmostesting/suites/is08/outputs.py
+++ b/nmostesting/suites/is08/outputs.py
@@ -60,7 +60,8 @@ class ACMOutput:
             msg = 'Could not find caps routable_inputs parameter for output {}'.format(self.id)
             raise NMOSTestException(self.test.FAIL(msg))
         if routableInputs is None:
-            return self.getInputList()
+            inputList = getIOList("input")
+            return inputList
         else:
             return routableInputs
 


### PR DESCRIPTION
In https://amwa-tv.github.io/nmos-audio-channel-mapping/branches/v1.0.x/docs/4.0._Behaviour.html#output-routing-constraints it specifies that if the 'routable_inputs' caps array is null then any input can be routed to the output. The code certainly expressed this intention, but as far as I can tell this would never have worked.

This fix unfortunately creates a circular dependency between the inputs and outputs files, but this is probably a minor concern here.