### PR TITLE
IS-05-01 Test 29/30: Allow for an API processing timeout interval

### DIFF
--- a/nmostesting/IS05Utils.py
+++ b/nmostesting/IS05Utils.py
@@ -331,7 +331,7 @@ class IS05Utils(NMOSUtils):
             except KeyError:
                 return False, "Expected 'activation_time' key in 'activation' object."
             # Allow extra time for processing between getting time and making request
-            time.sleep(2)
+            time.sleep(CONFIG.API_PROCESSING_TIMEOUT)
 
             retries = 0
             finished = False


### PR DESCRIPTION
between the PATCH and getting the first results

Some devices have higher latency then others on top of adjusting for difference in system time. The API_PROCESSING_TIMEOUT is applied within the retry loop but this PR applies it before the test as well.