### PR TITLE
Setup sdp template data using user-defined values for supporting diff…

### DIFF
--- a/nmostesting/Config.py
+++ b/nmostesting/Config.py
@@ -142,10 +142,17 @@ PREVALIDATE_API = True
 SDP_PREFERENCES = {
     "audio_channels": 2,
     "audio_sample_rate": 48000,
+    "audio_packet_time": 1,
+    "audio_max_packet_time": 1,
     "video_width": 1920,
     "video_height": 1080,
     "video_interlace": True,
-    "video_exactframerate": "25"
+    "video_exactframerate": "25",
+    "video_depth": 10,
+    "video_sampling": "YCbCr-4:2:2",
+    "video_colorimetry": "BT709",
+    "video_transfer_characteristic": "SDR",
+    "video_type_parameter": "2110TPW"	
 }
 
 # Test with an MQTT Broker as per AMWA IS-07

--- a/nmostesting/Config.py
+++ b/nmostesting/Config.py
@@ -152,7 +152,7 @@ SDP_PREFERENCES = {
     "video_sampling": "YCbCr-4:2:2",
     "video_colorimetry": "BT709",
     "video_transfer_characteristic": "SDR",
-    "video_type_parameter": "2110TPW"	
+    "video_type_parameter": "2110TPW"
 }
 
 # Test with an MQTT Broker as per AMWA IS-07

--- a/nmostesting/mocks/Node.py
+++ b/nmostesting/mocks/Node.py
@@ -375,7 +375,7 @@ def node_sdp(stream_type):
                                    channels=CONFIG.SDP_PREFERENCES["audio_channels"],
                                    sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"],
                                    max_packet_time=CONFIG.SDP_PREFERENCES["audio_max_packet_time"],
-                                   packet_time=CONFIG.SDP_PREFERENCES["audio_packet_time"])								   
+                                   packet_time=CONFIG.SDP_PREFERENCES["audio_packet_time"])
     elif stream_type == "data":
         sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip)
     elif stream_type == "mux":
@@ -589,7 +589,7 @@ def transport_file(version, resource, resource_id):
                                        sampling=CONFIG.SDP_PREFERENCES["video_sampling"],
                                        colorimetry=CONFIG.SDP_PREFERENCES["video_colorimetry"],
                                        transfer_characteristic=CONFIG.SDP_PREFERENCES["video_transfer_characteristic"],
-                                       type_parameter=CONFIG.SDP_PREFERENCES["video_type_parameter"])									   
+                                       type_parameter=CONFIG.SDP_PREFERENCES["video_type_parameter"])
 
             response = make_response(sdp_file, 200)
             response.headers["Content-Type"] = "application/sdp"

--- a/nmostesting/mocks/Node.py
+++ b/nmostesting/mocks/Node.py
@@ -363,12 +363,19 @@ def node_sdp(stream_type):
                                    width=CONFIG.SDP_PREFERENCES["video_width"],
                                    height=CONFIG.SDP_PREFERENCES["video_height"],
                                    interlace=interlace,
-                                   exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"])
+                                   exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"],
+                                   depth=CONFIG.SDP_PREFERENCES["video_depth"],
+                                   sampling=CONFIG.SDP_PREFERENCES["video_sampling"],
+                                   colorimetry=CONFIG.SDP_PREFERENCES["video_colorimetry"],
+                                   transfer_characteristic=CONFIG.SDP_PREFERENCES["video_transfer_characteristic"],
+                                   type_parameter=CONFIG.SDP_PREFERENCES["video_type_parameter"])
     elif stream_type == "audio":
         # TODO: The SDP_PREFERENCES doesn't include audio media type or sample depth
         sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="L24",
                                    channels=CONFIG.SDP_PREFERENCES["audio_channels"],
-                                   sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"])
+                                   sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"],
+                                   max_packet_time=CONFIG.SDP_PREFERENCES["audio_max_packet_time"],
+                                   packet_time=CONFIG.SDP_PREFERENCES["audio_packet_time"])								   
     elif stream_type == "data":
         sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip)
     elif stream_type == "mux":
