### PR TITLE
Added bulk mode to is-05-control script

### DIFF
--- a/utilities/is-05-control/README.md
+++ b/utilities/is-05-control/README.md
@@ -6,6 +6,7 @@ Allows you to:
 * Enable/Disable `master_enable`
 * Set Sender config
 * Set Receiver config
+* Update several resources via /bulk operation
 
 ## Installation
 To install the dependencies, run the following on a system with Python 3 and Pip installed:
@@ -28,17 +29,26 @@ optional arguments:
   --port PORT           Port number of IS-05 API of DuT
   --version VERSION     Version of IS-05 API of DuT
   -s, --sender          Configure NMOS Sender
+  -ss, --senders        Configure NMOS Senders by bulk operation
   -r, --receiver        Configure NMOS Receiver
+  -rr, --receivers      Configure NMOS Receivers by bulk operation
   --request REQUEST     JSON data to be sent in the request to configure
                         sender
   --sdp SDP             SDP file to be sent in the request to configure
-                        receiver
-  -u UUID, --uuid UUID  UUID of resource to be configured
+                        receiver (parameter can be provided several times for
+                        multiple SDPs)
+  -u UUID, --uuid UUID  UUID of resource to be configured (parameter can be
+                        provided several times for multiple UUIDs)
 ```
 
 Example call to change receiver
 ```
 python3 is05Control.py --ip <hostname or IP> --port <IS-05 Port> --version <IS-05 Version> --receiver --uuid <Receiver ID> --request tune-receiver-to-reference.json --sdp video-1080i-7.sdp
+```
+
+Example call to change multiple receivers
+```
+python3 is05Control.py --ip <hostname or IP> --port <IS-05 Port> --version <IS-05 Version> --receivers --uuid <Receiver ID 2> --uuid <Receiver ID 2>  --sdp video-1080i-7.sdp --sdp audio-2ch-7.sdp
 ```
 
 Example call to enable sender


### PR DESCRIPTION
When specified with --receivers(--rr) or --senders(-ss) flags one can list several sdp files and uuids to be used during activation. In this case the script will perform /bulk type operation