### PR TITLE
Add support for making upstream DNS requests 

### DIFF
--- a/nmostesting/Config.py
+++ b/nmostesting/Config.py
@@ -33,6 +33,10 @@ DNS_SD_ADVERT_TIMEOUT = 30
 # Number of seconds to wait after browsing for a DNS-SD advert before checking the results
 DNS_SD_BROWSE_TIMEOUT = 2
 
+# Provide an upstream DNS server for requests not handled by the mock DNS server, when in 'unicast' DNS-SD mode
+# For example, '127.0.0.53'.
+DNS_UPSTREAM_IP = None
+
 # Number of seconds expected between heartbeats for an IS-04 Node
 # Note: Currently this is only used for testing IS-04 Nodes. Registry behaviour is expected to match the defaults.
 HEARTBEAT_INTERVAL = 5


### PR DESCRIPTION
Add support for making upstream DNS requests for which the mock DNS server would otherwise send a no-such-domain (NXDOMAIN) reply via a Config setting `DNS_UPSTREAM_IP`.

Since the mock DNS server is started with the testing tool, and resolver behaviour when there are multiple DNS servers defined is inconsistent, this may help with running through multiple test suites in unicast DNS-SD mode.

----

I didn't feel the need yet to introduce `DNS_UPSTREAM_PORT` and another timeout setting for these:

```
        self.upstream_port = 53
        self.timeout = None
```