### PR TITLE
Patch jsonref dependency

### DIFF
--- a/nmostesting/Patches.py
+++ b/nmostesting/Patches.py
@@ -33,8 +33,6 @@ def _parse_json(self, jsonfile, base_path):
     else:
         base_uri_path = "file://" + base_path
 
-    loader = jsonref.JsonLoader(cache_results=False)
-
     with open(jsonfile, "r") as f:
-        schema = jsonref.load(f, base_uri=base_uri_path, loader=loader, jsonschema=True)
+        schema = jsonref.load(f, base_uri=base_uri_path, jsonschema=True)
     return schema

--- a/nmostesting/Patches.py
+++ b/nmostesting/Patches.py
@@ -34,5 +34,5 @@ def _parse_json(self, jsonfile, base_path):
         base_uri_path = "file://" + base_path
 
     with open(jsonfile, "r") as f:
-        schema = jsonref.load(f, base_uri=base_uri_path, jsonschema=True)
+        schema = jsonref.load(f, base_uri=base_uri_path, jsonschema=True, lazy_load=False)
     return schema

--- a/nmostesting/TestHelper.py
+++ b/nmostesting/TestHelper.py
@@ -277,9 +277,12 @@ class WebsocketWorker(threading.Thread):
         self.error_message = ""
 
     def run(self):
+        url = urlparse(self.ws.url)
         # strip the trailing dot of the hostname to prevent SSL certificate hostname mismatch
-        hostname = urlparse(self.ws.url).hostname.rstrip('.')
-        self.ws.run_forever(sslopt={"ca_certs": CONFIG.CERT_TRUST_ROOT_CA, "server_hostname": hostname})
+        hostname = url.hostname.rstrip('.')
+        # sslopt needs to be Falsey when not doing Secure WebSocket
+        sslopt = {"ca_certs": CONFIG.CERT_TRUST_ROOT_CA, "server_hostname": hostname} if url.scheme == "wss" else {}
+        self.ws.run_forever(sslopt=sslopt)
 
     def on_open(self, ws):
         self.connected = True

--- a/nmostesting/TestHelper.py
+++ b/nmostesting/TestHelper.py
@@ -239,13 +239,9 @@ def load_resolved_schema(spec_path, file_name=None, schema_obj=None, path_prefix
     if file_name:
         json_file = str(Path(base_path) / file_name)
         with open(json_file, "r") as f:
-            schema = jsonref.load(f, base_uri=base_uri_path, jsonschema=True)
+            schema = jsonref.load(f, base_uri=base_uri_path, jsonschema=True, lazy_load=False)
     elif schema_obj:
-        # Work around an exception when there's nothing to resolve using an object
-        if has_jsonref(schema_obj):
-            schema = jsonref.JsonRef.replace_refs(schema_obj, base_uri=base_uri_path, jsonschema=True)
-        else:
-            schema = schema_obj
+        schema = jsonref.replace_refs(schema_obj, base_uri=base_uri_path, jsonschema=True, lazy_load=False)
 
     return schema
 

--- a/nmostesting/TestHelper.py
+++ b/nmostesting/TestHelper.py
@@ -236,16 +236,14 @@ def load_resolved_schema(spec_path, file_name=None, schema_obj=None, path_prefix
     else:
         base_uri_path = "file://" + base_path
 
-    loader = jsonref.JsonLoader(cache_results=False)
-
     if file_name:
         json_file = str(Path(base_path) / file_name)
         with open(json_file, "r") as f:
-            schema = jsonref.load(f, base_uri=base_uri_path, loader=loader, jsonschema=True)
+            schema = jsonref.load(f, base_uri=base_uri_path, jsonschema=True)
     elif schema_obj:
         # Work around an exception when there's nothing to resolve using an object
         if has_jsonref(schema_obj):
-            schema = jsonref.JsonRef.replace_refs(schema_obj, base_uri=base_uri_path, loader=loader, jsonschema=True)
+            schema = jsonref.JsonRef.replace_refs(schema_obj, base_uri=base_uri_path, jsonschema=True)
         else:
             schema = schema_obj
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ netifaces
 gitpython
 ramlfications
 websocket-client>=1.0.0,!=1.2.2
-jsonref
+jsonref>=1.0.0
 dnslib
 jinja2
 junit-xml


### PR DESCRIPTION
Cherry-pick https://github.com/AMWA-TV/nmos-testing/pull/715/commits/8038da92e3b1035dce17ebdcc67066efc1e5d6c8

> the jsonref 1.0.0 release includes https://github.com/gazpachoking/jsonref/pull/43... it's not clear from https://github.com/AMWA-TV/nmos-testing/pull/106 why we needed to set `cache_results=False`) and the jsonref 1.0.0 makes significant changes to the way `$ref`ed schemas are cached, so I can't immediately tell if this is going to cause us a problem.

but I think we should go for it and fix any issues rather than pin `jsonref` back to pre-1.0.0.