### PR TITLE
[IS-04-01] Adapt the mock Node to config SDP_PREFERENCES

### DIFF
--- a/nmostesting/mocks/Node.py
+++ b/nmostesting/mocks/Node.py
@@ -15,23 +15,25 @@
 import uuid
 
 from flask import Blueprint, make_response, abort
-from ..Config import ENABLE_HTTPS, DNS_DOMAIN, PORT_BASE, DNS_SD_MODE
+from random import randint
+from jinja2 import Template
+from .. import Config as CONFIG
 from ..TestHelper import get_default_ip
 
 
 class Node(object):
     def __init__(self, port_increment):
-        self.port = PORT_BASE + 200 + port_increment
+        self.port = CONFIG.PORT_BASE + 200 + port_increment
 
     def get_sender(self, stream_type="video"):
         protocol = "http"
         host = get_default_ip()
-        if ENABLE_HTTPS:
+        if CONFIG.ENABLE_HTTPS:
             protocol = "https"
-            if DNS_SD_MODE == "multicast":
+            if CONFIG.DNS_SD_MODE == "multicast":
                 host = "nmos-mocks.local"
             else:
-                host = "mocks.{}".format(DNS_DOMAIN)
+                host = "mocks.{}".format(CONFIG.DNS_DOMAIN)
         # TODO: Provide the means to downgrade this to a <v1.2 JSON representation
         sender = {
             "id": str(uuid.uuid4()),
@@ -58,23 +60,46 @@ NODE_API = Blueprint('node_api', __name__)
 
 
 @NODE_API.route('/<stream_type>.sdp', methods=["GET"])
-def node_video_sdp(stream_type):
+def node_sdp(stream_type):
     # TODO: Should we check for an auth token here? May depend on the URL?
-    response = None
     if stream_type == "video":
-        with open("test_data/IS0401/video.sdp") as f:
-            response = make_response(f.read())
+        template_path = "test_data/IS0401/video.sdp"
     elif stream_type == "audio":
-        with open("test_data/IS0401/audio.sdp") as f:
-            response = make_response(f.read())
+        template_path = "test_data/IS0401/audio.sdp"
     elif stream_type == "data":
-        with open("test_data/IS0401/data.sdp") as f:
-            response = make_response(f.read())
+        template_path = "test_data/IS0401/data.sdp"
     elif stream_type == "mux":
-        with open("test_data/IS0401/mux.sdp") as f:
-            response = make_response(f.read())
+        template_path = "test_data/IS0401/mux.sdp"
     else:
         abort(404)
 
+    template_file = open(template_path).read()
+    template = Template(template_file, keep_trailing_newline=True)
+
+    src_ip = get_default_ip()
+    dst_ip = "232.40.50.{}".format(randint(1, 254))
+    dst_port = randint(5000, 5999)
+
+    if stream_type == "video":
+        interlace = ""
+        if CONFIG.SDP_PREFERENCES["video_interlace"] is True:
+            interlace = "interlace; "
+        # TODO: The SDP_PREFERENCES doesn't include video media type
+        sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="raw",
+                                   width=CONFIG.SDP_PREFERENCES["video_width"],
+                                   height=CONFIG.SDP_PREFERENCES["video_height"],
+                                   interlace=interlace,
+                                   exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"])
+    elif stream_type == "audio":
+        # TODO: The SDP_PREFERENCES doesn't include audio media type or sample depth
+        sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="L24",
+                                   channels=CONFIG.SDP_PREFERENCES["audio_channels"],
+                                   sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"])
+    elif stream_type == "data":
+        sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip)
+    elif stream_type == "mux":
+        sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip)
+
+    response = make_response(sdp_file)
     response.headers["Content-Type"] = "application/sdp"
     return response

--- a/test_data/IS0401/audio.sdp
+++ b/test_data/IS0401/audio.sdp
@@ -1,12 +1,12 @@
 v=0
-o=- 1543226711 1543226711 IN IP4 172.29.80.65
+o=- 1543226711 1543226711 IN IP4 {{ src_ip }}
 s=Demo Audio Stream
 t=0 0
-m=audio 46848 RTP/AVP 102
-c=IN IP4 232.130.55.188/32
-a=source-filter: incl IN IP4 232.130.55.188 172.29.80.65
+m=audio {{ dst_port }} RTP/AVP 102
+c=IN IP4 {{ dst_ip }}/32
+a=source-filter: incl IN IP4 {{ dst_ip }} {{ src_ip }}
 a=ts-refclk:ptp=IEEE1588-2008:EC-46-70-FF-FE-00-CE-DE:0
