### PR TITLE
[IS-08] Selector fix

### DIFF
--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -417,16 +417,18 @@ def index_page():
             try:
                 if test in TEST_DEFINITIONS:
                     test_def = TEST_DEFINITIONS[test]
+                    # selectors must be explicitly enabled on the test suite
+                    selector = "selector" in test_def and test_def["selector"]
                     endpoints = []
                     for index, spec in enumerate(test_def["specs"]):
                         # "disable_fields" is optional, none are disabled by default
                         disable_fields = spec["disable_fields"] if "disable_fields" in spec else []
                         endpoint = {}
                         for field in ["host", "port", "version", "selector"]:
-                            if field not in disable_fields:
-                                endpoint[field] = request.form.get("endpoints-{}-{}".format(index, field), None)
-                            else:
+                            if field in disable_fields or (field == "selector" and not selector):
                                 endpoint[field] = None
+                            else:
+                                endpoint[field] = request.form.get("endpoints-{}-{}".format(index, field), None)
                         endpoints.append(endpoint)
 
                     test_selection = request.form.getlist("test_selection")

--- a/nmostesting/templates/result.html
+++ b/nmostesting/templates/result.html
@@ -49,6 +49,7 @@
                     {{ endpoint.host }}
                     {{ endpoint.port }}
                     {{ endpoint.version }}
+                    {{ endpoint.selector }}
                 {% endfor %}
                 <input type="checkbox" unchecked id="auto_all" name="test_selection" value="auto"/>
             </div>


### PR DESCRIPTION
Should resolve #702.

We could do better with more refactoring. Right now, the caching of spec/endpoint data in the form when moving between different test suites is a little awkward since it's done by index not by API, e.g. move from IS-08-01 (which just needs the Channel Mapping API) to IS-08-02 (which needs Node API and Channel Mapping API, in that order) and the cached form content for the Channel Mapping API is used to populate the Node API fields.