### PR TITLE
Fix IS-04 test_20_01 to use the IS-05 transportfile paths when publishing I...

### DIFF
--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -1351,7 +1351,7 @@ class IS0401Test(GenericTest):
                     access_error = True
                     continue
 
-                if self.authorization and  href is not None and urlparse(href).path.startswith("/x-nmos/connection"):
+                if self.authorization and href is not None and urlparse(href).path.startswith("/x-nmos/connection"):
                     token = self.generate_token(["connection"], True)
                     headers = {"Authorization": "Bearer {}".format(token)}
                 else:

--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -1351,7 +1351,7 @@ class IS0401Test(GenericTest):
                     access_error = True
                     continue
 
-                if self.authorization:
+                if self.authorization and  href != None and urlparse(href).path.startswith("/x-nmos/connection"):
                     token = self.generate_token(["connection"], True)
                     headers = {"Authorization": "Bearer {}".format(token)}
                 else:

--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -1351,7 +1351,7 @@ class IS0401Test(GenericTest):
                     access_error = True
                     continue
 
-                if self.authorization and  href != None and urlparse(href).path.startswith("/x-nmos/connection"):
+                if self.authorization and  href is not None and urlparse(href).path.startswith("/x-nmos/connection"):
                     token = self.generate_token(["connection"], True)
                     headers = {"Authorization": "Bearer {}".format(token)}
                 else:

--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -1351,7 +1351,12 @@ class IS0401Test(GenericTest):
                     access_error = True
                     continue
 
-                valid, response = self.do_request("GET", href)
+                if self.authorization:
+                    token = self.generate_token(["connection"], True)
+                    headers = {"Authorization": "Bearer {}".format(token)}
+                else:
+                    headers = None
+                valid, response = self.do_request("GET", href, headers=headers)
                 if valid and response.status_code == 200:
                     valid, message = self.check_content_type(response.headers, "application/sdp")
                     if not content_type_warn and (not valid or message != ""):

--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -1351,7 +1351,7 @@ class IS0401Test(GenericTest):
                     access_error = True
                     continue
 
-                if self.authorization and href is not None and urlparse(href).path.startswith("/x-nmos/connection"):
+                if self.authorization and urlparse(href).path.startswith("/x-nmos/connection"):
                     token = self.generate_token(["connection"], True)
                     headers = {"Authorization": "Bearer {}".format(token)}
                 else:


### PR DESCRIPTION
…S-04 manifest_href Sender attribute. Thanks to **Mr Niitsu Keita-san** from Sony.

IS-05 `connection` scope token should be used for the test.
See https://specs.amwa.tv/bcp-003-02/releases/v1.0.0/docs/1.0._Authorization_Practice.html#node-manifest-href-authorization