### PR TITLE
Added test for patching auto values

### DIFF
--- a/nmostesting/suites/IS0501Test.py
+++ b/nmostesting/suites/IS0501Test.py
@@ -1157,8 +1157,8 @@ class IS0501Test(GenericTest):
                             for leg in response_active["transport_params"]:
                                 for param in leg:
                                     if param in autoParams and leg[param] == "auto":
-                                        return test.FAIL("Patched 'auto' for '{}' did not translate on  \
-                                                        '/active' endpoint".format(param))
+                                        return test.FAIL("Patched 'auto' for '{}' did not translate on "
+                                                         "'/active' endpoint".format(param))
                         except KeyError:
                             return test.FAIL("Did not find 'transport_params' in response from {}"
                                              .format(dest_active))

--- a/nmostesting/suites/IS0501Test.py
+++ b/nmostesting/suites/IS0501Test.py
@@ -216,53 +216,53 @@ class IS0501Test(GenericTest):
             return test.UNCLEAR("Not tested. No resources found.")
 
     def test_11_02(self, test):
-        """Patched 'auto' values are translated on '/active' endpoint for all rtp senders"""
-        if len(self.senders) > 0:
-            rtpSenders = list()
-            for sender in self.senders:
-                if self.transport_types[sender] == "urn:x-nmos:transport:rtp":
-                    rtpSenders.append(sender)
-
-            if len(rtpSenders) > 0:
-                for rtpSender in rtpSenders:
-                    data = {
-                        "transport_params": [
-                            {
-                                "source_ip": "auto",
-                                "destination_ip": "auto",
-                                "source_port": "auto",
-                                "destination_port": "auto"
-                            }
-                        ],
-                        "activation": {
-                            "mode": "activate_immediate"
-                        }
+        """Patched 'auto' values are translated on '/active' endpoint for all RTP senders"""
+        rtpSenders = list()
+        for sender in self.senders:
+            if self.transport_types[sender] == "urn:x-nmos:transport:rtp":
+                rtpSenders.append(sender)
+        for rtpSender in rtpSenders:
+            data = {
+                "transport_params": [
+                    {
+                        "source_ip": "auto",
+                        "destination_ip": "auto",
+                        "source_port": "auto",
+                        "destination_port": "auto"
                     }
-                    dest_staged = "single/senders/" + rtpSender + "/staged/"
-                    dest_active = "single/senders/" + rtpSender + "/active/"
-                    valid, response = self.is05_utils.checkCleanRequestJSON("PATCH", dest_staged, data=data)
-                    if valid:
-                        if len(response["transport_params"]) >= 1:
-                            valid2, response2 = self.is05_utils.checkCleanRequestJSON("GET", dest_active + "/")
-                            if valid2:
-                                try:
-                                    if response2["transport_params"][0]["source_ip"] != "auto" and \
-                                     response2["transport_params"][0]["destination_ip"] != "auto":
-                                        pass
-                                    else:
-                                        return test.FAIL("Patched 'auto' for 'interface_ip' did not \
-                                            translate on '/active' endpoint")
-                                except KeyError:
-                                    return test.FAIL("Did not find interface_ip in response from {}"
-                                                     .format(dest_active))
+                ],
+                "activation": {
+                    "mode": "activate_immediate"
+                }
+            }
+            dest_staged = "single/senders/" + rtpSender + "/staged/"
+            dest_active = "single/senders/" + rtpSender + "/active/"
+            valid, response = self.is05_utils.checkCleanRequestJSON("PATCH", dest_staged, data=data)
+            if valid:
+                if len(response["transport_params"]) >= 1:
+                    valid2, response2 = self.is05_utils.checkCleanRequestJSON("GET", dest_active + "/")
+                    if valid2:
+                        try:
+                            if response2["transport_params"][0]["source_ip"] != "auto" and \
+                                    response2["transport_params"][0]["destination_ip"] != "auto":
+                                pass
                             else:
-                                return test.FAIL(response2)
-                        else:
-                            return test.UNCLEAR("Not tested. No rtp ")
+                                return test.FAIL("Patched 'auto' for 'interface_ip' did not translate on "
+                                                 "'/active' endpoint")
+                        except KeyError:
+                            return test.FAIL("Did not find interface_ip in response from {}"
+                                             .format(dest_active))
                     else:
-                        return test.FAIL(response)
-                return test.PASS()
-        return test.UNCLEAR("Not tested. No resources found.")
+                        return test.FAIL(response2)
+                else:
+                    return test.UNCLEAR("Not tested. No rtp ")
+            else:
+                return test.FAIL(response)
+
+        if len(rtpSenders) > 0:
+            return test.PASS()
+        else:
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_12(self, test):
         """Receiver are using valid combination of parameters"""
@@ -333,49 +333,49 @@ class IS0501Test(GenericTest):
             return test.UNCLEAR("Not tested. No resources found.")
 
     def test_12_02(self, test):
-        """Patched 'auto' values are translated on '/active' endpoint for all rtp receivers"""
-        if len(self.receivers) > 0:
-            rtpReceivers = list()
-            for receiver in self.receivers:
-                if self.transport_types[receiver] == "urn:x-nmos:transport:rtp":
-                    rtpReceivers.append(receiver)
-            if len(rtpReceivers) > 0:
-                for rtpReceiver in rtpReceivers:
-                    if self.transport_types[rtpReceiver] == "urn:x-nmos:transport:rtp":
-                        data = {
-                            "transport_params": [
-                                {
-                                    "interface_ip": "auto"
-                                }
-                            ],
-                            "activation": {
-                                "mode": "activate_immediate"
-                            }
-                        }
-                        dest_staged = "single/receivers/" + rtpReceiver + "/staged/"
-                        dest_active = "single/receivers/" + rtpReceiver + "/active/"
-                        valid, response = self.is05_utils.checkCleanRequestJSON("PATCH", dest_staged, data=data)
-                        if valid:
-                            if len(response["transport_params"]) >= 1:
-                                valid2, response2 = self.is05_utils.checkCleanRequestJSON("GET", dest_active + "/")
-                                if valid2:
-                                    try:
-                                        if response2["transport_params"][0]["interface_ip"] != "auto":
-                                            pass
-                                        else:
-                                            return test.FAIL("Patched 'auto' for 'interface_ip' \
-                                                did not translate on '/active' endpoint")
-                                    except KeyError:
-                                        return test.FAIL("Did not find interface_ip in response from {}"
-                                                         .format(dest_active))
-                                else:
-                                    return test.FAIL(response2)
+        """Patched 'auto' values are translated on '/active' endpoint for all RTP receivers"""
+        rtpReceivers = list()
+        for receiver in self.receivers:
+            if self.transport_types[receiver] == "urn:x-nmos:transport:rtp":
+                rtpReceivers.append(receiver)
+        for rtpReceiver in rtpReceivers:
+            data = {
+                "transport_params": [
+                    {
+                        "interface_ip": "auto"
+                    }
+                ],
+                "activation": {
+                    "mode": "activate_immediate"
+                }
+            }
+            dest_staged = "single/receivers/" + rtpReceiver + "/staged/"
+            dest_active = "single/receivers/" + rtpReceiver + "/active/"
+            valid, response = self.is05_utils.checkCleanRequestJSON("PATCH", dest_staged, data=data)
+            if valid:
+                if len(response["transport_params"]) >= 1:
+                    valid2, response2 = self.is05_utils.checkCleanRequestJSON("GET", dest_active + "/")
+                    if valid2:
+                        try:
+                            if response2["transport_params"][0]["interface_ip"] != "auto":
+                                pass
                             else:
-                                return test.UNCLEAR("Not tested. No rtp ")
-                        else:
-                            return test.FAIL(response)
-                return test.PASS()
-        return test.UNCLEAR("Not tested. No resources found.")
+                                return test.FAIL("Patched 'auto' for 'interface_ip' did not translate on "
+                                                 "'/active' endpoint")
+                        except KeyError:
+                            return test.FAIL("Did not find interface_ip in response from {}"
+                                             .format(dest_active))
+                    else:
+                        return test.FAIL(response2)
+                else:
+                    return test.UNCLEAR("Not tested. No rtp ")
+            else:
+                return test.FAIL(response)
+
+        if len(rtpReceivers) > 0:
+            return test.PASS()
+        else:
+            return test.UNCLEAR("Not tested. No resources found.")
 
     def test_13(self, test):
         """Return of /single/senders/{senderId}/staged/ meets the schema"""

--- a/nmostesting/suites/IS0501Test.py
+++ b/nmostesting/suites/IS0501Test.py
@@ -247,7 +247,7 @@ class IS0501Test(GenericTest):
             'broker_authorization'
         ]
         autoParams = rtpAutoParams + websocketAutoParams + mqttAutoParams