@@ -577,7 +584,12 @@ def transport_file(version, resource, resource_id):
                                        width=CONFIG.SDP_PREFERENCES["video_width"],
                                        height=CONFIG.SDP_PREFERENCES["video_height"],
                                        interlace=interlace,
-                                       exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"])
+                                       exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"],
+                                       depth=CONFIG.SDP_PREFERENCES["video_depth"],
+                                       sampling=CONFIG.SDP_PREFERENCES["video_sampling"],
+                                       colorimetry=CONFIG.SDP_PREFERENCES["video_colorimetry"],
+                                       transfer_characteristic=CONFIG.SDP_PREFERENCES["video_transfer_characteristic"],
+                                       type_parameter=CONFIG.SDP_PREFERENCES["video_type_parameter"])									   
 
             response = make_response(sdp_file, 200)
             response.headers["Content-Type"] = "application/sdp"

--- a/nmostesting/suites/IS0502Test.py
+++ b/nmostesting/suites/IS0502Test.py
@@ -1120,33 +1120,54 @@ class IS0502Test(GenericTest):
                                                width=CONFIG.SDP_PREFERENCES["video_width"],
                                                height=CONFIG.SDP_PREFERENCES["video_height"],
                                                interlace=interlace,
-                                               exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"])
+                                               exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"],
+                                               depth=CONFIG.SDP_PREFERENCES["video_depth"],
+                                               sampling=CONFIG.SDP_PREFERENCES["video_sampling"],
+                                               colorimetry=CONFIG.SDP_PREFERENCES["video_colorimetry"],
+                                               transfer_characteristic=CONFIG.SDP_PREFERENCES["video_transfer_characteristic"],
+                                               type_parameter=CONFIG.SDP_PREFERENCES["video_type_parameter"])
                 elif "video/vc2" in receiver["caps"]["media_types"]:
                     sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="vc2",
                                                width=CONFIG.SDP_PREFERENCES["video_width"],
                                                height=CONFIG.SDP_PREFERENCES["video_height"],
                                                interlace=interlace,
-                                               exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"])
+                                               exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"],
+                                               depth=CONFIG.SDP_PREFERENCES["video_depth"],
+                                               sampling=CONFIG.SDP_PREFERENCES["video_sampling"],
+                                               colorimetry=CONFIG.SDP_PREFERENCES["video_colorimetry"],
+                                               transfer_characteristic=CONFIG.SDP_PREFERENCES["video_transfer_characteristic"],
+                                               type_parameter=CONFIG.SDP_PREFERENCES["video_type_parameter"])
                 elif "video/H264" in receiver["caps"]["media_types"]:
                     sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="H264",
                                                width=CONFIG.SDP_PREFERENCES["video_width"],
                                                height=CONFIG.SDP_PREFERENCES["video_height"],
                                                interlace=interlace,
-                                               exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"])
+                                               exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"],
+                                               depth=CONFIG.SDP_PREFERENCES["video_depth"],
+                                               sampling=CONFIG.SDP_PREFERENCES["video_sampling"],
+                                               colorimetry=CONFIG.SDP_PREFERENCES["video_colorimetry"],
+                                               transfer_characteristic=CONFIG.SDP_PREFERENCES["video_transfer_characteristic"],
+                                               type_parameter=CONFIG.SDP_PREFERENCES["video_type_parameter"])
             elif receiver["format"] == "urn:x-nmos:format:audio":
                 template = Template(audio_sdp, keep_trailing_newline=True)
                 if "audio/L16" in receiver["caps"]["media_types"]:
                     sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="L16",
                                                channels=CONFIG.SDP_PREFERENCES["audio_channels"],
-                                               sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"])
+                                               sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"],
+                                               max_packet_time=CONFIG.SDP_PREFERENCES["audio_max_packet_time"],
+                                               packet_time=CONFIG.SDP_PREFERENCES["audio_packet_time"])
                 elif "audio/L24" in receiver["caps"]["media_types"]:
                     sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="L24",
                                                channels=CONFIG.SDP_PREFERENCES["audio_channels"],
