### PR TITLE
IS-07-02: Add test_05 which covers WebSocket state messages

### DIFF
--- a/nmostesting/IS07Utils.py
+++ b/nmostesting/IS07Utils.py
@@ -14,6 +14,8 @@
 
 from . import TestHelper
 
+import fractions
+
 from .NMOSUtils import NMOSUtils
 
 
@@ -35,3 +37,9 @@ class IS07Utils(NMOSUtils):
                     if valid_sub and sub.status_code == 200:
                         toReturn[source_id][sub_path] = sub.json()
         return toReturn
+
+    def get_scale(self, payload):
+        return 1 if "scale" not in payload else payload["scale"]
+
+    def get_number(self, payload):
+        return fractions.Fraction(fractions.Fraction(payload["value"]), self.get_scale(payload))

--- a/nmostesting/suites/IS0702Test.py
+++ b/nmostesting/suites/IS0702Test.py
@@ -547,14 +547,13 @@ class IS0702Test(GenericTest):
     def check_state_messages(self, test, messages, connection_sources, subscription_command_counter):
         """Checks validity of received state messages"""
 
-        sources_dictionary = {}
+        sources = {}
         sources_flows = {}
         sources_errors = {}
         for connection_uri in connection_sources:
-            sources = connection_sources[connection_uri]
-            for source in sources:
+            for source in connection_sources[connection_uri]:
                 source_id = source["id"]
-                sources_dictionary[source_id] = source
+                sources[source_id] = source
                 sources_flows[source_id] = {}
                 for flow_id in self.is04_flows:
                     flow = self.is04_flows[flow_id]
@@ -588,7 +587,7 @@ class IS0702Test(GenericTest):
                     identity = parsed_message["identity"]
                     if "source_id" in identity:
                         identity_source = identity["source_id"]
-                        if identity_source in sources_dictionary:
+                        if identity_source in sources:
                             if "flow_id" in identity:
                                 identity_flow = identity["flow_id"]
                                 if identity_source in sources_flows:
@@ -600,7 +599,7 @@ class IS0702Test(GenericTest):
                                                 self.check_event_payload(
                                                     test,
                                                     connection_uri,
-                                                    sources_dictionary[identity_source],
+                                                    sources[identity_source],
                                                     parsed_message["event_type"],
                                                     parsed_message["payload"])
                                             else:

--- a/nmostesting/suites/IS0702Test.py
+++ b/nmostesting/suites/IS0702Test.py
@@ -655,8 +655,8 @@ class IS0702Test(GenericTest):
             raise NMOSTestException(
                 test.FAIL("WebSocket {} state response cannot be parsed exception {}, original message: {}"
                           .format(connection_uri, e, message)))
-        if len(missing_sources.keys()) > 0:
-            raise NMOSTestException(test.FAIL(list(missing_sources.keys())[0]))
+        if len(missing_sources) > 0:
+            raise NMOSTestException(test.FAIL(list(missing_sources.values())[0]))
 
     def check_event_payload(self, test, connection_uri, source, event_type, payload):
         """Checks validity of event payload"""

--- a/nmostesting/suites/IS0702Test.py
+++ b/nmostesting/suites/IS0702Test.py
@@ -591,33 +591,39 @@ class IS0702Test(GenericTest):
                         if identity_source in sources_dictionary:
                             if "flow_id" in identity:
                                 identity_flow = identity["flow_id"]
