### PR TITLE
Fix comparison of JSON values

### DIFF
--- a/nmostesting/TestHelper.py
+++ b/nmostesting/TestHelper.py
@@ -22,22 +22,114 @@ import jsonref
 import netifaces
 from copy import copy
 from pathlib import Path
+from enum import IntEnum
+from numbers import Number
+from functools import cmp_to_key
 
 from . import Config as CONFIG
 
 
-def ordered(obj):
-    if isinstance(obj, dict):
-        return sorted((k, ordered(v)) for k, v in obj.items())
-    if isinstance(obj, list):
-        return sorted(ordered(x) for x in obj)
-    else:
-        return obj
+class JsonType(IntEnum):
+    NULL = 0
+    BOOLEAN = 1
+    NUMBER = 2
+    STRING = 3
+    ARRAY = 4
+    OBJECT = 5
+
+    @classmethod
+    def of(cls, json):
+        if json is None:
+            return cls.NULL
+        # must check bool before Number
+        if isinstance(json, bool):
+            return cls.BOOLEAN
+        if isinstance(json, Number):
+            return cls.NUMBER
+        if isinstance(json, str):
+            return cls.STRING
+        if isinstance(json, list):
+            return cls.ARRAY
+        if isinstance(json, dict):
+            return cls.OBJECT
+        raise TypeError('Non-JSON type')
+
+    @classmethod
+    def eq(cls, json1, json2):
+        return cls._cmp_json(json1, json2) == 0
+
+    @classmethod
+    def lt(cls, json1, json2):
+        return cls._cmp_json(json1, json2) < 0
+
+    @classmethod
+    def _cmp_json(cls, json1, json2):
+        # compare JSON type first
+        t1 = cls.of(json1)
+        t2 = cls.of(json2)
+        if t1 < t2:
+            return -1
+        if t2 < t1:
+            return 1
+        # only compare values if types are the same
+        return {
+            cls.NULL: cls._cmp_null,
+            cls.BOOLEAN: cls._cmp_scalar,
+            cls.NUMBER: cls._cmp_scalar,
+            cls.STRING: cls._cmp_scalar,
+            cls.OBJECT: cls._cmp_object,
+            cls.ARRAY: cls._cmp_array,
+        }[t1](json1, json2)
+
+    @classmethod
+    def _cmp_null(cls, lhs, rhs):
+        # all nulls are equal
+        return 0
+
+    @classmethod
+    def _cmp_scalar(cls, lhs, rhs):
+        # '<' is supported by bool, Number and str
+        if lhs < rhs:
+            return -1
+        if rhs < lhs:
+            return 1
+        return 0
+
+    @classmethod
+    def _cmp_array(cls, lhs, rhs):
+        # in NMOS APIs, JSON arrays usually represent lists or sets in which ordering
+        # isn't important, so sort the elements of both arrays before comparing them
+        key = cmp_to_key(cls._cmp_json)
+        for lval, rval in zip(sorted(lhs, key=key), sorted(rhs, key=key)):
+            cmp = cls._cmp_json(lval, rval)
+            if cmp != 0:
+                return cmp
+        if len(lhs) < len(rhs):
+            return -1
+        if len(rhs) < len(lhs):
+            return 1
+        return 0
+
+    @classmethod
+    def _cmp_object(cls, lhs, rhs):
+        for lkey, rkey in zip(sorted(lhs.keys()), sorted(rhs.keys())):
+            if lkey < rkey:
+                return -1
+            if rkey < lkey:
+                return 1
+            cmp = cls._cmp_json(lhs[lkey], rhs[rkey])
+            if cmp != 0:
+                return cmp
+        if len(lhs) < len(rhs):
+            return -1
+        if len(rhs) < len(lhs):
+            return 1
+        return 0
 
 
 def compare_json(json1, json2):
-    """Compares two json objects for equality"""
-    return ordered(json1) == ordered(json2)
+    """Compares two JSON values for equality"""
+    return JsonType.eq(json1, json2)
 
 
 def get_default_ip():


### PR DESCRIPTION
… so that `true` doesn't compare equal to `1`, and arrays with heterogeneous types like `["foo", "bar", null]` can be compared (thus resolving one small part of #531)

This was harder to solve than it seemed, so maybe I missed something more elegant.
It would also benefit from tests...