### PR TITLE
readme: update badges to point at GitHub Actions status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# NMOS API Testing Tool [![LICENSE](https://img.shields.io/github/license/amwa-tv/nmos-testing.svg?color=blue&logo=apache)](https://github.com/amwa-tv/nmos-testing/blob/master/LICENSE) [![Build Status](https://travis-ci.com/AMWA-TV/nmos-testing.svg?branch=master)](https://travis-ci.com/AMWA-TV/nmos-testing)
+# NMOS API Testing Tool
+
+[![LICENSE](https://img.shields.io/github/license/amwa-tv/nmos-testing.svg?color=blue&logo=apache)](https://github.com/amwa-tv/nmos-testing/blob/master/LICENSE)
+[![Lint Status](https://github.com/AMWA-TV/nmos-testing/workflows/Lint/badge.svg)](https://github.com/AMWA-TV/nmos-testing/actions?query=workflow%3ALint)
+[![Render Status](https://github.com/AMWA-TV/nmos-testing/workflows/Render/badge.svg)](https://github.com/AMWA-TV/nmos-testing/actions?query=workflow%3ARender)
+[![Deploy Status](https://github.com/AMWA-TV/nmos-testing/workflows/Deploy/badge.svg)](https://github.com/AMWA-TV/nmos-testing/actions?query=workflow%3ADeploy)
 
 <!-- INTRO-START -->
 


### PR DESCRIPTION
Looks like the README is still pointing at a logo from Travis CI