### PR TITLE
testssl: recommend use of latest release version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ RUN apk update \
  && mv nmostesting/Config.py /config/Config.py \
  && ln -s /config/Config.py nmostesting/Config.py \
  && cd testssl \
- && wget https://github.com/drwetter/testssl.sh/archive/3.0rc5.tar.gz \
- && tar -xvzf 3.0rc5.tar.gz --strip-components=1 \
- && rm 3.0rc5.tar.gz \
+ && wget https://github.com/drwetter/testssl.sh/archive/3.0.2.tar.gz \
+ && tar -xvzf 3.0.2.tar.gz --strip-components=1 \
+ && rm 3.0.2.tar.gz \
  && npm config set unsafe-perm true \
  && npm install -g AMWA-TV/sdpoker#v0.2.0
 

--- a/nmostesting/Config.py
+++ b/nmostesting/Config.py
@@ -207,8 +207,6 @@ SPECIFICATIONS = {
         "repo": "nmos-secure-communication",
         "versions": ["v1.0"],
         "default_version": "v1.0",
-        "apis": {
-            "secure": {}
-        }
+        "apis": {}
     }
 }

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -834,7 +834,7 @@ def check_internal_requirements():
 def check_external_requirements():
     deps = {
         "sdpoker": ("sdpoker --version", "0.2.0"),
-        "testssl": ("testssl/testssl.sh -v", "3.0rc5")
+        "testssl": ("testssl/testssl.sh -v", "3.0.2")
     }
     for dep_name, dep_ver in deps.items():
         try:

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -261,10 +261,10 @@ TEST_DEFINITIONS = {
         "class": IS1001Test.IS1001Test
     },
     "BCP-003-01": {
-        "name": "BCP-003-01 Secure API Communications",
+        "name": "BCP-003-01 Secure Communication",
         "specs": [{
             "spec_key": "bcp-003-01",
-            "api_key": "bcp-003-01"
+            "api_key": "secure"
         }],
         "class": BCP00301Test.BCP00301Test
     }
@@ -431,8 +431,12 @@ def run_tests(test, endpoints, test_selection=["all"]):
                 base_url = "{}://{}:{}".format(protocol, endpoints[index]["host"], str(endpoints[index]["port"]))
             else:
                 base_url = None
-            if base_url is not None and endpoints[index]["version"] is not None:
-                url = "{}/x-nmos/{}/{}/".format(base_url, api_key, endpoints[index]["version"])
+            if base_url is not None:
+                url = base_url + "/"
+                if api_key in CONFIG.SPECIFICATIONS[spec_key]["apis"]:
+                    url += "x-nmos/{}/".format(api_key)
+                    if endpoints[index]["version"] is not None:
+                        url += "{}/".format(endpoints[index]["version"])
                 if endpoints[index]["selector"] not in [None, ""]:
                     url += "{}/".format(endpoints[index]["selector"])
                 tested_urls.append(url)

--- a/nmostesting/suites/BCP00301Test.py
+++ b/nmostesting/suites/BCP00301Test.py
@@ -292,6 +292,8 @@ class BCP00301Test(GenericTest):
                         ecdsa_found = True
 
             if not ecdsa_found:
+                if not rsa_found:
+                    return test.FAIL("Server is not providing an ECDSA or RSA certificate")
                 return test.WARNING("Server is not providing an ECDSA certificate")
             if not rsa_found:
                 return test.WARNING("Server is not providing an RSA certificate")

--- a/testssl/README.md
+++ b/testssl/README.md
@@ -1,13 +1,13 @@
 # testssl.sh
 
-In order to test BCP-003-01, the 'testssl.sh' script (v3.0 rc5) must be placed in this directory with 'execute' permission enabled. This tool is known to work on Linux and Mac OS, but requires [Ubuntu terminal](https://tutorials.ubuntu.com/tutorial/tutorial-ubuntu-on-windows) for usage on Windows. Note that the Linux terminal approach on Windows will be significantly slower to run than a pure Linux system (or Linux VM on Windows).
+In order to test BCP-003-01, the 'testssl.sh' script (v3.0.2) must be placed in this directory with 'execute' permission enabled. This tool is known to work on Linux and Mac OS, but requires [Ubuntu terminal](https://tutorials.ubuntu.com/tutorial/tutorial-ubuntu-on-windows) for usage on Windows. Note that the Linux terminal approach on Windows will be significantly slower to run than a pure Linux system (or Linux VM on Windows).
 
 Please download the required files using the following link, then untar the results into this directory:
-<https://github.com/drwetter/testssl.sh/archive/3.0rc5.tar.gz>
+<https://github.com/drwetter/testssl.sh/archive/3.0.2.tar.gz>
 
 Alternatively, use the following command which can be executed from within this 'testssl' directory.
 
 ```shell
-wget https://github.com/drwetter/testssl.sh/archive/3.0rc5.tar.gz
-tar -xvzf 3.0rc5.tar.gz --strip-components=1
+wget https://github.com/drwetter/testssl.sh/archive/3.0.2.tar.gz
+tar -xvzf 3.0.2.tar.gz --strip-components=1
 ```


### PR DESCRIPTION
This updates testssl to the latest released version rather than a release candidate. Tests against both a valid and invalid setup still appear to produce the correct results, but it would warrant testing against another implementation for additional confidence.