### PR TITLE
ServiceInfo.address, formerly deprecated, is removed in python-zeroconf 0.27.0

### DIFF
--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -103,8 +103,8 @@ class IS0401Test(GenericTest):
 
         info = ServiceInfo(service_type,
                            "NMOSTestSuite{}{}.{}".format(port, api_proto, service_type),
-                           socket.inet_aton(ip), port, 0, 0,
-                           txt, hostname)
+                           addresses=[socket.inet_aton(ip)], port=port,
+                           properties=txt, server=hostname)
         return info
 
     def do_node_basics_prereqs(self):
@@ -709,9 +709,13 @@ class IS0401Test(GenericTest):
         node_list = self.collect_mdns_announcements()
 
         for node in node_list:
-            address = socket.inet_ntoa(node.address)
             port = node.port
-            if address == api["ip"] and port == api["port"]:
+            if port != api["port"]:
+                continue
+            for address in node.addresses:
+                address = socket.inet_ntoa(address)
+                if address != api["ip"]:
+                    continue
                 properties = self.convert_bytes(node.properties)
                 for prop in properties:
                     if "ver_" in prop:
@@ -755,9 +759,13 @@ class IS0401Test(GenericTest):
         node_list = self.collect_mdns_announcements()
 
         for node in node_list:
-            address = socket.inet_ntoa(node.address)
             port = node.port
-            if address == api["ip"] and port == api["port"]:
+            if port != api["port"]:
+                continue
+            for address in node.addresses:
+                address = socket.inet_ntoa(address)
+                if address != api["ip"]:
+                    continue
                 properties = self.convert_bytes(node.properties)
                 if "api_ver" not in properties:
                     return test.FAIL("No 'api_ver' TXT record found in Node API advertisement.")

--- a/nmostesting/suites/IS0402Test.py
+++ b/nmostesting/suites/IS0402Test.py
@@ -73,9 +73,13 @@ class IS0402Test(GenericTest):
         sleep(CONFIG.DNS_SD_BROWSE_TIMEOUT)
         serv_list = self.zc_listener.get_service_list()
         for service in serv_list:
-            address = socket.inet_ntoa(service.address)
             port = service.port
-            if address == api["ip"] and port == api["port"]:
+            if port != api["port"]:
+                continue
+            for address in service.addresses:
+                address = socket.inet_ntoa(address)
+                if address != api["ip"]:
+                    continue
                 properties = self.convert_bytes(service.properties)
                 if "pri" not in properties:
                     return test.FAIL("No 'pri' TXT record found in {} advertisement.".format(api["name"]))

--- a/nmostesting/suites/IS0403Test.py
+++ b/nmostesting/suites/IS0403Test.py
@@ -60,10 +60,16 @@ class IS0403Test(GenericTest):
             node_list = self.zc_listener.get_service_list()
             # Iterate in reverse order to check the most recent advert first
             for node in reversed(node_list):
-                address = socket.inet_ntoa(node.address)
                 port = node.port
-                if address == api["ip"] and port == api["port"]:
+                if port != api["port"]:
+                    continue
+                for address in node.addresses:
+                    address = socket.inet_ntoa(address)
+                    if address != api["ip"]:
+                        continue
                     properties = self.convert_bytes(node.properties)
+                    break
+                if properties:
                     break
             # If the Node is still advertising as for registered operation, loop around
             if properties and "ver_slf" in properties:

--- a/nmostesting/suites/IS0902Test.py
+++ b/nmostesting/suites/IS0902Test.py
@@ -75,8 +75,8 @@ class IS0902Test(GenericTest):
         service_type = "_nmos-system._tcp.local."
         info = ServiceInfo(service_type,
                            "NMOSTestSuite{}{}.{}".format(port, api_proto, service_type),
-                           socket.inet_aton(ip), port, 0, 0,
-                           txt, hostname)
+                           addresses=[socket.inet_aton(ip)], port=port,
+                           properties=txt, server=hostname)
         return info
 
     def do_system_basics_prereqs(self):

--- a/nmostesting/suites/IS1001Test.py
+++ b/nmostesting/suites/IS1001Test.py
@@ -192,9 +192,13 @@ class IS1001Test(GenericTest):
         sleep(CONFIG.DNS_SD_BROWSE_TIMEOUT)
         serv_list = self.zc_listener.get_service_list()
         for service in serv_list:
-            address = socket.inet_ntoa(service.address)
             port = service.port
-            if address == api["ip"] and port == api["port"]:
+            if port != api["port"]:
+                continue
+            for address in service.addresses:
+                address = socket.inet_ntoa(address)
+                if address != api["ip"]:
+                    continue
                 properties = self.convert_bytes(service.properties)
                 if "pri" not in properties:
                     return test.FAIL("No 'pri' TXT record found in {} advertisement.".format(api["name"]))


### PR DESCRIPTION
Resolves #538.