### PR TITLE
IS-04-03: Allow the Node a grace period to update its service info

### DIFF
--- a/nmostesting/MdnsListener.py
+++ b/nmostesting/MdnsListener.py
@@ -24,14 +24,20 @@ class MdnsListener(object):
         self.services = list()
         self.resolve_queue = Queue()
 
-    def add_service(self, zeroconf, srv_type, name):
+    def _resolve_service(self, srv_type, name):
         self.resolve_queue.put((srv_type, name))
         t = Thread(target=self.worker)
         t.daemon = True
         t.start()
 
+    def add_service(self, zeroconf, srv_type, name):
+        self._resolve_service(srv_type, name)
+
     def remove_service(self, zeroconf, srv_type, name):
         pass
+
+    def update_service(self, zeroconf, srv_type, name):
+        self._resolve_service(srv_type, name)
 
     def get_service_list(self):
         self.resolve_queue.join()


### PR DESCRIPTION
The Node may have recently been communicating with a Registry, so it makes sense to give the Node a chance to update its service info with the ver_* TXT records when switching to peer-to-peer operation (same as we do when testing that the Node correctly adopts registered operation).

We identified this case in testing, after **jstasiak/python-zeroconf** fixed the slow (5 second) `Zeroconf.close()` operation in 0.25.1, which meant that when the IS-04-03 test suite was run immediately after the IS-04-01 test suite, `IS0403Test.test_01` started failing every time.