-                                flows = sources_flows[identity_source]
-                                if identity_flow in flows:
-                                    del sources_errors[identity_source]  # Remove sources which are ok
-                                    if "event_type" in parsed_message:
-                                        if "payload" in parsed_message:
-                                            self.check_event_payload(
-                                                test,
-                                                connection_uri,
-                                                sources_dictionary[identity_source],
-                                                parsed_message["event_type"],
-                                                parsed_message["payload"])
+                                if identity_source in sources_flows[identity_source]:
+                                    flows = sources_flows[identity_source]
+                                    if identity_flow in flows:
+                                        del sources_errors[identity_source]  # Remove sources which are ok
+                                        if "event_type" in parsed_message:
+                                            if "payload" in parsed_message:
+                                                self.check_event_payload(
+                                                    test,
+                                                    connection_uri,
+                                                    sources_dictionary[identity_source],
+                                                    parsed_message["event_type"],
+                                                    parsed_message["payload"])
+                                            else:
+                                                raise NMOSTestException(
+                                                    test.FAIL("WebSocket {} state response "
+                                                              "does not have a payload, original message: {}"
+                                                              .format(connection_uri, message)))
                                         else:
                                             raise NMOSTestException(
                                                 test.FAIL("WebSocket {} state response "
-                                                          "does not have a payload, original message: {}"
+                                                          "does not have an event_type, original message: {}"
                                                           .format(connection_uri, message)))
                                     else:
                                         raise NMOSTestException(
-                                            test.FAIL("WebSocket {} state response "
-                                                      "does not have an event_type, original message: {}"
-                                                      .format(connection_uri, message)))
+                                            test.FAIL("WebSocket {} state response identity flow_id {} "
+                                                      "does not match id of any associated source flows, "
+                                                      "for source id {}, original message: {}"
+                                                      .format(connection_uri, identity_flow, identity_source, message)))
                                 else:
                                     raise NMOSTestException(
-                                        test.FAIL("WebSocket {} state response identity flow_id {} "
-                                                  "does not match id of any associated source flows, for source id {}, "
-                                                  "original message: {}"
-                                                  .format(connection_uri, identity_flow, identity_source, message)))
+                                        test.FAIL("WebSocket {} source {} "
+                                                  "does not have any associated flows"
+                                                  .format(connection_uri, identity_source)))
                             else:
                                 raise NMOSTestException(
                                     test.FAIL("WebSocket {} state response identity does not have a flow_id, "

--- a/nmostesting/suites/IS0702Test.py
+++ b/nmostesting/suites/IS0702Test.py
@@ -591,7 +591,7 @@ class IS0702Test(GenericTest):
                         if identity_source in sources_dictionary:
                             if "flow_id" in identity:
                                 identity_flow = identity["flow_id"]
-                                if identity_source in sources_flows[identity_source]:
+                                if identity_source in sources_flows:
                                     flows = sources_flows[identity_source]
                                     if identity_flow in flows:
                                         del sources_errors[identity_source]  # Remove sources which are ok

--- a/nmostesting/suites/IS0702Test.py
+++ b/nmostesting/suites/IS0702Test.py
@@ -729,6 +729,13 @@ class IS0702Test(GenericTest):
                                           "type is greater than the max_length {} defined in the type definition, "
                                           "original payload: {}"
                                           .format(connection_uri, source_id, source_type["max_length"], str_payload)))
+                if "pattern" in source_type:
+                    pattern = source_type["pattern"]
+                    if re.match(pattern, value) is None:
+                        raise NMOSTestException(
+                                test.FAIL("WebSocket {}, source id: {} value for string event type, does not "
+                                          "match the pattern defined in the type definition, original payload: {}"
+                                          .format(connection_uri, source_id, str_payload)))
             elif base_event_type == "number":
                 try:
                     if not isinstance(value, int):

--- a/nmostesting/suites/IS0702Test.py
+++ b/nmostesting/suites/IS0702Test.py
@@ -560,9 +560,9 @@ class IS0702Test(GenericTest):
                     flow = self.is04_flows[flow_id]
                     if flow["source_id"] == source_id:
                         sources_flows[source_id][flow_id] = self.is04_flows[flow_id]
-                sources_errors[source["id"]] = ("WebSocket {}, source {} did not have a matching state response "
-                                                "after subscription command attempt number {}"
-                                                .format(connection_uri, source["id"], subscription_command_counter))
+                sources_errors[source_id] = ("WebSocket {}, source {} did not have a matching state response "
+                                             "after subscription command attempt number {}"
+                                             .format(connection_uri, source_id, subscription_command_counter))
         try:
             for message in messages:
                 parsed_message = json.loads(message)


### PR DESCRIPTION
The new test will assess the following:
- check if state messages are sent without a prior subscription command
- check if state messages are received after 1 subscription command and then after a second one is sent
- check if state messages have the correct identity
- check if state messages have minimum required timing
- check if state messages have the correct message_type
- check if state messages event_type matches the IS-04 source event_type
- checks if state messages for base event types have a valid payload