-a=rtpmap:102 L24/48000/2
+a=rtpmap:102 {{ media_type }}/{{ sample_rate }}/{{ channels }}
 a=mediaclk:direct=0
 a=ptime:1
 a=maxptime:1

--- a/test_data/IS0401/data.sdp
+++ b/test_data/IS0401/data.sdp
@@ -1,10 +1,10 @@
 v=0
-o=- 1543226713 1543226713 IN IP4 172.29.80.65
+o=- 1543226713 1543226713 IN IP4 {{ src_ip }}
 s=Demo Data Stream
 t=0 0
-m=video 11437 RTP/AVP 105
-c=IN IP4 232.32.87.86/32
-a=source-filter: incl IN IP4 232.32.87.86 172.29.80.65
+m=video {{ dst_port }} RTP/AVP 105
+c=IN IP4 {{ dst_ip }}/32
+a=source-filter: incl IN IP4 {{ dst_ip }} {{ src_ip }}
 a=ts-refclk:ptp=IEEE1588-2008:EC-46-70-FF-FE-00-CE-DE:0
 a=rtpmap:105 smpte291/90000
 a=mediaclk:direct=0 rate=90000

--- a/test_data/IS0401/mux.sdp
+++ b/test_data/IS0401/mux.sdp
@@ -1,8 +1,8 @@
 v=0
-o=- 198403 11 IN IP4 172.29.80.65
+o=- 198403 11 IN IP4 {{ src_ip }}
 s=Demo Mux Stream
 t=0 0
-m=video 5000 RTP/AVP 98
-c=IN IP4 232.0.16.1/32
-a=source-filter: incl IN IP4 232.0.16.1 172.29.80.65
+m=video {{ dst_port }} RTP/AVP 98
+c=IN IP4 {{ dst_ip }}/32
+a=source-filter: incl IN IP4 {{ dst_ip }} {{ src_ip }}
 a=rtpmap:98 SMPTE2022-6/27000000

--- a/test_data/IS0401/video.sdp
+++ b/test_data/IS0401/video.sdp
@@ -1,11 +1,11 @@
 v=0
-o=- 1543226715 1543226715 IN IP4 172.29.80.65
+o=- 1543226715 1543226715 IN IP4 {{ src_ip }}
 s=Demo Video Stream
 t=0 0
-m=video 27346 RTP/AVP 97
-c=IN IP4 232.80.177.113/32
-a=source-filter: incl IN IP4 232.80.177.113 172.29.80.65
+m=video {{ dst_port }} RTP/AVP 97
+c=IN IP4 {{ dst_ip }}/32
+a=source-filter: incl IN IP4 {{ dst_ip }} {{ src_ip }}
 a=ts-refclk:ptp=IEEE1588-2008:EC-46-70-FF-FE-00-CE-DE:0
-a=rtpmap:97 raw/90000
-a=fmtp:97 sampling=YCbCr-4:2:2; width=1920; height=1080; depth=10; interlace; SSN=ST2110-20:2017; colorimetry=BT709; PM=2110GPM; TP=2110TPW; TCS=SDR; exactframerate=25
+a=rtpmap:97 {{ media_type }}/90000
+a=fmtp:97 sampling=YCbCr-4:2:2; width={{ width }}; height={{ height }}; depth=10; {{ interlace }}SSN=ST2110-20:2017; colorimetry=BT709; PM=2110GPM; TP=2110TPW; TCS=SDR; exactframerate={{ exactframerate }}
 a=mediaclk:direct=0 rate=90000


### PR DESCRIPTION
Resolves #622, failures in IS-04-01 test_13 when `SDP_PREFERENCES` has been configured appropriately for a Node that analyzes and can reject an inappropriate SDP file.

Uses the same Jinja2 template mechanism as already employed for IS-05-02 (and elsewhere).

Yes, this has a little code duplication with `IS0502Test.test_18` and doesn't support Receivers that don't accept `video/raw` or `audio/L24` for example, or Receivers that check other SDP format-specific parameters (e.g. against their own Receiver caps), but that's a bigger issue, we need to introduce `video_media_type` and `audio_media_type` (or `audio_sample_depth`) etc. into `SDP_PREFERENCES` to resolve that.