### PR TITLE
is0502: make selected SDP media parameters configurable

### DIFF
--- a/nmostesting/Config.py
+++ b/nmostesting/Config.py
@@ -105,6 +105,17 @@ MULTICAST_STREAM_TARGET = "233.252.2.1"
 # Perform a GET against the submitted API before carrying out any tests to avoid wasting time if it doesn't exist
 PREVALIDATE_API = True
 
+# SDP media parameters which can be modified for devices which do not support the defaults
+# SDP testing is not concerned with support for specific media parameters, but must include them in the file
+SDP_PREFERENCES = {
+    "audio_channels": 2,
+    "audio_sample_rate": 48000,
+    "video_width": 1920,
+    "video_height": 1080,
+    "video_interlace": True,
+    "video_exactframerate": "25"
+}
+
 # Definition of each API specification and its versions.
 SPECIFICATIONS = {
     "is-04": {

--- a/nmostesting/suites/IS0502Test.py
+++ b/nmostesting/suites/IS0502Test.py
@@ -1081,20 +1081,42 @@ class IS0502Test(GenericTest):
             dst_port = randint(5000, 5999)
             if receiver["format"] == "urn:x-nmos:format:video":
                 template = Template(video_sdp, keep_trailing_newline=True)
+                interlace = ""
+                if CONFIG.SDP_PREFERENCES["video_interlace"] is True:
+                    interlace = "interlace; "
+                # TODO: The ST.2110-22 media types don't need some of the fmtp params in the template file
                 if "video/raw" in receiver["caps"]["media_types"]:
-                    sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="raw")
+                    sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="raw",
+                                               width=CONFIG.SDP_PREFERENCES["video_width"],
+                                               height=CONFIG.SDP_PREFERENCES["video_height"],
+                                               interlace=interlace,
+                                               exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"])
                 elif "video/vc2" in receiver["caps"]["media_types"]:
-                    sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="vc2")
+                    sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="vc2",
+                                               width=CONFIG.SDP_PREFERENCES["video_width"],
+                                               height=CONFIG.SDP_PREFERENCES["video_height"],
+                                               interlace=interlace,
+                                               exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"])
                 elif "video/H264" in receiver["caps"]["media_types"]:
-                    sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="H264")
+                    sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="H264",
+                                               width=CONFIG.SDP_PREFERENCES["video_width"],
+                                               height=CONFIG.SDP_PREFERENCES["video_height"],
+                                               interlace=interlace,
+                                               exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"])
             elif receiver["format"] == "urn:x-nmos:format:audio":
                 template = Template(audio_sdp, keep_trailing_newline=True)
                 if "audio/L16" in receiver["caps"]["media_types"]:
-                    sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="L16")
+                    sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="L16",
+                                               channels=CONFIG.SDP_PREFERENCES["audio_channels"],
+                                               sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"])
                 elif "audio/L24" in receiver["caps"]["media_types"]:
-                    sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="L24")
+                    sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="L24",
+                                               channels=CONFIG.SDP_PREFERENCES["audio_channels"],
+                                               sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"])
                 elif "audio/L32" in receiver["caps"]["media_types"]:
-                    sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="L32")
+                    sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="L32",
+                                               channels=CONFIG.SDP_PREFERENCES["audio_channels"],
+                                               sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"])
             elif receiver["format"] == "urn:x-nmos:format:data":
                 template = Template(data_sdp, keep_trailing_newline=True)
                 if "video/smpte291" in receiver["caps"]["media_types"]:

--- a/test_data/IS0502/audio.sdp
+++ b/test_data/IS0502/audio.sdp
@@ -6,7 +6,7 @@ m=audio {{ dst_port }} RTP/AVP 102
 c=IN IP4 {{ dst_ip }}/32
 a=source-filter: incl IN IP4 {{ dst_ip }} {{ src_ip }}
 a=ts-refclk:ptp=IEEE1588-2008:EC-46-70-FF-FE-00-CE-DE:0
-a=rtpmap:102 {{ media_type }}/48000/2
+a=rtpmap:102 {{ media_type }}/{{ sample_rate }}/{{ channels }}
 a=mediaclk:direct=0
 a=ptime:1
 a=maxptime:1

--- a/test_data/IS0502/video.sdp
+++ b/test_data/IS0502/video.sdp
@@ -7,5 +7,5 @@ c=IN IP4 {{ dst_ip }}/32
 a=source-filter: incl IN IP4 {{ dst_ip }} {{ src_ip }}
 a=ts-refclk:ptp=IEEE1588-2008:EC-46-70-FF-FE-00-CE-DE:0
 a=rtpmap:97 {{ media_type }}/90000
-a=fmtp:97 sampling=YCbCr-4:2:2; width=1920; height=1080; depth=10; interlace; SSN=ST2110-20:2017; colorimetry=BT709; PM=2110GPM; TP=2110TPW; TCS=SDR; exactframerate=25
+a=fmtp:97 sampling=YCbCr-4:2:2; width={{ width }}; height={{ height }}; depth=10; {{ interlace }}SSN=ST2110-20:2017; colorimetry=BT709; PM=2110GPM; TP=2110TPW; TCS=SDR; exactframerate={{ exactframerate }}
 a=mediaclk:direct=0 rate=90000


### PR DESCRIPTION
Relates to #494, but doesn't completely resolve it. The preferred solution to this would be to have 'caps' fully populated and to determine appropriate media parameters from there.

This is a workaround for the time being, and exposes a subset of the SDP media parameters which seem most likely to need to be modified for some implementations or configurations.