-        return self.patchAutoParams(test, self.senders, "senders", autoParams)
+        return self.patch_auto_params(test, self.senders, "senders", autoParams)
 
     def test_12(self, test):
         """Receiver are using valid combination of parameters"""
@@ -344,7 +344,7 @@ class IS0501Test(GenericTest):
             'broker_authorization'
         ]
         autoParams = rtpAutoParams + websocketAutoParams + mqttAutoParams
-        return self.patchAutoParams(test, self.receivers, "receivers", autoParams)
+        return self.patch_auto_params(test, self.receivers, "receivers", autoParams)
 
     def test_13(self, test):
         """Return of /single/senders/{senderId}/staged/ meets the schema"""
@@ -1114,7 +1114,7 @@ class IS0501Test(GenericTest):
         else:
             return False, "Invalid response while getting data: " + response
 
-    def patchAutoParams(self, test, resources, resourceType, autoParams):
+    def patch_auto_params(self, test, resources, resourceType, autoParams):
         """
         Patch all params to 'auto' from autoParams list to all resources (id-list) of type resourceType
         ("senders" / "receivers") and validate response

--- a/nmostesting/suites/IS0501Test.py
+++ b/nmostesting/suites/IS0501Test.py
@@ -225,9 +225,19 @@ class IS0501Test(GenericTest):
 
             if len(rtpSenders) > 0:
                 for rtpSender in rtpSenders:
-                    data = {"transport_params": [{"source_ip": "auto", "destination_ip": "auto", \
-                                                "source_port": "auto", "destination_port": "auto"}], \
-                            "activation": {"mode": "activate_immediate"}}
+                    data = {
+                        "transport_params": [
+                            {
+                                "source_ip": "auto",
+                                "destination_ip": "auto",
+                                "source_port": "auto",
+                                "destination_port": "auto"
+                            }
+                        ],
+                        "activation": {
+                            "mode": "activate_immediate"
+                        }
+                    }
                     dest_staged = "single/senders/" + rtpSender + "/staged/"
                     dest_active = "single/senders/" + rtpSender + "/active/"
                     valid, response = self.is05_utils.checkCleanRequestJSON("PATCH", dest_staged, data=data)
@@ -237,14 +247,14 @@ class IS0501Test(GenericTest):
                             if valid2:
                                 try:
                                     if response2["transport_params"][0]["source_ip"] != "auto" and \
-                                        response2["transport_params"][0]["destination_ip"] != "auto":
-                                         pass
+                                     response2["transport_params"][0]["destination_ip"] != "auto":
+                                        pass
                                     else:
                                         return test.FAIL("Patched 'auto' for 'interface_ip' did not \
                                             translate on '/active' endpoint")
                                 except KeyError:
-                                    return test.FAIL("Did not find interface_ip in response from {}" \
-                                        .format(dest_active))
+                                    return test.FAIL("Did not find interface_ip in response from {}"
+                                                     .format(dest_active))
                             else:
                                 return test.FAIL(response2)
                         else:
@@ -299,8 +309,8 @@ class IS0501Test(GenericTest):
                 except IndexError:
                     return test.FAIL("Expected an array from {}, got {}".format(dest, response))
                 except AttributeError:
-                    return test.FAIL("Expected constraints array at {} to contain dicts, got {}" \
-                        .format(dest, response))
+                    return test.FAIL("Expected constraints array at {} to contain dicts, got {}"
+                                     .format(dest, response))
             return test.PASS()
         else:
             return test.UNCLEAR("Not tested. No resources found.")
@@ -332,8 +342,16 @@ class IS0501Test(GenericTest):
             if len(rtpReceivers) > 0:
                 for rtpReceiver in rtpReceivers:
                     if self.transport_types[rtpReceiver] == "urn:x-nmos:transport:rtp":
-                        data = {"transport_params": [{"interface_ip": "auto"}], \
-                            "activation": {"mode": "activate_immediate"}}
+                        data = {
+                            "transport_params": [
+                                {
+                                    "interface_ip": "auto"
+                                }
+                            ],
+                            "activation": {
+                                "mode": "activate_immediate"
+                            }
+                        }
                         dest_staged = "single/receivers/" + rtpReceiver + "/staged/"
                         dest_active = "single/receivers/" + rtpReceiver + "/active/"
                         valid, response = self.is05_utils.checkCleanRequestJSON("PATCH", dest_staged, data=data)
@@ -348,8 +366,8 @@ class IS0501Test(GenericTest):
                                             return test.FAIL("Patched 'auto' for 'interface_ip' \
                                                 did not translate on '/active' endpoint")
                                     except KeyError:
-                                        return test.FAIL("Did not find interface_ip in response from {}" \
-                                            .format(dest_active))
+                                        return test.FAIL("Did not find interface_ip in response from {}"
+                                                         .format(dest_active))
                                 else:
                                     return test.FAIL(response2)
                             else:

--- a/nmostesting/suites/IS0501Test.py
+++ b/nmostesting/suites/IS0501Test.py
@@ -215,6 +215,43 @@ class IS0501Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
+    def test_11_02(self, test):
+        """Patched 'auto' values are translated on '/active' endpoint for all rtp senders"""
+        if len(self.senders) > 0:
+            rtpSenders = list()
+            for sender in self.senders:
+                if self.transport_types[sender] == "urn:x-nmos:transport:rtp":
+                    rtpSenders.append(sender)
+
+            if len(rtpSenders) > 0:
+                for rtpSender in rtpSenders:
+                    data = {"transport_params": [{"source_ip": "auto", "destination_ip": "auto", 
+                                                "source_port": "auto", "destination_port": "auto"}], 
+                            "activation": {"mode": "activate_immediate"}}
+                    dest_staged = "single/senders/" + rtpSender + "/staged/"
+                    dest_active = "single/senders/" + rtpSender + "/active/"
+                    valid, response = self.is05_utils.checkCleanRequestJSON("PATCH", dest_staged, data=data)
+                    if valid:
+                        if len(response["transport_params"]) >= 1:
+                            valid2, response2 = self.is05_utils.checkCleanRequestJSON("GET", dest_active + "/")
+                            if valid2:
+                                try:
+                                    if response2["transport_params"][0]["source_ip"] != "auto" \
+                                        and response2["transport_params"][0]["destination_ip"] != "auto":
+                                        pass
+                                    else:
+                                        return test.FAIL("Patched 'auto' for 'interface_ip' did not translate on '/active' endpoint")
+                                except KeyError:
+                                    return test.FAIL("Did not find interface_ip in response from {}".format(dest_active))
+                            else:
+                                return test.FAIL(response2)
+                        else:
+                            return test.UNCLEAR("Not tested. No rtp ")
+                    else:
+                        return test.FAIL(response)
+                return test.PASS()
+        return test.UNCLEAR("Not tested. No resources found.")
+
     def test_12(self, test):
         """Receiver are using valid combination of parameters"""
 
@@ -281,6 +318,40 @@ class IS0501Test(GenericTest):
             return test.PASS()
         else:
             return test.UNCLEAR("Not tested. No resources found.")
+
+    def test_12_02(self, test):
+        """Patched 'auto' values are translated on '/active' endpoint for all rtp receivers"""
+        if len(self.receivers) > 0:
+            rtpReceivers = list()
+            for receiver in self.receivers:
+                if self.transport_types[receiver] == "urn:x-nmos:transport:rtp":
+                    rtpReceivers.append(receiver)
+            if len(rtpReceivers) > 0:
+                for rtpReceiver in rtpReceivers:
+                    if self.transport_types[rtpReceiver] == "urn:x-nmos:transport:rtp":
+                        data = {"transport_params": [{"interface_ip": "auto"}], "activation": {"mode": "activate_immediate"}}
+                        dest_staged = "single/receivers/" + rtpReceiver + "/staged/"
+                        dest_active = "single/receivers/" + rtpReceiver + "/active/"
+                        valid, response = self.is05_utils.checkCleanRequestJSON("PATCH", dest_staged, data=data)
+                        if valid:
+                            if len(response["transport_params"]) >= 1:
+                                valid2, response2 = self.is05_utils.checkCleanRequestJSON("GET", dest_active + "/")
+                                if valid2:
+                                    try:
+                                        if response2["transport_params"][0]["interface_ip"] != "auto":
+                                            pass
+                                        else:
+                                            return test.FAIL("Patched 'auto' for 'interface_ip' did not translate on '/active' endpoint")
+                                    except KeyError:
+                                        return test.FAIL("Did not find interface_ip in response from {}".format(dest_active))
+                                else:
+                                    return test.FAIL(response2)
+                            else:
+                                return test.UNCLEAR("Not tested. No rtp ")
+                        else:
+                            return test.FAIL(response)
+                return test.PASS()
+        return test.UNCLEAR("Not tested. No resources found.")
 
     def test_13(self, test):
         """Return of /single/senders/{senderId}/staged/ meets the schema"""

--- a/nmostesting/suites/IS0501Test.py
+++ b/nmostesting/suites/IS0501Test.py
@@ -225,8 +225,8 @@ class IS0501Test(GenericTest):
 
             if len(rtpSenders) > 0:
                 for rtpSender in rtpSenders:
-                    data = {"transport_params": [{"source_ip": "auto", "destination_ip": "auto", 
-                                                "source_port": "auto", "destination_port": "auto"}], 
+                    data = {"transport_params": [{"source_ip": "auto", "destination_ip": "auto", \
+                                                "source_port": "auto", "destination_port": "auto"}], \
                             "activation": {"mode": "activate_immediate"}}
                     dest_staged = "single/senders/" + rtpSender + "/staged/"
                     dest_active = "single/senders/" + rtpSender + "/active/"
@@ -236,13 +236,15 @@ class IS0501Test(GenericTest):
                             valid2, response2 = self.is05_utils.checkCleanRequestJSON("GET", dest_active + "/")
                             if valid2:
                                 try:
-                                    if response2["transport_params"][0]["source_ip"] != "auto" \
-                                        and response2["transport_params"][0]["destination_ip"] != "auto":
-                                        pass
+                                    if response2["transport_params"][0]["source_ip"] != "auto" and \
+                                        response2["transport_params"][0]["destination_ip"] != "auto":
+                                         pass
                                     else:
-                                        return test.FAIL("Patched 'auto' for 'interface_ip' did not translate on '/active' endpoint")
+                                        return test.FAIL("Patched 'auto' for 'interface_ip' did not \
+                                            translate on '/active' endpoint")
                                 except KeyError:
-                                    return test.FAIL("Did not find interface_ip in response from {}".format(dest_active))
+                                    return test.FAIL("Did not find interface_ip in response from {}" \
+                                        .format(dest_active))
                             else:
                                 return test.FAIL(response2)
                         else:
@@ -297,7 +299,8 @@ class IS0501Test(GenericTest):
                 except IndexError:
                     return test.FAIL("Expected an array from {}, got {}".format(dest, response))
                 except AttributeError:
-                    return test.FAIL("Expected constraints array at {} to contain dicts, got {}".format(dest, response))
+                    return test.FAIL("Expected constraints array at {} to contain dicts, got {}" \
+                        .format(dest, response))
             return test.PASS()
         else:
             return test.UNCLEAR("Not tested. No resources found.")
@@ -329,7 +332,8 @@ class IS0501Test(GenericTest):
             if len(rtpReceivers) > 0:
                 for rtpReceiver in rtpReceivers:
                     if self.transport_types[rtpReceiver] == "urn:x-nmos:transport:rtp":
-                        data = {"transport_params": [{"interface_ip": "auto"}], "activation": {"mode": "activate_immediate"}}
+                        data = {"transport_params": [{"interface_ip": "auto"}], \
+                            "activation": {"mode": "activate_immediate"}}
                         dest_staged = "single/receivers/" + rtpReceiver + "/staged/"
                         dest_active = "single/receivers/" + rtpReceiver + "/active/"
                         valid, response = self.is05_utils.checkCleanRequestJSON("PATCH", dest_staged, data=data)
@@ -341,9 +345,11 @@ class IS0501Test(GenericTest):
                                         if response2["transport_params"][0]["interface_ip"] != "auto":
                                             pass
                                         else:
-                                            return test.FAIL("Patched 'auto' for 'interface_ip' did not translate on '/active' endpoint")
+                                            return test.FAIL("Patched 'auto' for 'interface_ip' \
+                                                did not translate on '/active' endpoint")
                                     except KeyError:
-                                        return test.FAIL("Did not find interface_ip in response from {}".format(dest_active))
+                                        return test.FAIL("Did not find interface_ip in response from {}" \
+                                            .format(dest_active))
                                 else:
                                     return test.FAIL(response2)
                             else:


### PR DESCRIPTION
We detected a couple of issues patching an `auto` value on some `transport_parameters` in our implementation and realized that that's not really covered by the test-suite yet.

Up to now the test-suite only checks that on the `/active` endpoint no `auto` value is present. It does not check what happens if `auto` is patched.

The 2 new tests patch `auto` for all possible parameters (for rtp transceivers) and checks if the values are translated in 'non-auto-values' after an activate_immediate.

If that seems to be useful for others, we could expand these tests for the other transport_types, as websocket / mqtt transports have their own '`auto`-able' parameters..