### PR TITLE
deploy: remove armv7 until build issue can be resolved

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           builder: ${{ steps.buildx.outputs.name }}
-          platforms: linux/amd64,linux/arm64,linux/armv7
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: amwa/nmos-testing:latest


### PR DESCRIPTION
At present an issue with libffi-dev is preventing the arm/v7 build. I'll look into this when I have more time, but for now this is required to fix the other builds.