### PR TITLE
logging: fix unhandled exception when headers missing from request

### DIFF
--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -752,9 +752,15 @@ class PortLoggingHandler(WSGIRequestHandler):
     def log(self, type, message, *args):
         # Conform to Combined Log Format, replacing Referer with the Host header or the local server address
         url_scheme = "http" if self.server.ssl_context is None else "https"
-        host = self.headers.get("Host", "{}:{}".format(self.server.server_address[0], self.server.server_address[1]))
+        if hasattr(self, "headers"):
+            host = self.headers.get("Host", "{}:{}".format(self.server.server_address[0],
+                                                           self.server.server_address[1]))
+            user_agent = self.headers.get("User-Agent", "")
+        else:
+            host = "{}:{}".format(self.server.server_address[0], self.server.server_address[1])
+            user_agent = ""
         referer = "{}://{}".format(url_scheme, host)
-        message += ' "{}" "{}"'.format(referer, self.headers.get("User-Agent", ""))
+        message += ' "{}" "{}"'.format(referer, user_agent)
         super().log(type, message, *args)
 
 


### PR DESCRIPTION
I've observed the following in the logs occasionally:

```
  File "/usr/local/lib/python3.6/dist-packages/werkzeug/serving.py", line 361, in handle_one_request
    elif self.parse_request():
  File "/usr/lib/python3.6/http/server.py", line 322, in parse_request
    "Bad request syntax (%r)" % requestline)
  File "/usr/lib/python3.6/http/server.py", line 448, in send_error
    self.log_error("code %d, message %s", code, message)
  File "/usr/local/lib/python3.6/dist-packages/werkzeug/serving.py", line 420, in log_error
    self.log("error", *args)
  File "/home/nmos-testing/nmostesting/NMOSTesting.py", line 759, in log
    host = self.headers.get("Host", "{}:{}".format(self.server.server_address[0], self.server.server_address[1]))
AttributeError: 'PortLoggingHandler' object has no attribute 'headers'
```

There is a workaround for missing headers already, but this doesn't handle the entire dict being missing.