### PR TITLE
Fix flake8 E275 missing whitespace after keyword

### DIFF
--- a/nmostesting/suites/IS0502Test.py
+++ b/nmostesting/suites/IS0502Test.py
@@ -49,7 +49,7 @@ class IS0502Test(GenericTest):
 
     def get_is04_resources(self, resource_type):
         """Retrieve all Senders or Receivers from a Node API, keeping hold of the returned objects"""
-        assert(resource_type in ["senders", "receivers", "sources", "flows"])
+        assert resource_type in ["senders", "receivers", "sources", "flows"]
 
         # Prevent this being executed twice in one test run
         if resource_type in self.is04_resources["_requested"]:
@@ -78,7 +78,7 @@ class IS0502Test(GenericTest):
 
     def get_is05_resources(self, resource_type):
         """Retrieve all Senders or Receivers from a Connection API, keeping hold of the returned IDs"""
-        assert(resource_type in ["senders", "receivers"])
+        assert resource_type in ["senders", "receivers"]
 
         # Prevent this being executed twice in one test run
         if resource_type in self.is05_resources["_requested"]:
@@ -108,7 +108,7 @@ class IS0502Test(GenericTest):
 
     def check_is04_in_is05(self, resource_type):
         """Check that each Sender or Receiver found via IS-04 has a matching entry in IS-05"""
-        assert(resource_type in ["senders", "receivers"])
+        assert resource_type in ["senders", "receivers"]
 
         result = True
         for is04_resource in self.is04_resources[resource_type]:
@@ -121,7 +121,7 @@ class IS0502Test(GenericTest):
 
     def check_is05_in_is04(self, resource_type):
         """Check that each Sender or Receiver found via IS-05 has a matching entry in IS-04"""
-        assert(resource_type in ["senders", "receivers"])
+        assert resource_type in ["senders", "receivers"]
 
         result = True
         for is05_resource in self.is05_resources[resource_type]:

--- a/nmostesting/suites/IS0802Test.py
+++ b/nmostesting/suites/IS0802Test.py
@@ -134,7 +134,7 @@ class IS0802Test(GenericTest):
 
     def get_is04_resources(self, resource_type):
         """Retrieve all Senders or Receivers from a Node API, keeping hold of the returned objects"""
-        assert(resource_type in ["senders", "receivers", "devices", "sources"])
+        assert resource_type in ["senders", "receivers", "devices", "sources"]
 
         # Prevent this being executed twice in one test run
         if resource_type in self.is04_resources["_requested"]:

--- a/utilities/is-05-control/is05Control.py
+++ b/utilities/is-05-control/is05Control.py
@@ -185,7 +185,7 @@ if __name__ == "__main__":
     with open("dummy-sdp.sdp", "r") as sdp_file:
         dummy_sdp_payload = sdp_file.read()
 
-    while(True):
+    while True:
         print('\nPress \'e\' to set master_enable True')
         print('Press \'d\' to set master_enable False')
         print('Press \'c\' to set Sender or Receiver to valid config')


### PR DESCRIPTION
`assert` is a statement not a function

See https://www.flake8rules.com/rules/E275.html
and https://docs.python.org/3/reference/simple_stmts.html#grammar-token-python-grammar-assert_stmt
