### PR TITLE
Make the auto tests more thorough by default

### DIFF
--- a/nmostesting/GenericTest.py
+++ b/nmostesting/GenericTest.py
@@ -506,7 +506,7 @@ class GenericTest(object):
                                                 self.apis[api]["version"],
                                                 resource[0].rstrip("/")), self.auto_test_name(api))
 
-        # Test URLs which include a {resourceId} or similar parameter
+        # Test URLs which include a single {resourceId} or similar parameter
         if resource[1]['params'] and len(resource[1]['params']) == 1:
             path = resource[0].split("{")[0].rstrip("/")
             if path in self.saved_entities:
@@ -537,6 +537,8 @@ class GenericTest(object):
                     return test.PASS()
             else:
                 return test.FAIL(message)
+
+        # URLs with more than one parameter are currently not tested by the automatically defined tests
         else:
             return None
 
@@ -560,7 +562,8 @@ class GenericTest(object):
             return False, "Incorrect response code: {}".format(response.status_code)
 
         # Gather IDs of sub-resources for testing of parameterised URLs...
-        self.save_subresources(path, response)
+        if resource[1].get('child_resources', False):
+            self.save_subresources(path, response)
 
         cors_valid, cors_message = self.check_CORS(resource[1]['method'], response.headers,
                                                    cors_methods, cors_headers)

--- a/nmostesting/Specification.py
+++ b/nmostesting/Specification.py
@@ -55,6 +55,14 @@ class Specification(object):
             # Register the collected data in the Specification object
             self.data[resource.path].append(resource_data)
 
+            # Record if parent resource GET method should provide a "child resources" response
+            path_components = resource.path.split("/")
+            if path_components[-1].startswith('{'):
+                parent_path = "/".join(path_components[0:-1])
+                for method_def in self.data[parent_path]:
+                    if method_def['method'] == 'get':
+                        method_def['child_resources'] = True
+
     def _fix_schemas(self, file_path):
         """Fixes RAML files to match ramlfications expectations (bugs)"""
         lines = []


### PR DESCRIPTION
The primary motivation here is to thoroughly test Nodes which support several different kinds of each resource type, e.g. video/audio/ancillary data Flows, RTP and WebSocket or MQTT Receivers, etc.

Resolves #625, though will make testing take longer by default for 'big' nodes.

I'm a little unhappy with passing `test` to the "check style" `check_api_resource` just to be able to get a `MANUAL` result if there's no schema.
