### PR TITLE
Using specs.amwa.tv and updated jt-nm.org links

### DIFF
--- a/docs/3.1. Testing Profiles - JT-NM TR-1001.md
+++ b/docs/3.1. Testing Profiles - JT-NM TR-1001.md
@@ -1,6 +1,6 @@
 # JT-NM TR-1001
 
-The [Joint Task Force on Networked Media (JT-NM)](http://jt-nm.org/) defined [Technical Recommendation 1001-1](http://jt-nm.org/documents/JT-NM_TR-1001-1:2018_v1.0.pdf) (or TR-1001-1) in 2018, with an aim of identifying a set of key components which should be implemented by any 'Media Node'. The document also identifies a number of key features of systems which these Media Nodes may be deployed into.
+The [Joint Task Force on Networked Media (JT-NM)](http://jt-nm.org/) defined [Technical Recommendation 1001-1](https://www.jt-nm.org/tr-1001-1) (or TR-1001-1) in 2018, with an aim of identifying a set of key components which should be implemented by any 'Media Node'. The document also identifies a number of key features of systems which these Media Nodes may be deployed into.
 
 This testing tool can be used to test a number of the requirements which this document sets out, as follows.
 

--- a/docs/3.1. Testing Profiles - JT-NM TR-1001.md
+++ b/docs/3.1. Testing Profiles - JT-NM TR-1001.md
@@ -1,6 +1,6 @@
 # JT-NM TR-1001
 
-The [Joint Task Force on Networked Media (JT-NM)](http://jt-nm.org/) defined [Technical Recommendation 1001-1](https://www.jt-nm.org/tr-1001-1) (or TR-1001-1) in 2018, with an aim of identifying a set of key components which should be implemented by any 'Media Node'. The document also identifies a number of key features of systems which these Media Nodes may be deployed into.
+The [Joint Task Force on Networked Media (JT-NM)](http://jt-nm.org/) first defined [Technical Recommendation 1001-1](https://www.jt-nm.org/tr-1001-1) (or TR-1001-1) in 2018, with an aim of identifying a set of key components which should be implemented by any 'Media Node'. The document also identifies a number of key features of systems which these Media Nodes may be deployed into.
 
 This testing tool can be used to test a number of the requirements which this document sets out, as follows.
 

--- a/nmostesting/suites/BCP00301Test.py
+++ b/nmostesting/suites/BCP00301Test.py
@@ -83,7 +83,7 @@ class BCP00301Test(GenericTest):
                     return test.FAIL("Protocol {} must be offered".format(report["id"].replace("_", ".")))
                 elif report["id"] in ["TLS1_3"] and not report["finding"].startswith("offered"):
                     return test.OPTIONAL("Protocol {} should be offered".format(report["id"].replace("_", ".")),
-                                         "https://amwa-tv.github.io/nmos-secure-communication/branches/{}"
+                                         "https://specs.amwa.tv/bcp-003-01/branches/{}"
                                          "/docs/1.0._Secure_Communication.html#tls-versions"
                                          .format(self.apis[SECURE_API_KEY]["spec_branch"]))
             return test.PASS()
@@ -134,13 +134,13 @@ class BCP00301Test(GenericTest):
             elif len(tls1_2_should) > 0:
                 return test.OPTIONAL("Implementation of the following TLS 1.2 ciphers is recommended: {}"
                                      .format(",".join(tls1_2_should)),
-                                     "https://amwa-tv.github.io/nmos-secure-communication/branches/{}"
+                                     "https://specs.amwa.tv/bcp-003-01/branches/{}"
                                      "/docs/1.0._Secure_Communication.html#tls-12-cipher-suites"
                                      .format(self.apis[SECURE_API_KEY]["spec_branch"]))
             elif tls1_3_supported and len(tls1_3_should) > 0:
                 return test.OPTIONAL("Implementation of the following TLS 1.3 ciphers is recommended: {}"
                                      .format(",".join(tls1_3_should)),
-                                     "https://amwa-tv.github.io/nmos-secure-communication/branches/{}"
+                                     "https://specs.amwa.tv/bcp-003-01/branches/{}"
                                      "/docs/1.0._Secure_Communication.html#tls-13-cipher-suites"
                                      .format(self.apis[SECURE_API_KEY]["spec_branch"]))
             else:
@@ -160,7 +160,7 @@ class BCP00301Test(GenericTest):
                     try:
                         ipaddress.ip_address(report["finding"])
                         return test.WARNING("CN is an IP address: {}".format(report["finding"]),
-                                            "https://amwa-tv.github.io/nmos-secure-communication/branches/{}"
+                                            "https://specs.amwa.tv/bcp-003-01/branches/{}"
                                             "/docs/1.0._Secure_Communication.html"
                                             "#x509-certificates-and-certificate-authority"
                                             .format(self.apis[SECURE_API_KEY]["spec_branch"]))
@@ -169,7 +169,7 @@ class BCP00301Test(GenericTest):
                 elif report["id"].split()[0] == "cert_subjectAltName":
                     if report["finding"].startswith("No SAN"):
                         return test.OPTIONAL("No SAN was found in the certificate",
-                                             "https://amwa-tv.github.io/nmos-secure-communication/branches/{}"
+                                             "https://specs.amwa.tv/bcp-003-01/branches/{}"
                                              "/docs/1.0._Secure_Communication.html"
                                              "#x509-certificates-and-certificate-authority"
                                              .format(self.apis[SECURE_API_KEY]["spec_branch"]))
@@ -177,7 +177,7 @@ class BCP00301Test(GenericTest):
                         alt_names = report["finding"].split()
                         if common_name not in alt_names:
                             return test.OPTIONAL("CN {} was not found in the SANs".format(common_name),
-                                                 "https://amwa-tv.github.io/nmos-secure-communication/branches/{}"
+                                                 "https://specs.amwa.tv/bcp-003-01/branches/{}"
                                                  "/docs/1.0._Secure_Communication.html"
                                                  "#x509-certificates-and-certificate-authority"
                                                  .format(self.apis[SECURE_API_KEY]["spec_branch"]))
@@ -185,7 +185,7 @@ class BCP00301Test(GenericTest):
                             try:
                                 ipaddress.ip_address(name)
                                 return test.WARNING("SAN is an IP address: {}".format(name),
-                                                    "https://amwa-tv.github.io/nmos-secure-communication/branches/{}"
+                                                    "https://specs.amwa.tv/bcp-003-01/branches/{}"
                                                     "/docs/1.0._Secure_Communication.html"
                                                     "#x509-certificates-and-certificate-authority"
                                                     .format(self.apis[SECURE_API_KEY]["spec_branch"]))
@@ -215,7 +215,7 @@ class BCP00301Test(GenericTest):
                 return test.PASS()
             elif hsts_supported is False:
                 return test.OPTIONAL("Strict Transport Security (HSTS) should be supported",
-                                     "https://amwa-tv.github.io/nmos-secure-communication/branches/{}"
+                                     "https://specs.amwa.tv/bcp-003-01/branches/{}"
                                      "/docs/1.0._Secure_Communication.html#http-server"
                                      .format(self.apis[SECURE_API_KEY]["spec_branch"]))
             else:
@@ -247,7 +247,7 @@ class BCP00301Test(GenericTest):
                 if report["id"].split()[0] == "OCSP_stapling":
                     if report["finding"] == "not offered":
                         return test.OPTIONAL("OCSP stapling is not offered by this server",
-                                             "https://amwa-tv.github.io/nmos-secure-communication/branches/{}"
+                                             "https://specs.amwa.tv/bcp-003-01/branches/{}"
                                              "/docs/1.0._Secure_Communication.html"
                                              "#x509-certificates-and-certificate-authority"
                                              .format(self.apis[SECURE_API_KEY]["spec_branch"]))

--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -1516,7 +1516,6 @@ class IS0401Test(GenericTest):
         else:
             return test.OPTIONAL("No BCP-002-01 groups were identified in Sender or Receiver tags",
                                  "https://specs.amwa.tv/bcp-002-01/branches/v1.0.x"
-
                                  "/docs/1.0._Natural_Grouping.html")
 
     def test_24(self, test):

--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -1515,7 +1515,8 @@ class IS0401Test(GenericTest):
             return test.PASS()
         else:
             return test.OPTIONAL("No BCP-002-01 groups were identified in Sender or Receiver tags",
-                                 "https://specs.amwa.tv/bcp-002-01/branches/{}"
+                                 "https://specs.amwa.tv/bcp-002-01/branches/v1.0.x"
+
                                  "/docs/1.0._Natural_Grouping.html")
 
     def test_24(self, test):

--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -525,7 +525,7 @@ class IS0401Test(GenericTest):
                                                  preceding_type + "_id", rdata[preceding_type + "_id"])
             if preceding_warn:
                 return test.WARNING(preceding_warn,
-                                    "https://amwa-tv.github.io/nmos-discovery-registration/branches/{}"
+                                    "https://specs.amwa.tv/is-04/branches/{}"
                                     "/docs/4.1._Behaviour_-_Registration.html#referential-integrity"
                                     .format(api["spec_branch"]))
             elif found_resource:
@@ -580,13 +580,13 @@ class IS0401Test(GenericTest):
             # Ensure the heartbeat request body is empty
             if heartbeat[1]["payload"] is not bytes():
                 return test.WARNING("Heartbeat POST contained a payload body.",
-                                    "https://amwa-tv.github.io/nmos-discovery-registration/branches/{}"
+                                    "https://specs.amwa.tv/is-04/branches/{}"
                                     "/docs/2.2._APIs_-_Client_Side_Implementation_Notes.html#empty-request-bodies"
                                     .format(api["spec_branch"]))
 
             if "Content-Type" in heartbeat[1]["headers"]:
                 return test.WARNING("Heartbeat POST contained a Content-Type header.",
-                                    "https://amwa-tv.github.io/nmos-discovery-registration/branches/{}"
+                                    "https://specs.amwa.tv/is-04/branches/{}"
                                     "/docs/2.2._APIs_-_Client_Side_Implementation_Notes.html#empty-request-bodies"
                                     .format(api["spec_branch"]))
 
@@ -596,7 +596,7 @@ class IS0401Test(GenericTest):
                     # The NMOS spec currently says Content-Length: 0 is OPTIONAL, but it is RECOMMENDED in RFC 7230
                     # and omitting it causes problems for commonly deployed HTTP servers
                     return test.WARNING("Heartbeat POST did not contain a valid Content-Length header.",
-                                        "https://amwa-tv.github.io/nmos-discovery-registration/branches/{}"
+                                        "https://specs.amwa.tv/is-04/branches/{}"
                                         "/docs/2.2._APIs_-_Client_Side_Implementation_Notes.html#empty-request-bodies"
                                         .format(api["spec_branch"]))
             else:
@@ -1515,8 +1515,8 @@ class IS0401Test(GenericTest):
             return test.PASS()
         else:
             return test.OPTIONAL("No BCP-002-01 groups were identified in Sender or Receiver tags",
-                                 "https://amwa-tv.github.io/nmos-grouping/branches/master"
-                                 "/best-practice-natural-grouping.html")
+                                 "https://specs.amwa.tv/bcp-002-01/branches/{}"
+                                 "/docs/1.0._Natural_Grouping.html")
 
     def test_24(self, test):
         """Periodic Sources specify a 'grain_rate'"""
@@ -1597,7 +1597,7 @@ class IS0401Test(GenericTest):
                     if "media_types" not in receiver["caps"]:
                         return test.WARNING("Receiver 'caps' should include a list of accepted 'media_types', unless "
                                             "this Receiver can handle any 'media_type'",
-                                            "https://amwa-tv.github.io/nmos-discovery-registration/branches/{}"
+                                            "https://specs.amwa.tv/is-04/branches/{}"
                                             "/docs/4.3._Behaviour_-_Nodes.html#all-resources"
                                             .format(api["spec_branch"]))
                     if self.is04_utils.compare_api_version(api["version"], "v1.3") >= 0:
@@ -1608,7 +1608,7 @@ class IS0401Test(GenericTest):
                                 return test.WARNING("Receiver 'caps' should include a list of accepted 'event_types' "
                                                     "if the Receiver accepts IS-07 events, unless this Receiver can "
                                                     "handle any 'event_type'",
-                                                    "https://amwa-tv.github.io/nmos-discovery-registration/branches/{}"
+                                                    "https://specs.amwa.tv/is-04/branches/{}"
                                                     "/docs/4.3._Behaviour_-_Nodes.html#all-resources"
                                                     .format(api["spec_branch"]))
             except json.JSONDecodeError:
@@ -1674,7 +1674,7 @@ class IS0401Test(GenericTest):
                         except ValidationError as e:
                             return test.FAIL("Receiver {} does not comply with the BCP-004-01 schema: "
                                              "{}".format(receiver["id"], str(e)),
-                                             "https://amwa-tv.github.io/nmos-receiver-capabilities/branches/{}"
+                                             "https://specs.amwa.tv/bcp-004-01/branches/{}"
                                              "/docs/1.0._Receiver_Capabilities.html"
                                              "#validating-parameter-constraints-and-constraint-sets"
                                              .format(api["spec_branch"]))
@@ -1684,7 +1684,7 @@ class IS0401Test(GenericTest):
                             except ValidationError as e:
                                 return test.FAIL("Receiver {} does not comply with the Capabilities register schema: "
                                                  "{}".format(receiver["id"], str(e)),
-                                                 "https://amwa-tv.github.io/nmos-receiver-capabilities/branches/{}"
+                                                 "https://specs.amwa.tv/bcp-004-01/branches/{}"
                                                  "/docs/1.0._Receiver_Capabilities.html"
                                                  "#behaviour-receivers"
                                                  .format(api["spec_branch"]))
@@ -1696,7 +1696,7 @@ class IS0401Test(GenericTest):
                             if not found_param_constraint:
                                 return test.FAIL("Receiver {} caps includes a constraint set without any "
                                                  "parameter constraints".format(receiver["id"]),
-                                                 "https://amwa-tv.github.io/nmos-receiver-capabilities/branches/{}"
+                                                 "https://specs.amwa.tv/bcp-004-01/branches/{}"
                                                  "/docs/1.0._Receiver_Capabilities.html"
                                                  "#constraint-sets"
                                                  .format(api["spec_branch"]))
@@ -1709,7 +1709,7 @@ class IS0401Test(GenericTest):
             return test.UNCLEAR("No Receivers were found on the Node")
         elif no_constraint_sets:
             return test.OPTIONAL("No BCP-004-01 'constraint_sets' were identified in Receiver caps",
-                                 "https://amwa-tv.github.io/nmos-receiver-capabilities/branches/{}"
+                                 "https://specs.amwa.tv/bcp-004-01/branches/{}"
                                  "/docs/1.0._Receiver_Capabilities.html#listing-constraint-sets"
                                  .format(api["spec_branch"]))
         else:
@@ -1735,7 +1735,7 @@ class IS0401Test(GenericTest):
                         if self.is04_utils.compare_resource_version(caps_version, core_version) > 0:
                             return test.FAIL("Receiver {} caps version is later than resource version"
                                              .format(receiver["id"]),
-                                             "https://amwa-tv.github.io/nmos-receiver-capabilities/branches/{}"
+                                             "https://specs.amwa.tv/bcp-004-01/branches/{}"
                                              "/docs/1.0._Receiver_Capabilities.html#behaviour-receivers"
                                              .format(api["spec_branch"]))
             except json.JSONDecodeError:
@@ -1747,7 +1747,7 @@ class IS0401Test(GenericTest):
             return test.UNCLEAR("No Receivers were found on the Node")
         elif no_caps_version:
             return test.OPTIONAL("No Receiver caps versions were found",
-                                 "https://amwa-tv.github.io/nmos-receiver-capabilities/branches/{}"
+                                 "https://specs.amwa.tv/bcp-004-01/branches/{}"
                                  "/docs/1.0._Receiver_Capabilities.html#capabilities-version"
                                  .format(api["spec_branch"]))
         else:
@@ -1791,12 +1791,12 @@ class IS0401Test(GenericTest):
             return test.UNCLEAR("No Receivers were found on the Node")
         elif no_constraint_sets:
             return test.OPTIONAL("No BCP-004-01 'constraint_sets' were identified in Receiver caps",
-                                 "https://amwa-tv.github.io/nmos-receiver-capabilities/branches/{}"
+                                 "https://specs.amwa.tv/bcp-004-01/branches/{}"
                                  "/docs/1.0._Receiver_Capabilities.html#listing-constraint-sets"
                                  .format(api["spec_branch"]))
         elif warn_unregistered:
             return test.WARNING(warn_unregistered,
-                                "https://amwa-tv.github.io/nmos-receiver-capabilities/branches/{}"
+                                "https://specs.amwa.tv/bcp-004-01/branches/{}"
                                 "/docs/1.0._Receiver_Capabilities.html#defining-parameter-constraints"
                                 .format(api["spec_branch"]))
         else:
@@ -1843,17 +1843,17 @@ class IS0401Test(GenericTest):
             return test.UNCLEAR("No Receivers were found on the Node")
         elif no_constraint_sets:
             return test.OPTIONAL("No BCP-004-01 'constraint_sets' were identified in Receiver caps",
-                                 "https://amwa-tv.github.io/nmos-receiver-capabilities/branches/{}"
+                                 "https://specs.amwa.tv/bcp-004-01/branches/{}"
                                  "/docs/1.0._Receiver_Capabilities.html#listing-constraint-sets"
                                  .format(api["spec_branch"]))
         elif no_meta:
             return test.OPTIONAL("No BCP-004-01 'constraint_sets' have {}".format(description),
-                                 "https://amwa-tv.github.io/nmos-receiver-capabilities/branches/{}"
+                                 "https://specs.amwa.tv/bcp-004-01/branches/{}"
                                  "/docs/1.0._Receiver_Capabilities.html#constraint-set-{}"
                                  .format(api["spec_branch"], meta))
         elif warn_not_all and not all_meta:
             return test.WARNING("Only some BCP-004-01 'constraint_sets' have {}".format(description),
-                                "https://amwa-tv.github.io/nmos-receiver-capabilities/branches/{}"
+                                "https://specs.amwa.tv/bcp-004-01/branches/{}"
                                 "/docs/1.0._Receiver_Capabilities.html#constraint-set-{}"
                                 .format(api["spec_branch"], meta))
         else:
@@ -1923,7 +1923,7 @@ class IS0401Test(GenericTest):
             return test.UNCLEAR("No Receivers were found on the Node")
         elif no_constraint_sets:
             return test.OPTIONAL("No BCP-004-01 'constraint_sets' were identified in Receiver caps",
-                                 "https://amwa-tv.github.io/nmos-receiver-capabilities/branches/{}"
+                                 "https://specs.amwa.tv/bcp-004-01/branches/{}"
                                  "/docs/1.0._Receiver_Capabilities.html#listing-constraint-sets"
                                  .format(api["spec_branch"]))
         elif warn_format:
@@ -1966,7 +1966,7 @@ class IS0401Test(GenericTest):
             return test.UNCLEAR("No Receivers were found on the Node")
         elif no_constraint_sets:
             return test.OPTIONAL("No BCP-004-01 'constraint_sets' were identified in Receiver caps",
-                                 "https://amwa-tv.github.io/nmos-receiver-capabilities/branches/{}"
+                                 "https://specs.amwa.tv/bcp-004-01/branches/{}"
                                  "/docs/1.0._Receiver_Capabilities.html#listing-constraint-sets"
                                  .format(api["spec_branch"]))
         else:

--- a/nmostesting/suites/IS0702Test.py
+++ b/nmostesting/suites/IS0702Test.py
@@ -206,7 +206,7 @@ class IS0702Test(GenericTest):
                     return test.FAIL("Source {} not found in Node API".format(source_id))
             if warn_topic:
                 return test.WARNING(warn_message,
-                                    "https://amwa-tv.github.io/nmos-event-tally/branches/{}"
+                                    "https://specs.amwa.tv/is-07/branches/{}"
                                     "/docs/5.1._Transport_-_MQTT.html#32-broker_topic"
                                     .format(api["spec_branch"]))
             else:


### PR DESCRIPTION
Updating amwa-tv.github.io links to use the new specs.amwa.tv equivalent (with AMWA ID in the path).  Please check the BCP-002-01 link in particular.  Also changed the TR-1001 link to match new jt-nm.org site.