### PR TITLE
IS-11: Test suites for Stream Compatibility Management

### DIFF
--- a/nmostesting/Config.py
+++ b/nmostesting/Config.py
@@ -259,6 +259,17 @@ SPECIFICATIONS = {
             }
         }
     },
+    "is-11": {
+        "repo": "is-11",
+        "versions": ["v1.0"],
+        "default_version": "v1.0",
+        "apis": {
+            "streamcompatibility": {
+                "name": "Stream Compatibility Management API",
+                "raml": "StreamCompatibilityManagementAPI.raml"
+            }
+        }
+    },
     "bcp-003-01": {
         "repo": "nmos-secure-communication",
         "versions": ["v1.0"],
@@ -274,6 +285,12 @@ SPECIFICATIONS = {
                 "name": "Receiver Capabilities"
             }
         }
+    },
+    "bcp-005-01": {
+        "repo": "bcp-005-01",
+        "versions": ["v1.0"],
+        "default_version": "v1.0",
+        "apis": {}
     },
     "nmos-parameter-registers": {
         "repo": "nmos-parameter-registers",

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -79,7 +79,10 @@ from .suites import IS0802Test
 from .suites import IS0901Test
 from .suites import IS0902Test
 # from .suites import IS1001Test
+from .suites import IS1101Test
+from .suites import IS1102Test
 from .suites import BCP00301Test
+from .suites import BCP0050101Test
 
 
 FLASK_APPS = []
@@ -316,6 +319,25 @@ TEST_DEFINITIONS = {
     #     }],
     #     "class": IS1001Test.IS1001Test
     # },
+    "IS-11-01": {
+        "name": "IS-11 Stream Compatibility Management API",
+        "specs": [{
+            "spec_key": "is-11",
+            "api_key": "streamcompatibility"
+        }],
+        "class": IS1101Test.IS1101Test
+    },
+    "IS-11-02": {
+        "name": "IS-11 Interaction with IS-04",
+        "specs": [{
+            "spec_key": "is-04",
+            "api_key": "node"
+        }, {
+            "spec_key": "is-11",
+            "api_key": "streamcompatibility"
+        }],
+        "class": IS1102Test.IS1102Test
+    },
     "BCP-003-01": {
         "name": "BCP-003-01 Secure Communication",
         "specs": [{
@@ -323,6 +345,14 @@ TEST_DEFINITIONS = {
             "api_key": "secure"
         }],
         "class": BCP00301Test.BCP00301Test
+    },
+    "BCP-005-01-01": {
+        "name": "BCP-005-01 EDID to Receiver Capabilities Mapping",
+        "specs": [{
+            "spec_key": "is-04",
+            "api_key": "node"
+        }],
+        "class": BCP0050101Test.BCP0050101Test
     },
 }
 

--- a/nmostesting/suites/BCP0050101Test.py
+++ b/nmostesting/suites/BCP0050101Test.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2022 Advanced Media Workflow Association
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..GenericTest import GenericTest
+
+NODE_API_KEY = "node"
+
+
+class BCP0050101Test(GenericTest):
+    """
+    Runs Node Tests covering BCP-005-01
+    """
+    def __init__(self, apis):
+        GenericTest.__init__(self, apis)
+        self.node_url = self.apis[NODE_API_KEY]["url"]

--- a/nmostesting/suites/IS1101Test.py
+++ b/nmostesting/suites/IS1101Test.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2022 Advanced Media Workflow Association
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..GenericTest import GenericTest
+
+COMPAT_API_KEY = "streamcompatibility"
+
+
+class IS1101Test(GenericTest):
+    """
+    Runs Node Tests covering IS-11
+    """
+    def __init__(self, apis):
+        GenericTest.__init__(self, apis)
+        self.compat_url = self.apis[COMPAT_API_KEY]["url"]

--- a/nmostesting/suites/IS1102Test.py
+++ b/nmostesting/suites/IS1102Test.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2022 Advanced Media Workflow Association
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..GenericTest import GenericTest
+
+NODE_API_KEY = "node"
+COMPAT_API_KEY = "streamcompatibility"
+
+
+class IS1102Test(GenericTest):
+    """
+    Runs Node Tests covering both IS-04 and IS-11
+    """
+    def __init__(self, apis):
+        GenericTest.__init__(self, apis,)
+        self.node_url = self.apis[NODE_API_KEY]["url"]
+        self.compat_url = self.apis[COMPAT_API_KEY]["url"]


### PR DESCRIPTION
... and BCP-005-01 EDID to Receiver Capabilities Mapping

Replaces https://github.com/AMWA-TV/nmos-testing/pull/716 with an **is-11** activity branch in the AMWA-TV/nmos-testing for simpler collaboration. The group can make PRs to extend the test suites onto this branch, which the activity group can review before merging. Others can use this 'stable' activity branch for testing.