### PR TITLE
Controller Test patches for improved Controller compatibility

### DIFF
--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -303,9 +303,10 @@ class ControllerTest(GenericTest):
             time.sleep(0.1)
             if receiver["registered"]:
                 self._register_receiver(receiver)
-                # Add receiver to mock node
-                receiver_json = self._create_receiver_json(receiver)
-                self.node.add_receiver(receiver_json)
+                if receiver["connectable"]:
+                    # Add receiver to mock node
+                    receiver_json = self._create_receiver_json(receiver)
+                    self.node.add_receiver(receiver_json)
 
     def load_resource_data(self):
         """Loads test data from files"""

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -303,8 +303,10 @@ class ControllerTest(GenericTest):
             time.sleep(0.1)
             if receiver["registered"]:
                 self._register_receiver(receiver)
+                # Add receiver to mock node
+                # Note: mock node is currently only a mock Connection API
+                # so only add 'connectable' receivers
                 if receiver["connectable"]:
-                    # Add receiver to mock node
                     receiver_json = self._create_receiver_json(receiver)
                     self.node.add_receiver(receiver_json)
 

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -90,6 +90,7 @@ class ControllerTest(GenericTest):
         self.extra_time = 2 * CONFIG.API_PROCESSING_TIMEOUT  # API processing time to add to test timeout
         self.test_data = self.load_resource_data()
         self.senders = []
+        self.sender_ip_addresses = {}
         self.receivers = []
         # receiver list containing: {'label': '', 'description': '', 'id': '',
         #   'registered': True/False, 'connectable': True/False, 'display_answer': ''}
@@ -255,7 +256,7 @@ class ControllerTest(GenericTest):
         """Populate registry and mock node with mock senders and receivers"""
         self.node.reset()  # Ensure previouly added senders and receivers are removed
         self.primary_registry.common.reset()  # Ensure any previouly registered senders and receivers are removed
-        sender_ip = 159
+        sender_ip_final_octet = 159
 
         # Register node
         self._register_node(self.node.id, "AMWA Test Suite Node", "AMWA Test Suite Node")
@@ -280,8 +281,10 @@ class ControllerTest(GenericTest):
                 self._register_sender(sender)
                 # Add sender to mock node
                 sender_json = self._create_sender_json(sender)
-                self.node.add_sender(sender_json, self.senders_ip_base + str(sender_ip))
-                sender_ip += 1
+                sender_ip_address = self.senders_ip_base + str(sender_ip_final_octet)
+                self.node.add_sender(sender_json, sender_ip_address)
+                self.sender_ip_addresses[sender["id"]] = sender_ip_address
+                sender_ip_final_octet += 1
 
         # self.receivers should be initialized in the set_up_tests() override of derived test
         # each mock receiver defined as: {'label': <unique label>, 'description': '',

--- a/nmostesting/mocks/Node.py
+++ b/nmostesting/mocks/Node.py
@@ -111,6 +111,9 @@ class Node(object):
             'activations': sender_update
         }
 
