### PR TITLE
Python websocket-client 1.0.0 fix

### DIFF
--- a/nmostesting/TestHelper.py
+++ b/nmostesting/TestHelper.py
@@ -270,7 +270,7 @@ class WebsocketWorker(threading.Thread):
     def on_message(self, ws, message):
         self.messages.append(message)
 
-    def on_close(self, ws):
+    def on_close(self, ws, close_status, close_message):
         self.connected = False
 
     def on_error(self, ws, error):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ requests
 netifaces
 gitpython
 ramlfications
-websocket-client>=0.58.0
+websocket-client>=1.0.0
 jsonref
 dnslib
 jinja2


### PR DESCRIPTION
Python websocket-client 1.0.0 changes the way arguments are passed to the `on_close` callback (see https://github.com/websocket-client/websocket-client/commit/c414127161f6822e57177a531843c3652bc98dd6).

This caused spurious failure in **IS-07-02 test_04**: "WebSocket connection (no health cmd sent) to ws://192.168.56.1:3217/x-nmos/events/v1.0/devices/5775c3ce-310f-5036-9282-5664dc3d0ce7 was not closed after timeout".

Rather reminiscent of #605, but hopefully now that they have indicated they're adopting **semver** this shouldn't happen so often!

@lo-simon, please would you review?