### PR TITLE
Bug Fix: IS0402 Test 31 - resources expiring before test complete

### DIFF
--- a/nmostesting/suites/IS0402Test.py
+++ b/nmostesting/suites/IS0402Test.py
@@ -1907,7 +1907,7 @@ class IS0402Test(GenericTest):
             # Heartbeat node after sleep to prevent expiry
             valid, r = self.do_request("POST", "{}health/nodes/{}".format(self.reg_url, self.test_data["node"]["id"]))
             if not valid:
-                return test.FAIL("Unable to heartbeat node: {}".format(r))
+                return test.FAIL("Registration API failed to respond to heartbeat request: {}".format(r))
 
             for resource, resource_data in test_data.items():
                 if websockets[resource].did_error_occur():
@@ -1957,7 +1957,7 @@ class IS0402Test(GenericTest):
             # Heartbeat node after sleep to prevent expiry
             valid, r = self.do_request("POST", "{}health/nodes/{}".format(self.reg_url, self.test_data["node"]["id"]))
             if not valid:
-                return test.FAIL("Unable to heartbeat node: {}".format(r))
+                return test.FAIL("Registration API failed to respond to heartbeat request: {}".format(r))
 
             for resource, resource_data in test_data.items():
                 received_messages = websockets[resource].get_messages()


### PR DESCRIPTION
IS0402 Test 31 can take too long to check validity of Registry responses on some platforms, leading to resources expiring and premature failure of the test.

A heartbeat has been added to the test after sleep periods prevent registered resources expiring