### PR TITLE
BCP-006-01 Controller Test: ensure example "video/raw" Senders/Receivers in tests

### DIFF
--- a/nmostesting/suites/BCP0060102Test.py
+++ b/nmostesting/suites/BCP0060102Test.py
@@ -684,6 +684,7 @@ class BCP0060102Test(ControllerTest):
         """
         # Controllers MUST support IS-04 to discover JPEG XS Senders
 
+        MAX_COMPATIBLE_RECEIVER_COUNT = 3
         CANDIDATE_SENDER_COUNT = 4
 
         try:
@@ -699,7 +700,7 @@ class BCP0060102Test(ControllerTest):
             jpeg_xs_senders = [s for s in self.senders if 'video/jxsv' == s['sdp_params']['media_type']]
             video_raw_senders = [s for s in self.senders if 'video/raw' == s['sdp_params']['media_type']]
 
-            jpeg_xs_sender_count = NMOSUtils.RANDOM.randint(1, min(CANDIDATE_SENDER_COUNT, len(jpeg_xs_senders)))
+            jpeg_xs_sender_count = NMOSUtils.RANDOM.randint(1, min(MAX_COMPATIBLE_RECEIVER_COUNT, len(jpeg_xs_senders)))
             candidate_senders = NMOSUtils.RANDOM.sample(jpeg_xs_senders, jpeg_xs_sender_count)
 
             if len(candidate_senders) < CANDIDATE_SENDER_COUNT:
@@ -735,6 +736,7 @@ class BCP0060102Test(ControllerTest):
         """
         # Controllers MUST support IS-04 to discover JPEG XS Receivers
 
+        MAX_COMPATIBLE_RECEIVER_COUNT = 3
         CANDIDATE_RECEIVER_COUNT = 4
 
         try:
@@ -750,7 +752,8 @@ class BCP0060102Test(ControllerTest):
             jpeg_xs_receivers = [r for r in self.receivers if 'video/jxsv' in r['caps']['media_types']]
             video_raw_receivers = [r for r in self.receivers if 'video/raw' in r['caps']['media_types']]
 
-            jpeg_xs_receiver_count = NMOSUtils.RANDOM.randint(1, min(CANDIDATE_RECEIVER_COUNT, len(jpeg_xs_receivers)))
+            jpeg_xs_receiver_count = NMOSUtils.RANDOM.randint(1, min(MAX_COMPATIBLE_RECEIVER_COUNT,
+                                                                     len(jpeg_xs_receivers)))
             candidate_receivers = NMOSUtils.RANDOM.sample(jpeg_xs_receivers, jpeg_xs_receiver_count)
 
             if len(candidate_receivers) < CANDIDATE_RECEIVER_COUNT:

--- a/nmostesting/suites/BCP0060102Test.py
+++ b/nmostesting/suites/BCP0060102Test.py
@@ -684,7 +684,7 @@ class BCP0060102Test(ControllerTest):
         """
         # Controllers MUST support IS-04 to discover JPEG XS Senders
 
-        MAX_COMPATIBLE_RECEIVER_COUNT = 3
+        MAX_COMPATIBLE_SENDER_COUNT = 3
         CANDIDATE_SENDER_COUNT = 4
 
         try:
@@ -700,7 +700,7 @@ class BCP0060102Test(ControllerTest):
             jpeg_xs_senders = [s for s in self.senders if 'video/jxsv' == s['sdp_params']['media_type']]
             video_raw_senders = [s for s in self.senders if 'video/raw' == s['sdp_params']['media_type']]
 
-            jpeg_xs_sender_count = NMOSUtils.RANDOM.randint(1, min(MAX_COMPATIBLE_RECEIVER_COUNT, len(jpeg_xs_senders)))
+            jpeg_xs_sender_count = NMOSUtils.RANDOM.randint(1, min(MAX_COMPATIBLE_SENDER_COUNT, len(jpeg_xs_senders)))
             candidate_senders = NMOSUtils.RANDOM.sample(jpeg_xs_senders, jpeg_xs_sender_count)
 
             if len(candidate_senders) < CANDIDATE_SENDER_COUNT:


### PR DESCRIPTION
In test_01 and test_02 ensure there is at least one "video/raw" Sender or Receiver