### PR TITLE
Check for unnecessary charset should only be applied to specific media types

### DIFF
--- a/nmostesting/GenericTest.py
+++ b/nmostesting/GenericTest.py
@@ -269,12 +269,13 @@ class GenericTest(object):
             if ctype_params[0] != expected_type:
                 return False, "API signalled a Content-Type of {} rather than {}." \
                               .format(ctype, expected_type)
-            elif len(ctype_params) == 2 and ctype_params[1].strip().lower() == "charset=utf-8":
-                return True, "API signalled an unnecessary 'charset' in its Content-Type: {}" \
-                             .format(ctype)
-            elif len(ctype_params) >= 2:
-                return False, "API signalled unexpected additional parameters in its Content-Type: {}" \
-                              .format(ctype)
+            elif ctype_params[0] in ["application/json", "application/sdp"]:
+                if len(ctype_params) == 2 and ctype_params[1].strip().lower() == "charset=utf-8":
+                    return True, "API signalled an unnecessary 'charset' in its Content-Type: {}" \
+                                 .format(ctype)
+                elif len(ctype_params) >= 2:
+                    return False, "API signalled unexpected additional parameters in its Content-Type: {}" \
+                                  .format(ctype)
         return True, ""
 
     def check_accept(self, headers):


### PR DESCRIPTION
…where we *know* it's incorrect to include the charset.

That includes [application/json](https://www.iana.org/assignments/media-types/application/json) and [application/sdp](https://www.iana.org/assignments/media-types/application/sdp), neither of which define charset as an optional or required parameter - JSON is _always_ UTF-8 and SDP charset can be mixed, and is indicated by the `a=charset:` attribute.