### PR TITLE
IS-09-02: System API mock and trailing slashes

### DIFF
--- a/nmostesting/mocks/System.py
+++ b/nmostesting/mocks/System.py
@@ -54,7 +54,7 @@ def base_resource(version):
     return Response(json.dumps(base_data), mimetype='application/json')
 
 
-@SYSTEM_API.route('/x-nmos/system/<version>/global', methods=["GET"])
+@SYSTEM_API.route('/x-nmos/system/<version>/global', methods=["GET"], strict_slashes=False)
 def system_global(version):
     system = SYSTEMS[flask.current_app.config["SYSTEM_INSTANCE"]]
     if not system.enabled:


### PR DESCRIPTION
Though clients are recommended (by description in the spec of which is considered the 'primary' path) to make requests without a trailing slash, the System API mock should accept a GET **/x-nmos/system/v1.0/global/** request (with the trailing slash) as per [URLs: Approach to Trailing Slashes: GET and HEAD requests](https://amwa-tv.github.io/nmos-system/branches/v1.0-dev/docs/2.0._APIs.html#get-and-head-requests).

Resolves #506.
