### PR TITLE
token: ensure Query API is in scopes when testing without DNS-SD

### DIFF
--- a/nmostesting/GenericTest.py
+++ b/nmostesting/GenericTest.py
@@ -190,6 +190,9 @@ class GenericTest(object):
             scopes = []
             for api in self.apis:
                 scopes.append(api)
+            # Add 'query' permission when mock registry is disabled and existing network registry is used
+            if not CONFIG.ENABLE_DNS_SD and "query" not in scopes:
+                scopes.append("query")
             CONFIG.AUTH_TOKEN = self.generate_token(scopes, True)
         if CONFIG.PREVALIDATE_API:
             for api in self.apis:


### PR DESCRIPTION
This fixes an issue with the authorization token scopes when running IS-04-01 test_04 with DNS SD disabled in the configuration.

This isn't a perfect fix as it adds 'query' scope where it may not be required for some tests. I may come back to it when I have more time.