### PR TITLE
is0401: don't check audio grain_rate due to lack of docs

### DIFF
--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -1449,7 +1449,6 @@ class IS0401Test(GenericTest):
                            (flow_rate["numerator"] * source_rate["denominator"])):
                             return test.FAIL("Flow 'grain_rate' MUST be integer divisible by the Source 'grain_rate'")
                     elif flow["format"] in ["urn:x-nmos:format:video",
-                                            "urn:x-nmos:format:audio",
                                             "urn:x-nmos:format:mux"]:
                         return test.WARNING("Flows SHOULD specify a 'grain_rate' if they are periodic")
                 if len(flow_response.json()) > 0:

--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -1413,7 +1413,6 @@ class IS0401Test(GenericTest):
                 for resource in response.json():
                     # Currently testing where it would be particularly unusual to find a non-periodic Source
                     if resource["format"] in ["urn:x-nmos:format:video",
-                                              "urn:x-nmos:format:audio",
                                               "urn:x-nmos:format:mux"]:
                         if "grain_rate" not in resource:
                             return test.WARNING("Sources MUST specify a 'grain_rate' if they are periodic")


### PR DESCRIPTION
Relates to #517 

At least until any docs issues are resolved this removes checking for audio `grain_rate` in Sources.