### PR TITLE
IS-04-02/-03: Fix "API authorization ('api_auth') TXT record is not one of 'true' or 'false'." with python-zeroconf 0.25.0

### DIFF
--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -731,8 +731,7 @@ class IS0401Test(GenericTest):
                 if self.is04_utils.compare_api_version(api["version"], "v1.3") >= 0:
                     if "api_auth" not in properties:
                         return test.FAIL("No 'api_auth' TXT record found in Node API advertisement.")
-                    elif not isinstance(properties["api_auth"], bool):
-                        # zeroconf translates 'true' to True and 'false' to False automatically
+                    elif properties["api_auth"] not in ["true", "false"]:
                         return test.FAIL("API authorization ('api_auth') TXT record is not one of 'true' or 'false'.")
 
                 return test.PASS()

--- a/nmostesting/suites/IS0402Test.py
+++ b/nmostesting/suites/IS0402Test.py
@@ -104,8 +104,7 @@ class IS0402Test(GenericTest):
                 if self.is04_reg_utils.compare_api_version(api["version"], "v1.3") >= 0:
                     if "api_auth" not in properties:
                         return test.FAIL("No 'api_auth' TXT record found in {} advertisement.".format(api["name"]))
-                    elif not isinstance(properties["api_auth"], bool):
-                        # zeroconf translates 'true' to True and 'false' to False automatically
+                    elif properties["api_auth"] not in ["true", "false"]:
                         return test.FAIL("API authorization ('api_auth') TXT record is not one of 'true' or 'false'.")
 
                 return test.PASS()

--- a/nmostesting/suites/IS0403Test.py
+++ b/nmostesting/suites/IS0403Test.py
@@ -88,8 +88,7 @@ class IS0403Test(GenericTest):
                 if self.is04_utils.compare_api_version(api["version"], "v1.3") >= 0:
                     if "api_auth" not in properties:
                         return test.FAIL("No 'api_auth' TXT record found in Node API advertisement.")
-                    elif not isinstance(properties["api_auth"], bool):
-                        # zeroconf translates 'true' to True and 'false' to False automatically
+                    elif properties["api_auth"] not in ["true", "false"]:
                         return test.FAIL("API authorization ('api_auth') TXT record is not one of 'true' or 'false'.")
 
                 return test.PASS()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 flask>=1.0.0
 wtforms
 jsonschema
-zeroconf-monkey>=0.1.1
+zeroconf-monkey>=1.0.0
 requests
 netifaces
 gitpython

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 flask>=1.0.0
 wtforms
 jsonschema
-zeroconf-monkey
+zeroconf-monkey>=0.1.1
 requests
 netifaces
 gitpython


### PR DESCRIPTION
Fix #522, by matching test code to jstakias/python-zeroconf 0.25.0, required via zeroconf-monkey 0.1.1 (https://github.com/bbc/rd-ext-lib-zeroconf-monkey/pull/1)