### PR TITLE
Fix IS-04 auto_node_17 (Missing Authorization_header) test, add flag …

### DIFF
--- a/nmostesting/GenericTest.py
+++ b/nmostesting/GenericTest.py
@@ -463,7 +463,7 @@ class GenericTest(object):
             headers = {}
             if token:
                 headers = {"Authorization": "Bearer {}".format(token)}
-            valid, response = self.do_request("GET", url, headers=headers)
+            valid, response = self.do_request("GET", url, headers=headers, auth_test=None)
             if not valid:
                 return test.FAIL(response)
 

--- a/nmostesting/TestHelper.py
+++ b/nmostesting/TestHelper.py
@@ -191,8 +191,10 @@ def do_request(method, url, headers=None, **kwargs):
 
         # CORS preflight requests do not use Auth
         is_CORS_preflight = method.upper() == "OPTIONS" and "Access-Control-Request-Method" in headers
-        if not is_CORS_preflight and "Authorization" not in headers and CONFIG.ENABLE_AUTH and CONFIG.AUTH_TOKEN:
+        if not is_CORS_preflight and "Authorization" not in headers and CONFIG.ENABLE_AUTH and CONFIG.AUTH_TOKEN and "auth_test" not in kwargs:
             headers["Authorization"] = "Bearer " + CONFIG.AUTH_TOKEN
+        if "auth_test" in kwargs:
+            del kwargs["auth_test"]
 
         # all requests must have Origin to qualify as CORS requests
         headers["Origin"] = "null"

--- a/nmostesting/TestHelper.py
+++ b/nmostesting/TestHelper.py
@@ -191,7 +191,8 @@ def do_request(method, url, headers=None, **kwargs):
 
         # CORS preflight requests do not use Auth
         is_CORS_preflight = method.upper() == "OPTIONS" and "Access-Control-Request-Method" in headers
-        if not is_CORS_preflight and "Authorization" not in headers and CONFIG.ENABLE_AUTH and CONFIG.AUTH_TOKEN and "auth_test" not in kwargs:
+        if (not is_CORS_preflight and "Authorization" not in headers and CONFIG.ENABLE_AUTH and CONFIG.AUTH_TOKEN
+            and "auth_test" not in kwargs):
             headers["Authorization"] = "Bearer " + CONFIG.AUTH_TOKEN
         if "auth_test" in kwargs:
             del kwargs["auth_test"]

--- a/nmostesting/TestHelper.py
+++ b/nmostesting/TestHelper.py
@@ -192,7 +192,7 @@ def do_request(method, url, headers=None, **kwargs):
         # CORS preflight requests do not use Auth
         is_CORS_preflight = method.upper() == "OPTIONS" and "Access-Control-Request-Method" in headers
         if (not is_CORS_preflight and "Authorization" not in headers and CONFIG.ENABLE_AUTH and CONFIG.AUTH_TOKEN
-            and "auth_test" not in kwargs):
+                and "auth_test" not in kwargs):
             headers["Authorization"] = "Bearer " + CONFIG.AUTH_TOKEN
         if "auth_test" in kwargs:
             del kwargs["auth_test"]


### PR DESCRIPTION
…to indicate while running Authorization Test.

This is necessary while running the `Missing Authorization Header` test, to indicate no Authorization Header to be inserted by default.