+    def delete_sender(self, sender_id):
+        self.senders.pop(sender_id)
+
     def add_receiver(self, receiver):
 
         staged_transport_params = [{

--- a/nmostesting/suites/IS0404Test.py
+++ b/nmostesting/suites/IS0404Test.py
@@ -251,6 +251,7 @@ class IS0404Test(ControllerTest):
             expected_answer = 'answer_' + str(offline_sender_index)
 
             self._delete_sender(test, self.senders[offline_sender_index])
+            self.node.delete_sender(self.senders[offline_sender_index]["id"])
 
             # Set the offline sender to registered false for future tests
             self.senders[offline_sender_index]['registered'] = False
@@ -295,6 +296,8 @@ class IS0404Test(ControllerTest):
 
             # Re-register sender
             self._register_sender(self.senders[offline_sender_index], codes=[200, 201])
+            sender_json = self._create_sender_json(self.senders[offline_sender_index])
+            self.node.add_sender(sender_json, self.sender_ip_addresses[sender_json["id"]])
             self.senders[offline_sender_index]['registered'] = True
 
             # Await/get testing façade response

--- a/nmostesting/suites/IS0503Test.py
+++ b/nmostesting/suites/IS0503Test.py
@@ -180,7 +180,8 @@ class IS0503Test(ControllerTest):
                     if not patch_requests[0]['data']['master_enable']:
                         return test.FAIL('Master_enable not set to True in PATCH request')
 
-                if 'sender_id' in patch_requests[0]['data'] and patch_requests[0]['data']['sender_id'] != sender['id']:
+                if 'sender_id' in patch_requests[0]['data'] and patch_requests[0]['data']['sender_id']\
+                        and patch_requests[0]['data']['sender_id'] != sender['id']:
                     return test.FAIL('Incorrect sender found in PATCH request')
 
                 if 'activation' not in patch_requests[0]['data']:
@@ -198,8 +199,12 @@ class IS0503Test(ControllerTest):
                 if not receiver_details['subscription']['active']:
                     return test.FAIL('Receiver does not have active subscription')
 
-                if receiver_details['subscription']['sender_id'] != sender['id']:
+                if 'sender_id' in receiver_details['subscription'] and receiver_details['subscription']['sender_id']\
+                        and receiver_details['subscription']['sender_id'] != sender['id']:
                     return test.FAIL('Receiver did not connect to correct sender')
+
+            if 'sender_id' not in patch_requests[0]['data'] or not patch_requests[0]['data']['sender_id']:
+                return test.WARNING('Sender id SHOULD be set in patch request')
 
             return test.PASS("Connection successfully established")
         except TestingFacadeException as e:

--- a/nmostesting/suites/IS0503Test.py
+++ b/nmostesting/suites/IS0503Test.py
@@ -166,7 +166,8 @@ class IS0503Test(ControllerTest):
             self._invoke_testing_facade(question, possible_answers, test_type="action", metadata=metadata)
 
             # Check the staged API endpoint received the correct PATCH request
-            patch_requests = [r for r in self.node.staged_requests if r['method'] == 'PATCH']
+            patch_requests = [r for r in self.node.staged_requests
+                              if r['method'] == 'PATCH' and r['resource'] == 'receivers']
             if len(patch_requests) < 1:
                 return test.FAIL('No PATCH request was received by the node')
             elif len(patch_requests) == 1:
@@ -263,7 +264,8 @@ class IS0503Test(ControllerTest):
             self._invoke_testing_facade(question, possible_answers, test_type="action", metadata=metadata)
 
             # Check the staged API endpoint received a PATCH request
-            patch_requests = [r for r in self.node.staged_requests if r['method'] == 'PATCH']
+            patch_requests = [r for r in self.node.staged_requests
+                              if r['method'] == 'PATCH' and r['resource'] == 'receivers']
             if len(patch_requests) < 1:
                 return test.FAIL('No PATCH request was received by the node')
             elif len(patch_requests) > 1:

--- a/nmostesting/suites/IS0503Test.py
+++ b/nmostesting/suites/IS0503Test.py
@@ -173,14 +173,14 @@ class IS0503Test(ControllerTest):
                 if patch_requests[0]['resource_id'] != receiver['id']:
                     return test.FAIL('Connection request sent to incorrect receiver')
 
-                if 'master_enable' not in patch_requests[0]['data'] or 'sender_id' not in patch_requests[0]['data']:
-                    return test.FAIL('Sender id or master enable not found in PATCH request')
+                if 'master_enable' not in patch_requests[0]['data']:
+                    return test.FAIL('Master enable not found in PATCH request')
                 else:
                     if not patch_requests[0]['data']['master_enable']:
                         return test.FAIL('Master_enable not set to True in PATCH request')
 
-                    if patch_requests[0]['data']['sender_id'] != sender['id']:
-                        return test.FAIL('Incorrect sender found in PATCH request')
+                if 'sender_id' in patch_requests[0]['data'] and patch_requests[0]['data']['sender_id'] != sender['id']:
+                    return test.FAIL('Incorrect sender found in PATCH request')
 
                 if 'activation' not in patch_requests[0]['data']:
                     return test.FAIL('No activation details in PATCH request')

--- a/nmostesting/suites/IS0503Test.py
+++ b/nmostesting/suites/IS0503Test.py
@@ -69,7 +69,9 @@ class IS0503Test(ControllerTest):
         """
         Send deactivate requests to all receivers
         """
-        for receiver in self.receivers:
+        connectable_receivers = [receiver for receiver in self.receivers if receiver["connectable"]]
+
+        for receiver in connectable_receivers:
             deactivate_json = {"master_enable": False, 'sender_id': None,
                                "activation": {"mode": "activate_immediate"}}
             self.node.patch_staged('receivers', receiver['id'], deactivate_json)


### PR DESCRIPTION
This pull request aims to improve controller compatibility:

- In the IS-04 Controller tests where a Sender is put offline/back online the Senders on the mock Node are now removed/added to be consistent with the mock Registry
- In the IS-05 Controller tests Receivers that do not have a connection API are no longer added to the mock Node (i.e. only connectable receivers appear on the mock Node)
- In the IS-05 Controller tests, a guard has been put in when checking for double patch requests so that Sender patches aren't confused with Receiver patches (i.e. when patching both the Sender and Receiver, it is now no longer interpreted as a double Receiver patch).
- If a `sender_id` has not being set in the Receiver patch requests this results in a warning, rather than a failure (in the current published specification setting the `sender_id` is a SHOULD not a MUST, but this will change in the near future).