### PR TITLE
[BCP-006-01] Require IS-04 v1.3

### DIFF
--- a/nmostesting/suites/BCP0060101Test.py
+++ b/nmostesting/suites/BCP0060101Test.py
@@ -65,6 +65,19 @@ class BCP0060101Test(GenericTest):
         return True, ""
 
     def test_01(self, test):
+        """Check that version 1.3 or greater of the Node API is available"""
+
+        api = self.apis[NODE_API_KEY]
+        if self.is04_utils.compare_api_version(api["version"], "v1.3") >= 0:
+            valid, result = self.do_request("GET", self.node_url)
+            if valid:
+                return test.PASS()
+            else:
+                return test.FAIL("Node API did not respond as expected: {}".format(result))
+        else:
+            return test.FAIL("Node API must be running v1.3 or greater to fully implement BCP-006-01")
+
+    def test_02(self, test):
         """JPEG XS Flows have the required attributes"""
 
         self.do_test_node_api_v1_1(test)
@@ -146,7 +159,7 @@ class BCP0060101Test(GenericTest):
 
         return test.UNCLEAR("No JPEG XS Flow resources were found on the Node")
 
-    def test_02(self, test):
+    def test_03(self, test):
         """JPEG XS Sources have the required attributes"""
 
         self.do_test_node_api_v1_1(test)
@@ -176,7 +189,7 @@ class BCP0060101Test(GenericTest):
 
         return test.UNCLEAR("No JPEG XS Flow resources were found on the Node")
 
-    def test_03(self, test):
+    def test_04(self, test):
         """JPEG XS Senders have the required attributes"""
 
         self.do_test_node_api_v1_1(test)
@@ -257,7 +270,7 @@ class BCP0060101Test(GenericTest):
 
         return test.UNCLEAR("No JPEG XS Sender resources were found on the Node")
 
-    def test_04(self, test):
+    def test_05(self, test):
         """JPEG XS Sender manifests have the required parameters"""
 
         self.do_test_node_api_v1_1(test)
@@ -527,7 +540,7 @@ class BCP0060101Test(GenericTest):
 
         return test.UNCLEAR("No JPEG XS Sender resources were found on the Node")
 
-    def test_05(self, test):
+    def test_06(self, test):
         """JPEG XS Receivers have the required attributes"""
 
         self.do_test_node_api_v1_1(test)
@@ -589,7 +602,7 @@ class BCP0060101Test(GenericTest):
 
         return test.UNCLEAR("No JPEG XS Receiver resources were found on the Node")
 
-    def test_06(self, test):
+    def test_07(self, test):
         """JPEG XS Receiver parameter constraints have valid values"""
 
         self.do_test_node_api_v1_1(test)

--- a/nmostesting/suites/BCP0060101Test.py
+++ b/nmostesting/suites/BCP0060101Test.py
@@ -771,4 +771,4 @@ class BCP0060101Test(GenericTest):
         """
         api = self.apis[NODE_API_KEY]
         if self.is04_utils.compare_api_version(api["version"], "v1.1") < 0:
-            raise NMOSTestException(test.NA("This test cannot be run against IS-04 below version v1.1."))
+            raise NMOSTestException(test.NA("This test cannot be run against Node API below version v1.1."))

--- a/nmostesting/suites/BCP0060102Test.py
+++ b/nmostesting/suites/BCP0060102Test.py
@@ -16,8 +16,11 @@ import textwrap
 from operator import itemgetter
 from itertools import cycle, islice
 from .. import Config as CONFIG
+from ..GenericTest import NMOSInitException
 from ..ControllerTest import ControllerTest, TestingFacadeException
 from ..NMOSUtils import NMOSUtils
+
+QUERY_API_KEY = "query"
 
 
 class BCP0060102Test(ControllerTest):
@@ -26,6 +29,8 @@ class BCP0060102Test(ControllerTest):
     """
     def __init__(self, apis, registries, node, dns_server, **kwargs):
         ControllerTest.__init__(self, apis, registries, node, dns_server)
+        if NMOSUtils.compare_api_version(self.apis[QUERY_API_KEY]["version"], "v1.1") < 0:
+            raise NMOSInitException("This test suite cannot be run against Query API below version v1.1.")
 
     def _create_interop_point(self, sdp_base, override_params):
         interop_point = {**sdp_base, **override_params}

--- a/nmostesting/suites/IS0502Test.py
+++ b/nmostesting/suites/IS0502Test.py
@@ -1308,4 +1308,4 @@ class IS0502Test(GenericTest):
         """
         api = self.apis[NODE_API_KEY]
         if self.is05_utils.compare_api_version(api["version"], "v1.2") < 0:
-            raise NMOSTestException(test.NA("This test cannot be run against IS-04 below version v1.2."))
+            raise NMOSTestException(test.NA("This test cannot be run against Node API below version v1.2."))


### PR DESCRIPTION
Cf. https://github.com/AMWA-TV/bcp-006-01/pull/24

A Node that only implements (i.e. is tested against) IS-04 v1.2 will get one **Fail** and a couple of **Not Applicables** with explanations of what will be required when they implement IS-04 v1.3.

![image](https://user-images.githubusercontent.com/31761158/207309610-02687d75-b365-44f0-8e21-b10da41b4072.png)