-                                               sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"])
+                                               sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"],
+                                               max_packet_time=CONFIG.SDP_PREFERENCES["audio_max_packet_time"],
+                                               packet_time=CONFIG.SDP_PREFERENCES["audio_packet_time"])
                 elif "audio/L32" in receiver["caps"]["media_types"]:
                     sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="L32",
                                                channels=CONFIG.SDP_PREFERENCES["audio_channels"],
-                                               sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"])
+                                               sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"],
+                                               max_packet_time=CONFIG.SDP_PREFERENCES["audio_max_packet_time"],
+                                               packet_time=CONFIG.SDP_PREFERENCES["audio_packet_time"])
             elif receiver["format"] == "urn:x-nmos:format:data":
                 template = Template(data_sdp, keep_trailing_newline=True)
                 if "video/smpte291" in receiver["caps"]["media_types"]:

--- a/nmostesting/suites/IS0502Test.py
+++ b/nmostesting/suites/IS0502Test.py
@@ -1114,60 +1114,66 @@ class IS0502Test(GenericTest):
                 interlace = ""
                 if CONFIG.SDP_PREFERENCES["video_interlace"] is True:
                     interlace = "interlace; "
-                # TODO: The ST.2110-22 media types don't need some of the fmtp params in the template file
+                # TODO: The media types besides video/raw likely need some different fmtp params
                 if "video/raw" in receiver["caps"]["media_types"]:
-                    sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="raw",
-                                               width=CONFIG.SDP_PREFERENCES["video_width"],
-                                               height=CONFIG.SDP_PREFERENCES["video_height"],
-                                               interlace=interlace,
-                                               exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"],
-                                               depth=CONFIG.SDP_PREFERENCES["video_depth"],
-                                               sampling=CONFIG.SDP_PREFERENCES["video_sampling"],
-                                               colorimetry=CONFIG.SDP_PREFERENCES["video_colorimetry"],
-                                               transfer_characteristic=CONFIG.SDP_PREFERENCES["video_transfer_characteristic"],
-                                               type_parameter=CONFIG.SDP_PREFERENCES["video_type_parameter"])
+                    sdp_file = template.render(
+                        dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="raw",
+                        width=CONFIG.SDP_PREFERENCES["video_width"],
+                        height=CONFIG.SDP_PREFERENCES["video_height"],
+                        interlace=interlace,
+                        exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"],
+                        depth=CONFIG.SDP_PREFERENCES["video_depth"],
+                        sampling=CONFIG.SDP_PREFERENCES["video_sampling"],
+                        colorimetry=CONFIG.SDP_PREFERENCES["video_colorimetry"],
+                        transfer_characteristic=CONFIG.SDP_PREFERENCES["video_transfer_characteristic"],
+                        type_parameter=CONFIG.SDP_PREFERENCES["video_type_parameter"])
                 elif "video/vc2" in receiver["caps"]["media_types"]:
-                    sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="vc2",
-                                               width=CONFIG.SDP_PREFERENCES["video_width"],
-                                               height=CONFIG.SDP_PREFERENCES["video_height"],
-                                               interlace=interlace,
-                                               exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"],
-                                               depth=CONFIG.SDP_PREFERENCES["video_depth"],
-                                               sampling=CONFIG.SDP_PREFERENCES["video_sampling"],
-                                               colorimetry=CONFIG.SDP_PREFERENCES["video_colorimetry"],
-                                               transfer_characteristic=CONFIG.SDP_PREFERENCES["video_transfer_characteristic"],
-                                               type_parameter=CONFIG.SDP_PREFERENCES["video_type_parameter"])
+                    sdp_file = template.render(
+                        dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="vc2",
+                        width=CONFIG.SDP_PREFERENCES["video_width"],
+                        height=CONFIG.SDP_PREFERENCES["video_height"],
+                        interlace=interlace,
+                        exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"],
+                        depth=CONFIG.SDP_PREFERENCES["video_depth"],
+                        sampling=CONFIG.SDP_PREFERENCES["video_sampling"],
+                        colorimetry=CONFIG.SDP_PREFERENCES["video_colorimetry"],
+                        transfer_characteristic=CONFIG.SDP_PREFERENCES["video_transfer_characteristic"],
+                        type_parameter=CONFIG.SDP_PREFERENCES["video_type_parameter"])
                 elif "video/H264" in receiver["caps"]["media_types"]:
-                    sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="H264",
-                                               width=CONFIG.SDP_PREFERENCES["video_width"],
-                                               height=CONFIG.SDP_PREFERENCES["video_height"],
-                                               interlace=interlace,
-                                               exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"],
-                                               depth=CONFIG.SDP_PREFERENCES["video_depth"],
-                                               sampling=CONFIG.SDP_PREFERENCES["video_sampling"],
-                                               colorimetry=CONFIG.SDP_PREFERENCES["video_colorimetry"],
-                                               transfer_characteristic=CONFIG.SDP_PREFERENCES["video_transfer_characteristic"],
-                                               type_parameter=CONFIG.SDP_PREFERENCES["video_type_parameter"])
+                    sdp_file = template.render(
+                        dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="H264",
+                        width=CONFIG.SDP_PREFERENCES["video_width"],
+                        height=CONFIG.SDP_PREFERENCES["video_height"],
+                        interlace=interlace,
+                        exactframerate=CONFIG.SDP_PREFERENCES["video_exactframerate"],
+                        depth=CONFIG.SDP_PREFERENCES["video_depth"],
+                        sampling=CONFIG.SDP_PREFERENCES["video_sampling"],
+                        colorimetry=CONFIG.SDP_PREFERENCES["video_colorimetry"],
+                        transfer_characteristic=CONFIG.SDP_PREFERENCES["video_transfer_characteristic"],
+                        type_parameter=CONFIG.SDP_PREFERENCES["video_type_parameter"])
             elif receiver["format"] == "urn:x-nmos:format:audio":
                 template = Template(audio_sdp, keep_trailing_newline=True)
                 if "audio/L16" in receiver["caps"]["media_types"]:
-                    sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="L16",
-                                               channels=CONFIG.SDP_PREFERENCES["audio_channels"],
-                                               sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"],
-                                               max_packet_time=CONFIG.SDP_PREFERENCES["audio_max_packet_time"],
-                                               packet_time=CONFIG.SDP_PREFERENCES["audio_packet_time"])
+                    sdp_file = template.render(
+                        dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="L16",
+                        channels=CONFIG.SDP_PREFERENCES["audio_channels"],
+                        sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"],
+                        max_packet_time=CONFIG.SDP_PREFERENCES["audio_max_packet_time"],
+                        packet_time=CONFIG.SDP_PREFERENCES["audio_packet_time"])
                 elif "audio/L24" in receiver["caps"]["media_types"]:
-                    sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="L24",
-                                               channels=CONFIG.SDP_PREFERENCES["audio_channels"],
-                                               sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"],
-                                               max_packet_time=CONFIG.SDP_PREFERENCES["audio_max_packet_time"],
-                                               packet_time=CONFIG.SDP_PREFERENCES["audio_packet_time"])
+                    sdp_file = template.render(
+                        dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="L24",
+                        channels=CONFIG.SDP_PREFERENCES["audio_channels"],
+                        sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"],
+                        max_packet_time=CONFIG.SDP_PREFERENCES["audio_max_packet_time"],
+                        packet_time=CONFIG.SDP_PREFERENCES["audio_packet_time"])
                 elif "audio/L32" in receiver["caps"]["media_types"]:
-                    sdp_file = template.render(dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="L32",
-                                               channels=CONFIG.SDP_PREFERENCES["audio_channels"],
-                                               sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"],
-                                               max_packet_time=CONFIG.SDP_PREFERENCES["audio_max_packet_time"],
-                                               packet_time=CONFIG.SDP_PREFERENCES["audio_packet_time"])
+                    sdp_file = template.render(
+                        dst_ip=dst_ip, dst_port=dst_port, src_ip=src_ip, media_type="L32",
+                        channels=CONFIG.SDP_PREFERENCES["audio_channels"],
+                        sample_rate=CONFIG.SDP_PREFERENCES["audio_sample_rate"],
+                        max_packet_time=CONFIG.SDP_PREFERENCES["audio_max_packet_time"],
+                        packet_time=CONFIG.SDP_PREFERENCES["audio_packet_time"])
             elif receiver["format"] == "urn:x-nmos:format:data":
                 template = Template(data_sdp, keep_trailing_newline=True)
                 if "video/smpte291" in receiver["caps"]["media_types"]:

--- a/test_data/IS0401/audio.sdp
+++ b/test_data/IS0401/audio.sdp
@@ -8,5 +8,5 @@ a=source-filter: incl IN IP4 {{ dst_ip }} {{ src_ip }}
 a=ts-refclk:ptp=IEEE1588-2008:EC-46-70-FF-FE-00-CE-DE:0
 a=rtpmap:102 {{ media_type }}/{{ sample_rate }}/{{ channels }}
 a=mediaclk:direct=0
-a=ptime:1
-a=maxptime:1
+a=ptime:{{ packet_time }}
+a=maxptime:{{ max_packet_time }}

--- a/test_data/IS0401/video.sdp
+++ b/test_data/IS0401/video.sdp
@@ -7,5 +7,5 @@ c=IN IP4 {{ dst_ip }}/32
 a=source-filter: incl IN IP4 {{ dst_ip }} {{ src_ip }}
 a=ts-refclk:ptp=IEEE1588-2008:EC-46-70-FF-FE-00-CE-DE:0
 a=rtpmap:97 {{ media_type }}/90000
-a=fmtp:97 sampling=YCbCr-4:2:2; width={{ width }}; height={{ height }}; depth=10; {{ interlace }}SSN=ST2110-20:2017; colorimetry=BT709; PM=2110GPM; TP=2110TPW; TCS=SDR; exactframerate={{ exactframerate }}
+a=fmtp:97 sampling={{ sampling }}; width={{ width }}; height={{ height }}; depth={{ depth }}; {{ interlace }}SSN=ST2110-20:2017; colorimetry={{ colorimetry }}; PM=2110GPM; TP={{ type_parameter }}; TCS={{ transfer_characteristic }}; exactframerate={{ exactframerate }}
 a=mediaclk:direct=0 rate=90000

--- a/test_data/IS0502/audio.sdp
+++ b/test_data/IS0502/audio.sdp
@@ -8,5 +8,5 @@ a=source-filter: incl IN IP4 {{ dst_ip }} {{ src_ip }}
 a=ts-refclk:ptp=IEEE1588-2008:EC-46-70-FF-FE-00-CE-DE:0
 a=rtpmap:102 {{ media_type }}/{{ sample_rate }}/{{ channels }}
 a=mediaclk:direct=0
-a=ptime:1
-a=maxptime:1
+a=ptime:{{ packet_time }}
+a=maxptime:{{ max_packet_time }}

--- a/test_data/IS0502/video.sdp
+++ b/test_data/IS0502/video.sdp
@@ -7,5 +7,5 @@ c=IN IP4 {{ dst_ip }}/32
 a=source-filter: incl IN IP4 {{ dst_ip }} {{ src_ip }}
 a=ts-refclk:ptp=IEEE1588-2008:EC-46-70-FF-FE-00-CE-DE:0
 a=rtpmap:97 {{ media_type }}/90000
-a=fmtp:97 sampling=YCbCr-4:2:2; width={{ width }}; height={{ height }}; depth=10; {{ interlace }}SSN=ST2110-20:2017; colorimetry=BT709; PM=2110GPM; TP=2110TPW; TCS=SDR; exactframerate={{ exactframerate }}
+a=fmtp:97 sampling={{ sampling }}; width={{ width }}; height={{ height }}; depth={{ depth }}; {{ interlace }}SSN=ST2110-20:2017; colorimetry={{ colorimetry }}; PM=2110GPM; TP={{ type_parameter }}; TCS={{ transfer_characteristic }}; exactframerate={{ exactframerate }}
 a=mediaclk:direct=0 rate=90000


### PR DESCRIPTION
…erent values used by the receiver cap's constraint_sets

The receiver can define the different values in its receiver cap's constraint_sets than the test-suite's spd template data files. Without this fix, those receivers who specified their extra values in their constraint_sets  will fail to make the IS-05 connection due to constraint mismatch.

The following 2 test cases are affected:
IS-04-01, test_13
IS-05-02, test_18