### PR TITLE
IS-05-01: Refactor IS-05 activation utility functions

### DIFF
--- a/nmostesting/IS05Utils.py
+++ b/nmostesting/IS05Utils.py
@@ -173,7 +173,7 @@ class IS05Utils(NMOSUtils):
                 time.sleep(activateSleep)
 
             # Check the values now on /active
-            maxTries = 1 if activateMode == IMMEDIATE_ACTIVATION else 5
+            maxTries = 1 if activateMode == IMMEDIATE_ACTIVATION else 2
             tries = 0
             ready = False
 
@@ -227,9 +227,9 @@ class IS05Utils(NMOSUtils):
                     return False, activeParams
                 time.sleep(CONFIG.API_PROCESSING_TIMEOUT)
             if ready:
-                return False, "Activation entries were not set at {} during {} activation{}" \
+                return False, "Activation entries were not set at {} after {} activation{}" \
                               .format(activeUrl, activationName, " (Tries: {})".format(tries) if tries > 1 else "")
-            return False, "Transport parameters did not transition to {} during {} activation{}" \
+            return False, "Transport parameters did not transition to {} after {} activation{}" \
                           .format(activeUrl, activationName, " (Tries: {})".format(tries) if tries > 1 else "")
         else:
             return False, response
@@ -239,11 +239,16 @@ class IS05Utils(NMOSUtils):
 
     def check_perform_relative_activation(self, port, portId, stagedParams, changedParam):
         return self._check_perform_activation(port, portId, stagedParams, changedParam,
-                                              "relative", SCHEDULED_RELATIVE_ACTIVATION, "0:100000000", 0.1)
+                                              "relative", SCHEDULED_RELATIVE_ACTIVATION,
+                                              "0:200000000", 0.2)
 
     def check_perform_absolute_activation(self, port, portId, stagedParams, changedParam):
