### PR TITLE
Possible Markdown table syntax fix for Jekyll

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 This tool creates a simple web service which tests implementations of the NMOS APIs.
 
-![Testing Tool Launcher](docs/images/initial-launch.png "Testing Tool Launcher") | ![Example Results Window](docs/images/test-results.png "Example Results Window")
---- | ---
+| ![Testing Tool Launcher](docs/images/initial-launch.png "Testing Tool Launcher") | ![Example Results Window](docs/images/test-results.png "Example Results Window") |
+| --- | --- |
 
 The following test suites are currently supported:
 *   IS-04 Node API

--- a/docs/1.0. Installation.md
+++ b/docs/1.0. Installation.md
@@ -5,6 +5,6 @@ The tool can be deployed either locally or by using a Docker container. The Dock
 - [On a local machine](1.1.%20Installation%20-%20Local.md)
 - [In a Docker container](1.2.%20Installation%20-%20Docker.md)
 
-# Configuration
+## Configuration
 
 To alter settings defined in `nmostesting/Config.py` copy `nmostesting/UserConfig.example.py` to `nmostesting/UserConfig.py` and make your changes there.


### PR DESCRIPTION
Noticed this wasn't rendered correctly on specs.amwa.tv.
https://www.markdownguide.org/extended-syntax/#tables suggests pipes at start/end of rows are required by some implementations (they're optional for GitHub-Flavor Markdown).
