### PR TITLE
Websocket-client version 1.2.2 breaks WebSocket testing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ requests
 netifaces
 gitpython
 ramlfications
-websocket-client>=1.0.0
+websocket-client>=1.0.0,!=1.2.2
 jsonref
 dnslib
 jinja2


### PR DESCRIPTION
Avoid websocket-client 1.2.2 due to https://github.com/websocket-client/websocket-client/issues/769