+        # As stated in the README, the time of the test device and the time of the device hosting the tests
+        # needs to be synchronized in order to test absolute activation, but allow a 0.1 seconds difference...
+        MAX_TIME_SYNC_OFFSET = 0.1
         return self._check_perform_activation(port, portId, stagedParams, changedParam,
-                                              "absolute", SCHEDULED_ABSOLUTE_ACTIVATION, self.get_TAI_time(1), 1)
+                                              "absolute", SCHEDULED_ABSOLUTE_ACTIVATION,
+                                              self.get_TAI_time(1), 1 + MAX_TIME_SYNC_OFFSET)
 
     def check_activation(self, port, portId, activationMethod, transportType, masterEnable=None):
         """Checks that when an immediate activation is called staged parameters are moved

--- a/nmostesting/IS05Utils.py
+++ b/nmostesting/IS05Utils.py
@@ -331,7 +331,7 @@ class IS05Utils(NMOSUtils):
             except KeyError:
                 return False, "Expected 'activation_time' key in 'activation' object."
             # Allow extra time for processing between getting time and making request
-            time.sleep(2)
+            time.sleep(CONFIG.API_PROCESSING_TIMEOUT)
 
             retries = 0
             finished = False

--- a/nmostesting/suites/IS0501Test.py
+++ b/nmostesting/suites/IS0501Test.py
@@ -608,7 +608,10 @@ class IS0501Test(GenericTest):
                                              .format(sender, response2))
                 else:
                     return test.FAIL(response)
-            return test.PASS(warn)
+            if warn:
+                return test.WARNING(warn)
+            else:
+                return test.PASS()
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
@@ -626,8 +629,10 @@ class IS0501Test(GenericTest):
                         warn = response
                 else:
                     return test.FAIL(response)
-
-            return test.PASS(warn)
+            if warn:
+                return test.WARNING(warn)
+            else:
+                return test.PASS()
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
@@ -651,7 +656,10 @@ class IS0501Test(GenericTest):
                                              .format(sender, response2))
                 else:
                     return test.FAIL(response)
-            return test.PASS(warn)
+            if warn:
+                return test.WARNING(warn)
+            else:
+                return test.PASS()
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
@@ -669,7 +677,10 @@ class IS0501Test(GenericTest):
                         warn = response
                 else:
                     return test.FAIL(response)
-            return test.PASS(warn)
+            if warn:
+                return test.WARNING(warn)
+            else:
+                return test.PASS()
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
@@ -693,7 +704,10 @@ class IS0501Test(GenericTest):
                                              .format(sender, response2))
                 else:
                     return test.FAIL(response)
-            return test.PASS(warn)
+            if warn:
+                return test.WARNING(warn)
+            else:
+                return test.PASS()
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
@@ -711,7 +725,10 @@ class IS0501Test(GenericTest):
                         warn = response
                 else:
                     return test.FAIL(response)
-            return test.PASS(warn)
+            if warn:
+                return test.WARNING(warn)
+            else:
+                return test.PASS()
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 

--- a/nmostesting/suites/IS0501Test.py
+++ b/nmostesting/suites/IS0501Test.py
@@ -592,12 +592,15 @@ class IS0501Test(GenericTest):
         """Immediate activation of a sender is possible"""
 
         if len(self.senders) > 0:
+            warn = ""
             for sender in self.is05_utils.sampled_list(self.senders):
                 valid, response = self.is05_utils.check_activation("sender", sender,
                                                                    self.is05_utils.check_perform_immediate_activation,
                                                                    self.transport_types[sender],
                                                                    True)
                 if valid:
+                    if response and not warn:
+                        warn = response
                     if self.transport_types[sender] == "urn:x-nmos:transport:rtp":
                         valid2, response2 = self.is05_utils.check_sdp_matches_params(sender)
                         if not valid2:
@@ -605,7 +608,7 @@ class IS0501Test(GenericTest):
                                              .format(sender, response2))
                 else:
                     return test.FAIL(response)
-            return test.PASS()
+            return test.PASS(warn)
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
@@ -613,16 +616,18 @@ class IS0501Test(GenericTest):
         """Immediate activation of a receiver is possible"""
 
         if len(self.receivers) > 0:
+            warn = ""
             for receiver in self.is05_utils.sampled_list(self.receivers):
                 valid, response = self.is05_utils.check_activation("receiver", receiver,
                                                                    self.is05_utils.check_perform_immediate_activation,
                                                                    self.transport_types[receiver])
                 if valid:
-                    pass
+                    if response and not warn:
+                        warn = response
                 else:
                     return test.FAIL(response)
 
-            return test.PASS()
+            return test.PASS(warn)
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
@@ -630,12 +635,15 @@ class IS0501Test(GenericTest):
         """Relative activation of a sender is possible"""
 
         if len(self.senders) > 0:
+            warn = ""
             for sender in self.is05_utils.sampled_list(self.senders):
                 valid, response = self.is05_utils.check_activation("sender", sender,
                                                                    self.is05_utils.check_perform_relative_activation,
                                                                    self.transport_types[sender],
                                                                    True)
                 if valid:
+                    if response and not warn:
+                        warn = response
                     if self.transport_types[sender] == "urn:x-nmos:transport:rtp":
                         valid2, response2 = self.is05_utils.check_sdp_matches_params(sender)
                         if not valid2:
@@ -643,7 +651,7 @@ class IS0501Test(GenericTest):
                                              .format(sender, response2))
                 else:
                     return test.FAIL(response)
-            return test.PASS(response)
+            return test.PASS(warn)
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
@@ -651,15 +659,17 @@ class IS0501Test(GenericTest):
         """Relative activation of a receiver is possible"""
 
         if len(self.receivers) > 0:
+            warn = ""
             for receiver in self.is05_utils.sampled_list(self.receivers):
                 valid, response = self.is05_utils.check_activation("receiver", receiver,
                                                                    self.is05_utils.check_perform_relative_activation,
                                                                    self.transport_types[receiver])
                 if valid:
-                    pass
+                    if response and not warn:
+                        warn = response
                 else:
                     return test.FAIL(response)
-            return test.PASS(response)
+            return test.PASS(warn)
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
@@ -667,12 +677,15 @@ class IS0501Test(GenericTest):
         """Absolute activation of a sender is possible"""
 
         if len(self.senders) > 0:
+            warn = ""
             for sender in self.is05_utils.sampled_list(self.senders):
                 valid, response = self.is05_utils.check_activation("sender", sender,
                                                                    self.is05_utils.check_perform_absolute_activation,
                                                                    self.transport_types[sender],
                                                                    True)
                 if valid:
+                    if response and not warn:
+                        warn = response
                     if self.transport_types[sender] == "urn:x-nmos:transport:rtp":
                         valid2, response2 = self.is05_utils.check_sdp_matches_params(sender)
                         if not valid2:
@@ -680,7 +693,7 @@ class IS0501Test(GenericTest):
                                              .format(sender, response2))
                 else:
                     return test.FAIL(response)
-            return test.PASS(response)
+            return test.PASS(warn)
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
@@ -688,15 +701,17 @@ class IS0501Test(GenericTest):
         """Absolute activation of a receiver is possible"""
 
         if len(self.receivers) > 0:
+            warn = ""
             for receiver in self.is05_utils.sampled_list(self.receivers):
                 valid, response = self.is05_utils.check_activation("receiver", receiver,
                                                                    self.is05_utils.check_perform_absolute_activation,
                                                                    self.transport_types[receiver])
                 if valid:
-                    pass
+                    if response and not warn:
+                        warn = response
                 else:
                     return test.FAIL(response)
-            return test.PASS(response)
+            return test.PASS(warn)
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 


### PR DESCRIPTION
Been meaning to look into this code for a while, just hadn't got around to deeply investigating and deciding how the test should handle checking activation when it can't easily make a change to a parameter, e.g. because the single value allowed by the **/constraints** enum is already set in **/active**.

Prompted to get into it by #584. 

This refactor implements the checks of immediate activations and both scheduled activation modes with a common function, reducing LOC by ~100. That function now performs additional checks of the activation sub-object attributes, and the number of permitted retries is reduced so that the maximum delay on a scheduled activation is reduced to a bit more than a single `Config.API_PROCESSING_TIMEOUT`. A clear `MAX_TIME_SYNC_OFFSET` of 0.1s is added, in line with the other test cases that require absolute timing synchronization between the Testing Tool and the API under test.
