### PR TITLE
handle hostname trailing dot

### DIFF
--- a/nmostesting/NMOSUtils.py
+++ b/nmostesting/NMOSUtils.py
@@ -144,7 +144,10 @@ class NMOSUtils(object):
 
         comparisons = ["scheme", "hostname", "path"]
         for attr in comparisons:
-            if getattr(url1_parsed, attr) != getattr(url2_parsed, attr):
+            if attr == "hostname":
+                if getattr(url1_parsed, attr).rstrip('.') != getattr(url2_parsed, attr).rstrip('.'):
+                    return False
+            elif getattr(url1_parsed, attr) != getattr(url2_parsed, attr):
                 return False
 
         # Ports can be None if they are the default for the scheme

--- a/nmostesting/TestHelper.py
+++ b/nmostesting/TestHelper.py
@@ -29,6 +29,7 @@ from enum import IntEnum
 from numbers import Number
 from functools import cmp_to_key
 from collections.abc import KeysView
+from urllib.parse import urlparse
 
 from . import Config as CONFIG
 
@@ -267,7 +268,9 @@ class WebsocketWorker(threading.Thread):
         self.error_message = ""
 
     def run(self):
-        self.ws.run_forever(sslopt={"ca_certs": CONFIG.CERT_TRUST_ROOT_CA})
+        # strip the trailing dot of the hostname to prevent SSL certificate hostname mismatch
+        hostname = urlparse(self.ws.url).hostname.rstrip('.')
+        self.ws.run_forever(sslopt={"ca_certs": CONFIG.CERT_TRUST_ROOT_CA, "server_hostname": hostname})
 
     def on_open(self, ws):
         self.connected = True

--- a/nmostesting/suites/BCP00301Test.py
+++ b/nmostesting/suites/BCP00301Test.py
@@ -57,7 +57,7 @@ class BCP00301Test(GenericTest):
                                       str(CONFIG.HTTP_TIMEOUT),
                                       "--add-ca",
                                       CONFIG.CERT_TRUST_ROOT_CA
-                                      ] + args + ["{}:{}".format(self.apis[SECURE_API_KEY]["hostname"],
+                                      ] + args + ["{}:{}".format(self.apis[SECURE_API_KEY]["hostname"].rstrip('.'),
                                                                  self.apis[SECURE_API_KEY]["port"])]
                                      )
                 if ret.returncode == 0:
@@ -265,7 +265,7 @@ class BCP00301Test(GenericTest):
 
         try:
             context = ssl.create_default_context(cafile=CONFIG.CERT_TRUST_ROOT_CA)
-            hostname = self.apis[SECURE_API_KEY]["hostname"]
+            hostname = self.apis[SECURE_API_KEY]["hostname"].rstrip('.')
             sock = context.wrap_socket(socket.socket(), server_hostname=hostname)
             sock.settimeout(CONFIG.HTTP_TIMEOUT)
             # Verification of certificate and CN/SAN matches is performed during connect

--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -1238,7 +1238,7 @@ class IS0401Test(GenericTest):
                         if self.authorization is not endpoint.get("authorization", False):
                             return test.FAIL("One or more Node 'api.endpoints' do not match the current authorization "
                                              "mode")
-                    if endpoint["host"].lower() == api["hostname"].lower() and endpoint["port"] == api["port"]:
+                    if endpoint["host"].lower().rstrip('.') == api["hostname"].lower().rstrip('.') and endpoint["port"] == api["port"]:
                         found_api_endpoint = True
                     if self.is04_utils.compare_urls(node_self["href"], "{}://{}:{}"
                                                     .format(endpoint["protocol"], endpoint["host"], endpoint["port"])):


### PR DESCRIPTION
- Treat hostname with or without the trailing dot be the same.
- Ignore the hostname trailing dot for SSL certificate validation to prevent the hostname mismatch while creating WebSocket.