### PR TITLE
Secure Controller Testing

### DIFF
--- a/docs/2.8. Usage - Testing Controllers.md
+++ b/docs/2.8. Usage - Testing Controllers.md
@@ -16,7 +16,7 @@ Select and launch the tests from the NMOS Testing tool, and follow the instructi
 
 ## Secure Controller Testing
 
-Secure testing should typically be done in a unicast DNS-SD environment, by setting DNS_SD_MODE to 'unicast' in UserConfig.py (see [Usage - Testing Unicast Discovery](2.1.%20Usage%20-%20Testing%20Unicast%20Discovery.md).
+Secure testing should typically be done in a unicast DNS-SD environment, by setting DNS_SD_MODE to 'unicast' in UserConfig.py (see [Usage - Testing Unicast Discovery](2.1.%20Usage%20-%20Testing%20Unicast%20Discovery.md)).
 
 Before running the Controller tests in secure mode, add entries to the hosts file of the host running the test suite, and the host running the Controller under test, pointing at the IP address of the host running the test suite.
 These entries should correspond to the DNS_DOMAIN and be of the form 'mocks.[DNS_DOMAIN]', which by default should be 'mocks.testsuite.nmos.tv'.

--- a/docs/2.8. Usage - Testing Controllers.md
+++ b/docs/2.8. Usage - Testing Controllers.md
@@ -16,7 +16,7 @@ Select and launch the tests from the NMOS Testing tool, and follow the instructi
 
 ## Secure Controller Testing
 
-Secure testing should typically be done in a unicast DNS-SD environment, by setting DNS_SD_MODE to 'unicast' in UserConfig.py (see [Usage - Testing Unicast Discovery](2.1%20Usage%20-%20Testing%20Unicast%20Discovery.md).
+Secure testing should typically be done in a unicast DNS-SD environment, by setting DNS_SD_MODE to 'unicast' in UserConfig.py (see [Usage - Testing Unicast Discovery](2.1.%20Usage%20-%20Testing%20Unicast%20Discovery.md).
 
 Before running the Controller tests in secure mode, add entries to the hosts file of the host running the test suite, and the host running the Controller under test, pointing at the IP address of the host running the test suite.
 These entries should correspond to the DNS_DOMAIN and be of the form 'mocks.[DNS_DOMAIN]', which by default should be 'mocks.testsuite.nmos.tv'.

--- a/docs/2.8. Usage - Testing Controllers.md
+++ b/docs/2.8. Usage - Testing Controllers.md
@@ -16,7 +16,10 @@ Select and launch the tests from the NMOS Testing tool, and follow the instructi
 
 ## Secure Controller Testing
 
-Before running the Controller tests in secure mode, add an entry to the hosts file for 'mocks.testsuite.nmos.tv' pointing at the IP address of the host running the test suite on the host running the test suite and the host running the Controller under test.
+Secure testing should typically be done in a unicast DNS-SD environment, by setting DNS_SD_MODE to 'unicast' in UserConfig.py (see [Usage - Testing Unicast Discovery](2.1%20Usage%20-%20Testing%20Unicast%20Discovery.md).
+
+Before running the Controller tests in secure mode, add entries to the hosts file of the host running the test suite, and the host running the Controller under test, pointing at the IP address of the host running the test suite.
+These entries should correspond to the DNS_DOMAIN and be of the form 'mocks.[DNS_DOMAIN]', which by default should be 'mocks.testsuite.nmos.tv'.
 
 More details on secure testing can be found in the [BCP-003-01 TLS section](2.2.%20Usage%20-%20Testing%20BCP-003-01%20TLS.md).
 

--- a/docs/2.8. Usage - Testing Controllers.md
+++ b/docs/2.8. Usage - Testing Controllers.md
@@ -19,7 +19,7 @@ Select and launch the tests from the NMOS Testing tool, and follow the instructi
 Secure testing should typically be done in a unicast DNS-SD environment, by setting DNS_SD_MODE to 'unicast' in UserConfig.py (see [Usage - Testing Unicast Discovery](2.1.%20Usage%20-%20Testing%20Unicast%20Discovery.md)).
 
 Before running the Controller tests in secure mode, add entries to the hosts file of the host running the test suite, and the host running the Controller under test, pointing at the IP address of the host running the test suite.
-These entries should correspond to the DNS_DOMAIN and be of the form 'mocks.[DNS_DOMAIN]', which by default should be 'mocks.testsuite.nmos.tv'.
+These entries should correspond to the DNS_DOMAIN and be of the form 'mocks.<DNS_DOMAIN>', which by default should be 'mocks.testsuite.nmos.tv'.
 
 More details on secure testing can be found in the [BCP-003-01 TLS section](2.2.%20Usage%20-%20Testing%20BCP-003-01%20TLS.md).
 

--- a/docs/2.8. Usage - Testing Controllers.md
+++ b/docs/2.8. Usage - Testing Controllers.md
@@ -20,7 +20,7 @@ Before running the Controller tests in secure mode, add an entry to the hosts fi
 
 More details on secure testing can be found in the [BCP-003-01 TLS section](2.2.%20Usage%20-%20Testing%20BCP-003-01%20TLS.md).
 
-### Known Issues
+## Known Issues
 
 * The "auto" test selection, although present, doesn't do anything presently as there is no RAML associated with the Controller tests.
 * The Mock Registry is currently open to registrations from any NMOS Node. Therefore NMOS Nodes on your network searching for a Registry are likely to register with the Mock Registry.

--- a/docs/2.8. Usage - Testing Controllers.md
+++ b/docs/2.8. Usage - Testing Controllers.md
@@ -14,6 +14,12 @@ In the NMOS Testing Tool select one of the 'Controller' test suites and configur
 
 Select and launch the tests from the NMOS Testing tool, and follow the instructions displayed on the Testing Façade.
 
+## Secure Controller Testing
+
+Before running the Controller tests in secure mode, add an entry to the hosts file for 'mocks.testsuite.nmos.tv' pointing at the IP address of the host running the test suite on the host running the test suite and the host running the Controller under test.
+
+More details on secure testing can be found in the [BCP-003-01 TLS section](2.2.%20Usage%20-%20Testing%20BCP-003-01%20TLS.md).
+
 ### Known Issues
 
 * The "auto" test selection, although present, doesn't do anything presently as there is no RAML associated with the Controller tests.

--- a/nmos-testing-facade.py
+++ b/nmos-testing-facade.py
@@ -56,18 +56,15 @@ def index():
             # POST to test suite to confirm answer available
             valid, response = do_request('POST', form['response_url'], json=answer_json)
 
-            if not valid:
-                return response
+            return response.reason, response.status_code
         else:
             if 'all_data' in form:
                 # Form was submitted but no answer(s) chosen
                 valid, response = do_request('POST', form['response_url'], json=answer_json)
 
-                if not valid:
-                    return response
-            return "No answer submitted", 400
+                return response.reason, response.status_code
 
-        return 'Answer set'
+        return 'Unexpected form data', 400
 
 
 @app.route('/x-nmos/testquestion/<version>', methods=['POST'], strict_slashes=False)

--- a/nmos-testing-facade.py
+++ b/nmos-testing-facade.py
@@ -47,22 +47,17 @@ def index():
         json_data = json.loads(form['all_data'])
         answer_json = {'question_id': json_data['question_id'], 'answer_response': None}
 
-        if 'answer' in form or 'Next' in form:
+        if 'answer' in form:
             if json_data['test_type'] == 'multi_choice':
                 answer_json['answer_response'] = request.form.getlist('answer')
             elif json_data['test_type'] == 'single_choice':
                 answer_json['answer_response'] = form['answer']
 
+        if 'answer' in form or 'Next' in form or 'all_data' in form:
             # POST to test suite to confirm answer available
             valid, response = do_request('POST', form['response_url'], json=answer_json)
 
             return response.reason, response.status_code
-        else:
-            if 'all_data' in form:
-                # Form was submitted but no answer(s) chosen
-                valid, response = do_request('POST', form['response_url'], json=answer_json)
-
-                return response.reason, response.status_code
 
         return 'Unexpected form data', 400
 

--- a/nmos-testing-facade.py
+++ b/nmos-testing-facade.py
@@ -55,10 +55,16 @@ def index():
 
             # POST to test suite to confirm answer available
             valid, response = do_request('POST', form['response_url'], json=answer_json)
+
+            if not valid:
+                return response
         else:
             if 'all_data' in form:
                 # Form was submitted but no answer(s) chosen
                 valid, response = do_request('POST', form['response_url'], json=answer_json)
+
+                if not valid:
+                    return response
             return "No answer submitted", 400
 
         return 'Answer set'

--- a/nmostesting/Config.py
+++ b/nmostesting/Config.py
@@ -119,6 +119,10 @@ AUTH_TOKEN = None
 # This must match the domain name used for certificates in HTTPS mode
 DNS_DOMAIN = "testsuite.nmos.tv"
 
+# The host name of the mocks used by the Controller tests when they are run securely. This should be consistent
+# with the hosts entries in the host running the test suite and the host running the Controller under test.
+MOCKS_HOSTNAME = "mocks.testsuite.nmos.tv"
+
 # The testing tool uses multiple ports to run mock services. This sets the lowest of these, which also runs the GUI
 # Note that changing this from the default of 5000 also requires changes to supporting files such as
 # test_data/BCP00301/ca/intermediate/openssl.cnf and any generated certificates.

--- a/nmostesting/Config.py
+++ b/nmostesting/Config.py
@@ -119,10 +119,6 @@ AUTH_TOKEN = None
 # This must match the domain name used for certificates in HTTPS mode
 DNS_DOMAIN = "testsuite.nmos.tv"
 
-# The host name of the mocks used by the Controller tests when they are run securely. This should be consistent
-# with the hosts entries in the host running the test suite and the host running the Controller under test.
-MOCKS_HOSTNAME = "mocks.testsuite.nmos.tv"
-
 # The testing tool uses multiple ports to run mock services. This sets the lowest of these, which also runs the GUI
 # Note that changing this from the default of 5000 also requires changes to supporting files such as
 # test_data/BCP00301/ca/intermediate/openssl.cnf and any generated certificates.

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -81,7 +81,7 @@ class ControllerTest(GenericTest):
     def __init__(self, apis, registries, node, dns_server, disable_auto=True):
         # Remove the spec_path as there are no corresponding GitHub repos for Controller Tests
         apis[CONTROLLER_TEST_API_KEY].pop("spec_path", None)
-        if apis[CONTROLLER_TEST_API_KEY]["base_url"].startswith("https"):
+        if CONFIG.ENABLE_HTTPS:
             # Comms with Testing Facade are http only
             apis[CONTROLLER_TEST_API_KEY]["base_url"] \
                 = apis[CONTROLLER_TEST_API_KEY]["base_url"].replace("https", "http")

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -38,6 +38,8 @@ CONN_API_KEY = "connection"
 
 CALLBACK_ENDPOINT = "/x-nmos/testanswer/<version>"
 
+MOCKS_HOSTNAME = "mocks.testsuite.nmos.tv"
+
 # asyncio queue for passing Testing Façade answer responses back to tests
 _event_loop = asyncio.new_event_loop()
 asyncio.set_event_loop(_event_loop)
@@ -105,12 +107,8 @@ class ControllerTest(GenericTest):
             if CONN_API_KEY in apis and "version" in self.apis[CONN_API_KEY] else "v1.1"
         self.qa_api_version = self.apis[CONTROLLER_TEST_API_KEY]["version"] \
             if CONTROLLER_TEST_API_KEY in apis and "version" in self.apis[CONTROLLER_TEST_API_KEY] else "v1.0"
-        if CONFIG.ENABLE_HTTPS:
-            self.answer_uri = "https://mocks.testsuite.nmos.tv:5000" + \
-                CALLBACK_ENDPOINT.replace('<version>', self.qa_api_version)
-        else:
-            self.answer_uri = "http://" + get_default_ip() + ":5000" + \
-                CALLBACK_ENDPOINT.replace('<version>', self.qa_api_version)
+        self.answer_uri = "http://" + get_default_ip() + ":" + str(CONFIG.PORT_BASE) + \
+            CALLBACK_ENDPOINT.replace('<version>', self.qa_api_version)
 
     def set_up_tests(self):
         if self.dns_server:
@@ -126,9 +124,9 @@ class ControllerTest(GenericTest):
         self.primary_registry.reset()
         self.primary_registry.enable()
         if CONFIG.ENABLE_HTTPS:
-            self.mock_registry_base_url = 'https://mocks.testsuite.nmos.tv:' + \
+            self.mock_registry_base_url = 'https://' + MOCKS_HOSTNAME + ':' + \
                 str(self.primary_registry.get_data().port) + '/'
-            self.mock_node_base_url = 'https://mocks.testsuite.nmos.tv:' + str(self.node.port) + '/'
+            self.mock_node_base_url = 'https://' + MOCKS_HOSTNAME + ':' + str(self.node.port) + '/'
         else:
             self.mock_registry_base_url = 'http://' + get_default_ip() + ':' + \
                 str(self.primary_registry.get_data().port) + '/'

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -79,6 +79,10 @@ class ControllerTest(GenericTest):
     def __init__(self, apis, registries, node, dns_server, disable_auto=True):
         # Remove the spec_path as there are no corresponding GitHib repos for Controller Tests
         apis[CONTROLLER_TEST_API_KEY].pop("spec_path", None)
+        if apis[CONTROLLER_TEST_API_KEY]["base_url"].startswith("https"):
+            # Comms with Testing Facade are http only
+            apis[CONTROLLER_TEST_API_KEY]["base_url"] = apis[CONTROLLER_TEST_API_KEY]["base_url"].replace("https", "http")
+            apis[CONTROLLER_TEST_API_KEY]["url"] = apis[CONTROLLER_TEST_API_KEY]["url"].replace("https", "http")
         GenericTest.__init__(self, apis, disable_auto=disable_auto)
         self.authorization = False
         self.primary_registry = registries[1]

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -83,7 +83,8 @@ class ControllerTest(GenericTest):
         apis[CONTROLLER_TEST_API_KEY].pop("spec_path", None)
         if apis[CONTROLLER_TEST_API_KEY]["base_url"].startswith("https"):
             # Comms with Testing Facade are http only
-            apis[CONTROLLER_TEST_API_KEY]["base_url"] = apis[CONTROLLER_TEST_API_KEY]["base_url"].replace("https", "http")
+            apis[CONTROLLER_TEST_API_KEY]["base_url"] \
+                = apis[CONTROLLER_TEST_API_KEY]["base_url"].replace("https", "http")
             apis[CONTROLLER_TEST_API_KEY]["url"] = apis[CONTROLLER_TEST_API_KEY]["url"].replace("https", "http")
         GenericTest.__init__(self, apis, disable_auto=disable_auto)
         self.authorization = False

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -112,6 +112,8 @@ class ControllerTest(GenericTest):
             CALLBACK_ENDPOINT.replace('<version>', self.qa_api_version)
 
     def set_up_tests(self):
+        test = Test("Test setup", "set_up_tests")
+
         if self.dns_server:
             self.dns_server.load_zone(self.apis[QUERY_API_KEY]["version"], self.protocol, self.authorization,
                                       "test_data/controller/dns_records.zone", CONFIG.PORT_BASE+100)
@@ -134,7 +136,7 @@ class ControllerTest(GenericTest):
             self.mock_node_base_url = 'http://' + get_default_ip() + ':' + str(self.node.port) + '/'
 
         # Populate mock registry with senders and receivers and store the results
-        self._populate_registry()
+        self._populate_registry(test)
 
         # Set up mock node
         self.node.registry_url = self.mock_registry_base_url
@@ -264,14 +266,14 @@ class ControllerTest(GenericTest):
         """ Used to format answers based on device metadata """
         return label + ' (' + description + ', ' + id + ')'
 
-    def _populate_registry(self):
+    def _populate_registry(self, test):
         """Populate registry and mock node with mock senders and receivers"""
         self.node.reset()  # Ensure previouly added senders and receivers are removed
         self.primary_registry.common.reset()  # Ensure any previouly registered senders and receivers are removed
         sender_ip_final_octet = 159
 
         # Register node
-        self._register_node(self.node.id, "AMWA Test Suite Node", "AMWA Test Suite Node")
+        self._register_node(test, self.node.id, "AMWA Test Suite Node", "AMWA Test Suite Node")
 
         # self.senders should be initialized in the set_up_tests() override of derived test
         # each mock sender defined as: {'label': <unique label>, 'description': '',
@@ -290,7 +292,7 @@ class ControllerTest(GenericTest):
             # Version number is used by pagination in lieu of creation or update time
             time.sleep(0.1)
             if sender["registered"]:
-                self._register_sender(sender)
+                self._register_sender(test, sender)
                 # Add sender to mock node
                 sender_json = self._create_sender_json(sender)
                 sender_ip_address = self.senders_ip_base + str(sender_ip_final_octet)
@@ -314,7 +316,7 @@ class ControllerTest(GenericTest):
             # Version number is used by pagination in lieu of creation or update time
             time.sleep(0.1)
             if receiver["registered"]:
-                self._register_receiver(receiver)
+                self._register_receiver(test, receiver)
                 # Add receiver to mock node
                 # Note: mock node is currently only a mock Connection API
                 # so only add 'connectable' receivers
@@ -380,17 +382,16 @@ class ControllerTest(GenericTest):
 
         return location, timestamp
 
-    def _register_node(self, node_id, label, description):
+    def _register_node(self, test, node_id, label, description):
         """
         Perform POST requests on the Registration API to create node registration
-        Assume that Node has already been registered
         """
         node_data = deepcopy(self.test_data["node"])
         node_data["id"] = node_id
         node_data["label"] = label
         node_data["description"] = description
         node_data["version"] = NMOSUtils.get_TAI_time()
-        self.post_resource(self, "node", node_data, codes=[201])
+        self.post_resource(test, "node", node_data, codes=[201])
 
     def _create_sender_json(self, sender):
         sender_data = deepcopy(self.test_data["sender"])
@@ -404,7 +405,7 @@ class ControllerTest(GenericTest):
 
         return sender_data
 
-    def _register_sender(self, sender, codes=[201], fail=Test.FAIL):
+    def _register_sender(self, test, sender, codes=[201], fail=Test.FAIL):
         """
         Perform POST requests on the Registration API to create sender registration
         Assume that Node has already been registered
@@ -424,7 +425,7 @@ class ControllerTest(GenericTest):
         device_data["senders"] = [sender["id"]]
         device_data["receivers"] = []
         device_data["version"] = sender["version"]
-        self.post_resource(self, "device", device_data, codes=codes, fail=fail)
+        self.post_resource(test, "device", device_data, codes=codes, fail=fail)
 
         # Register source
         source_data = deepcopy(self.test_data["source"])
@@ -433,7 +434,7 @@ class ControllerTest(GenericTest):
         source_data["description"] = "AMWA Test Source"
         source_data["device_id"] = sender["device_id"]
         source_data["version"] = sender["version"]
-        self.post_resource(self, "source", source_data, codes=codes, fail=fail)
+        self.post_resource(test, "source", source_data, codes=codes, fail=fail)
 
         # Register flow
         flow_data = deepcopy(self.test_data["flow"])
@@ -443,11 +444,11 @@ class ControllerTest(GenericTest):
         flow_data["device_id"] = sender["device_id"]
         flow_data["source_id"] = sender["source_id"]
         flow_data["version"] = sender["version"]
-        self.post_resource(self, "flow", flow_data, codes=codes, fail=fail)
+        self.post_resource(test, "flow", flow_data, codes=codes, fail=fail)
 
         # Register sender
         sender_data = self._create_sender_json(sender)
-        self.post_resource(self, "sender", sender_data, codes=codes, fail=fail)
+        self.post_resource(test, "sender", sender_data, codes=codes, fail=fail)
 
     def _delete_sender(self, test, sender):
         del_url = self.mock_registry_base_url + 'x-nmos/registration/v1.3/resource/senders/' + sender['id']
@@ -455,7 +456,7 @@ class ControllerTest(GenericTest):
         valid, r = self.do_request("DELETE", del_url)
         if not valid:
             # Hmm - do we need these exceptions as the registry is our own mock registry?
-            raise NMOSTestException(test.FAIL(test, "Registration API returned an unexpected response: {}".format(r)))
+            raise NMOSTestException(test.FAIL("Registration API returned an unexpected response: {}".format(r)))
 
     def _create_receiver_json(self, receiver):
         # Register receiver
@@ -468,7 +469,7 @@ class ControllerTest(GenericTest):
 
         return receiver_data
 
-    def _register_receiver(self, receiver, codes=[201], fail=Test.FAIL):
+    def _register_receiver(self, test, receiver, codes=[201], fail=Test.FAIL):
         """
         Perform POST requests on the Registration API to create receiver registration
         Assume that Node has already been registered
@@ -492,12 +493,12 @@ class ControllerTest(GenericTest):
         device_data["version"] = receiver["version"]
         device_data["senders"] = []
         device_data["receivers"] = [receiver["id"]]
-        self.post_resource(self, "device", device_data, codes=codes, fail=fail)
+        self.post_resource(test, "device", device_data, codes=codes, fail=fail)
 
         # Register receiver
         receiver_data = self._create_receiver_json(receiver)
 
-        self.post_resource(self, "receiver", receiver_data, codes=codes, fail=fail)
+        self.post_resource(test, "receiver", receiver_data, codes=codes, fail=fail)
 
     def _delete_receiver(self, test, receiver):
 
@@ -506,14 +507,14 @@ class ControllerTest(GenericTest):
         valid, r = self.do_request("DELETE", del_url)
         if not valid:
             # Hmm - do we need these exceptions as the registry is our own mock registry?
-            raise NMOSTestException(test.FAIL(test, "Registration API returned an unexpected response: {}".format(r)))
+            raise NMOSTestException(test.FAIL("Registration API returned an unexpected response: {}".format(r)))
 
         del_url = self.mock_registry_base_url + 'x-nmos/registration/v1.3/resource/devices/' + receiver['device_id']
 
         valid, r = self.do_request("DELETE", del_url)
         if not valid:
             # Hmm - do we need these exceptions as the registry is our own mock registry?
-            raise NMOSTestException(test.FAIL(test, "Registration API returned an unexpected response: {}".format(r)))
+            raise NMOSTestException(test.FAIL("Registration API returned an unexpected response: {}".format(r)))
 
     def pre_tests_message(self):
         """

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -26,7 +26,7 @@ from threading import Event
 
 from .GenericTest import GenericTest, NMOSTestException
 from . import Config as CONFIG
-from .TestHelper import get_default_ip
+from .TestHelper import get_default_ip, get_mocks_hostname
 from .TestResult import Test
 from .NMOSUtils import NMOSUtils
 
@@ -37,8 +37,6 @@ QUERY_API_KEY = "query"
 CONN_API_KEY = "connection"
 
 CALLBACK_ENDPOINT = "/x-nmos/testanswer/<version>"
-
-MOCKS_HOSTNAME = "mocks." + CONFIG.DNS_DOMAIN if CONFIG.DNS_SD_MODE == "unicast" else "nmos-mocks.local"
 
 # asyncio queue for passing Testing Façade answer responses back to tests
 _event_loop = asyncio.new_event_loop()
@@ -127,7 +125,7 @@ class ControllerTest(GenericTest):
         self.primary_registry.reset()
         self.primary_registry.enable()
 
-        host = MOCKS_HOSTNAME if CONFIG.ENABLE_HTTPS else get_default_ip()
+        host = get_mocks_hostname() if CONFIG.ENABLE_HTTPS else get_default_ip()
         self.mock_registry_base_url = self.protocol + '://' + host + ':'\
             + str(self.primary_registry.get_data().port) + '/'
         self.mock_node_base_url = self.protocol + '://' + host + ':' + str(self.node.port) + '/'

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -38,6 +38,8 @@ CONN_API_KEY = "connection"
 
 CALLBACK_ENDPOINT = "/x-nmos/testanswer/<version>"
 
+MOCKS_HOSTNAME = "mocks." + CONFIG.DNS_DOMAIN if CONFIG.DNS_SD_MODE == "unicast" else "nmos-mocks.local"
+
 # asyncio queue for passing Testing Façade answer responses back to tests
 _event_loop = asyncio.new_event_loop()
 asyncio.set_event_loop(_event_loop)
@@ -124,14 +126,10 @@ class ControllerTest(GenericTest):
         # Reset registry to clear previous heartbeats, etc.
         self.primary_registry.reset()
         self.primary_registry.enable()
-        if CONFIG.ENABLE_HTTPS:
-            self.mock_registry_base_url = 'https://' + CONFIG.MOCKS_HOSTNAME + ':' + \
-                str(self.primary_registry.get_data().port) + '/'
-            self.mock_node_base_url = 'https://' + CONFIG.MOCKS_HOSTNAME + ':' + str(self.node.port) + '/'
-        else:
-            self.mock_registry_base_url = 'http://' + get_default_ip() + ':' + \
-                str(self.primary_registry.get_data().port) + '/'
-            self.mock_node_base_url = 'http://' + get_default_ip() + ':' + str(self.node.port) + '/'
+
+        host = MOCKS_HOSTNAME if CONFIG.ENABLE_HTTPS else get_default_ip()
+        self.mock_registry_base_url = self.protocol + '://' + host + ':' + str(self.primary_registry.get_data().port) + '/'
+        self.mock_node_base_url = self.protocol + '://'  + host + ':' + str(self.node.port) + '/'
 
         # Populate mock registry with senders and receivers and store the results
         self._populate_registry(test)

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -128,8 +128,9 @@ class ControllerTest(GenericTest):
         self.primary_registry.enable()
 
         host = MOCKS_HOSTNAME if CONFIG.ENABLE_HTTPS else get_default_ip()
-        self.mock_registry_base_url = self.protocol + '://' + host + ':' + str(self.primary_registry.get_data().port) + '/'
-        self.mock_node_base_url = self.protocol + '://'  + host + ':' + str(self.node.port) + '/'
+        self.mock_registry_base_url = self.protocol + '://' + host + ':'\
+            + str(self.primary_registry.get_data().port) + '/'
+        self.mock_node_base_url = self.protocol + '://' + host + ':' + str(self.node.port) + '/'
 
         # Populate mock registry with senders and receivers and store the results
         self._populate_registry(test)

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -134,7 +134,7 @@ class ControllerTest(GenericTest):
         try:
             self._populate_registry(test)
         except NMOSTestException as e:
-            raise NMOSInitException(e.args[0].output())
+            raise NMOSInitException(e.args[0].detail)
 
         # Set up mock node
         self.node.registry_url = self.mock_registry_base_url

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -265,8 +265,8 @@ class ControllerTest(GenericTest):
 
     def _populate_registry(self, test):
         """Populate registry and mock node with mock senders and receivers"""
-        self.node.reset()  # Ensure previouly added senders and receivers are removed
-        self.primary_registry.common.reset()  # Ensure any previouly registered senders and receivers are removed
+        self.node.reset()  # Ensure previously added senders and receivers are removed
+        self.primary_registry.common.reset()  # Ensure any previously registered senders and receivers are removed
         sender_ip_final_octet = 159
 
         # Register node

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -77,7 +77,7 @@ class ControllerTest(GenericTest):
     Testing initial set up of new test suite for controller testing
     """
     def __init__(self, apis, registries, node, dns_server, disable_auto=True):
-        # Remove the spec_path as there are no corresponding GitHib repos for Controller Tests
+        # Remove the spec_path as there are no corresponding GitHub repos for Controller Tests
         apis[CONTROLLER_TEST_API_KEY].pop("spec_path", None)
         if apis[CONTROLLER_TEST_API_KEY]["base_url"].startswith("https"):
             # Comms with Testing Facade are http only

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -38,8 +38,6 @@ CONN_API_KEY = "connection"
 
 CALLBACK_ENDPOINT = "/x-nmos/testanswer/<version>"
 
-MOCKS_HOSTNAME = "mocks.testsuite.nmos.tv"
-
 # asyncio queue for passing Testing Façade answer responses back to tests
 _event_loop = asyncio.new_event_loop()
 asyncio.set_event_loop(_event_loop)
@@ -127,9 +125,9 @@ class ControllerTest(GenericTest):
         self.primary_registry.reset()
         self.primary_registry.enable()
         if CONFIG.ENABLE_HTTPS:
-            self.mock_registry_base_url = 'https://' + MOCKS_HOSTNAME + ':' + \
+            self.mock_registry_base_url = 'https://' + CONFIG.MOCKS_HOSTNAME + ':' + \
                 str(self.primary_registry.get_data().port) + '/'
-            self.mock_node_base_url = 'https://' + MOCKS_HOSTNAME + ':' + str(self.node.port) + '/'
+            self.mock_node_base_url = 'https://' + CONFIG.MOCKS_HOSTNAME + ':' + str(self.node.port) + '/'
         else:
             self.mock_registry_base_url = 'http://' + get_default_ip() + ':' + \
                 str(self.primary_registry.get_data().port) + '/'

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -105,8 +105,12 @@ class ControllerTest(GenericTest):
             if CONN_API_KEY in apis and "version" in self.apis[CONN_API_KEY] else "v1.1"
         self.qa_api_version = self.apis[CONTROLLER_TEST_API_KEY]["version"] \
             if CONTROLLER_TEST_API_KEY in apis and "version" in self.apis[CONTROLLER_TEST_API_KEY] else "v1.0"
-        self.answer_uri = "http://" + get_default_ip() + ":5000" + \
-            CALLBACK_ENDPOINT.replace('<version>', self.qa_api_version)
+        if CONFIG.ENABLE_HTTPS:
+            self.answer_uri = "https://mocks.testsuite.nmos.tv:5000" + \
+                CALLBACK_ENDPOINT.replace('<version>', self.qa_api_version)
+        else:
+            self.answer_uri = "http://" + get_default_ip() + ":5000" + \
+                CALLBACK_ENDPOINT.replace('<version>', self.qa_api_version)
 
     def set_up_tests(self):
         if self.dns_server:
@@ -121,9 +125,14 @@ class ControllerTest(GenericTest):
         # Reset registry to clear previous heartbeats, etc.
         self.primary_registry.reset()
         self.primary_registry.enable()
-        self.mock_registry_base_url = 'http://' + get_default_ip() + ':' + \
-            str(self.primary_registry.get_data().port) + '/'
-        self.mock_node_base_url = 'http://' + get_default_ip() + ':' + str(self.node.port) + '/'
+        if CONFIG.ENABLE_HTTPS:
+            self.mock_registry_base_url = 'https://mocks.testsuite.nmos.tv:' + \
+                str(self.primary_registry.get_data().port) + '/'
+            self.mock_node_base_url = 'https://mocks.testsuite.nmos.tv:' + str(self.node.port) + '/'
+        else:
+            self.mock_registry_base_url = 'http://' + get_default_ip() + ':' + \
+                str(self.primary_registry.get_data().port) + '/'
+            self.mock_node_base_url = 'http://' + get_default_ip() + ':' + str(self.node.port) + '/'
 
         # Populate mock registry with senders and receivers and store the results
         self._populate_registry()

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -24,7 +24,7 @@ from urllib.parse import urlparse
 from dnslib import QTYPE
 from threading import Event
 
-from .GenericTest import GenericTest, NMOSTestException
+from .GenericTest import GenericTest, NMOSTestException, NMOSInitException
 from . import Config as CONFIG
 from .TestHelper import get_default_ip, get_mocks_hostname
 from .TestResult import Test
@@ -131,7 +131,10 @@ class ControllerTest(GenericTest):
         self.mock_node_base_url = self.protocol + '://' + host + ':' + str(self.node.port) + '/'
 
         # Populate mock registry with senders and receivers and store the results
-        self._populate_registry(test)
+        try:
+            self._populate_registry(test)
+        except NMOSTestException as e:
+            raise NMOSInitException(e.args[0].output())
 
         # Set up mock node
         self.node.registry_url = self.mock_registry_base_url

--- a/nmostesting/TestHelper.py
+++ b/nmostesting/TestHelper.py
@@ -166,8 +166,10 @@ def get_default_ip():
         preferred_interface = CONFIG.BIND_INTERFACE
     return netifaces.ifaddresses(preferred_interface)[netifaces.AF_INET][0]['addr']
 
+
 def get_mocks_hostname():
     return "mocks." + CONFIG.DNS_DOMAIN if CONFIG.DNS_SD_MODE == "unicast" else "nmos-mocks.local"
+
 
 def is_ip_address(arg):
     """True if arg is an IPv4 or IPv6 address"""

--- a/nmostesting/TestHelper.py
+++ b/nmostesting/TestHelper.py
@@ -166,6 +166,8 @@ def get_default_ip():
         preferred_interface = CONFIG.BIND_INTERFACE
     return netifaces.ifaddresses(preferred_interface)[netifaces.AF_INET][0]['addr']
 
+def get_mocks_hostname():
+    return "mocks." + CONFIG.DNS_DOMAIN if CONFIG.DNS_SD_MODE == "unicast" else "nmos-mocks.local"
 
 def is_ip_address(arg):
     """True if arg is an IPv4 or IPv6 address"""

--- a/nmostesting/mocks/Node.py
+++ b/nmostesting/mocks/Node.py
@@ -505,7 +505,7 @@ def staged(version, resource, resource_id):
     """
     # Track requests
     NODE.staged_requests.append({'method': request.method, 'resource': resource, 'resource_id': resource_id,
-                                 'data': request.get_json() if request.is_json else None})
+                                 'data': request.get_json(silent=True)})
 
     try:
         if resource == 'senders':

--- a/nmostesting/mocks/Node.py
+++ b/nmostesting/mocks/Node.py
@@ -505,7 +505,7 @@ def staged(version, resource, resource_id):
     """
     # Track requests
     NODE.staged_requests.append({'method': request.method, 'resource': resource, 'resource_id': resource_id,
-                                 'data': request.json})
+                                 'data': request.get_json() if request.is_json else None})
 
     try:
         if resource == 'senders':
@@ -523,7 +523,7 @@ def staged(version, resource, resource_id):
 
         elif request.method == 'PATCH':
             # Check JSON data only contains allowed values
-            for item in request.json:
+            for item in request.get_json():
                 if item not in allowed_json:
                     return {'code': 400, 'debug': None, 'error': 'Invalid JSON entry ' + item}, 400
 

--- a/nmostesting/mocks/Registry.py
+++ b/nmostesting/mocks/Registry.py
@@ -25,7 +25,7 @@ from ..Config import PORT_BASE, AUTH_TOKEN_PUBKEY, ENABLE_AUTH, AUTH_TOKEN_ISSUE
     WEBSOCKET_PORT_BASE, ENABLE_HTTPS, SPECIFICATIONS
 from authlib.jose import jwt
 from ..NMOSUtils import NMOSUtils
-from ..TestHelper import SubscriptionWebsocketWorker, get_default_ip
+from ..TestHelper import SubscriptionWebsocketWorker, get_default_ip, get_mocks_hostname
 
 
 class RegistryCommon(object):
@@ -228,13 +228,15 @@ class Registry(object):
 
             protocol = 'wss' if secure else 'ws'
 
+            host = get_mocks_hostname() if secure else get_default_ip()
+
             subscription = {'id': subscription_id,
                             'max_update_rate_ms': subscription_request['max_update_rate_ms'],
                             'params': subscription_request['params'],
                             'persist': subscription_request['persist'],
                             'resource_path': subscription_request['resource_path'],
                             'secure': secure,
-                            'ws_href': protocol + '://' + get_default_ip() + ':' + str(websocket_port)
+                            'ws_href': protocol + '://' + host + ':' + str(websocket_port)
                             + '/x-nmos/query/' + version + '/subscriptions/' + subscription_id,
                             'version': NMOSUtils.get_TAI_time()}
 

--- a/nmostesting/mocks/Registry.py
+++ b/nmostesting/mocks/Registry.py
@@ -220,7 +220,7 @@ class Registry(object):
                 return subscription, False
 
             websocket_port = WEBSOCKET_PORT_BASE + len(self.subscription_websockets)
-            websocket_server = SubscriptionWebsocketWorker('0.0.0.0', websocket_port, resource_type)
+            websocket_server = SubscriptionWebsocketWorker('0.0.0.0', websocket_port, resource_type, secure)
             websocket_server.set_queue_sync_data_grain_callback(self.queue_sync_data_grain)
             websocket_server.start()
 
@@ -655,7 +655,7 @@ def post_subscription(version):
 
         # The current implementation of WebSockets in this mock Registry does not implement secure
         # sockets, and does not support query parameters in the request
-        if secure or len(subscription_request['params']) > 0:
+        if len(subscription_request['params']) > 0:
             abort(501)
 
         subscription, created = registry.subscribe_to_query_api(version, subscription_request, secure)

--- a/nmostesting/mocks/Registry.py
+++ b/nmostesting/mocks/Registry.py
@@ -653,8 +653,7 @@ def post_subscription(version):
         # Note: 'secure' not required in request, but is required in response
         secure = subscription_request['secure'] if 'secure' in subscription_request else ENABLE_HTTPS
 
-        # The current implementation of WebSockets in this mock Registry does not implement secure
-        # sockets, and does not support query parameters in the request
+        # The current implementation of WebSockets in this mock Registry does not support query parameters in request
         if len(subscription_request['params']) > 0:
             abort(501)
 

--- a/nmostesting/suites/IS0404Test.py
+++ b/nmostesting/suites/IS0404Test.py
@@ -295,7 +295,7 @@ class IS0404Test(ControllerTest):
             exitTestEvent.wait(time_delay)
 
             # Re-register sender
-            self._register_sender(self.senders[offline_sender_index], codes=[200, 201])
+            self._register_sender(test, self.senders[offline_sender_index], codes=[200, 201])
             sender_json = self._create_sender_json(self.senders[offline_sender_index])
             self.node.add_sender(sender_json, self.sender_ip_addresses[sender_json["id"]])
             self.senders[offline_sender_index]['registered'] = True

--- a/testingfacade/templates/index.html
+++ b/testingfacade/templates/index.html
@@ -22,9 +22,16 @@
                     type: form.attr('method'),
                     url: form.attr('action'),
                     data: form.serialize(),
+                    success: function (response) {
+                        console.log(response);
+                        $('#submitbtn').val('Submitting...');
+                    },
+                    error: function (xhr, ajaxOptions, thrownError) {
+                        $('#submitbtn').val('Error!');
+                        alert(thrownError);
+                    }
                 });
                 e.preventDefault();
-                $('#submitbtn').val('Submitting...');
                 $('#submitbtn').attr("disabled", true);
             });
         });


### PR DESCRIPTION
Updates required to run the NMOS Controller tests in secure mode. These include:

- Correctly forming secure URLs within the ControllerTest.py base class
- Implementing secure version of WebSocket server for mock Registry subscriptions
- Fix of bug in mock Node which could have led to spurious failure of IS-05 Controller test_02 (in both secure and insecure modes)