### PR TITLE
is0401: allow the Node time to react after performing a DNS query

### DIFF
--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -71,6 +71,8 @@ class IS0401Test(GenericTest):
                 ],
                 CONFIG.DNS_SD_ADVERT_TIMEOUT
             )
+            # Wait for a short time to allow the device to react after performing the query
+            time.sleep(CONFIG.API_PROCESSING_TIMEOUT)
 
     def tear_down_tests(self):
         if self.zc:


### PR DESCRIPTION
For Nodes which may still be in the process of starting up after issuing their first DNS query, this allows a short time for them to finish the process before beginning tests.