### PR TITLE
[IS-08] UNCLEAR rather than NA

### DIFF
--- a/nmostesting/suites/IS0801Test.py
+++ b/nmostesting/suites/IS0801Test.py
@@ -264,7 +264,7 @@ class IS0801Test(GenericTest):
                 )
 
         if len(constrainedOutputList) == 0:
-            return test.NA("Could not test - no outputs have routing constraints set.")
+            return test.UNCLEAR("Could not test - no outputs have routing constraints set.")
 
         inputIDList = [None]
         for inputInstance in inputList:
@@ -290,7 +290,7 @@ class IS0801Test(GenericTest):
                            "and Output {} despite routing constraint."
                            .format(forbiddenRoutes[0], outputInstance.id))
                     return test.FAIL(msg)
-        return test.NA("Could not test - no route is forbidden.")
+        return test.UNCLEAR("Could not test - no route is forbidden.")
 
     def test_14(self, test):
         """It is not possible to re-order channels when re-ordering is set to false"""
@@ -308,7 +308,7 @@ class IS0801Test(GenericTest):
                 constraintSet = True
 
         if not constraintSet:
-            return test.NA("No inputs prevent re-ordering.")
+            return test.UNCLEAR("No inputs prevent re-ordering.")
 
         # Filter out inputs where the constraint can't be tested because the
         # block size prevents re-ordering anyway
@@ -383,7 +383,7 @@ class IS0801Test(GenericTest):
                 constrainedInputs.append(inputInstance)
 
         if not constraintSet:
-            return test.NA("No inputs constrain by block.")
+            return test.UNCLEAR("No inputs constrain by block.")
 
         chosenInput = constrainedInputs[0]
         output = chosenInput.getRoutableOutputs()


### PR DESCRIPTION
There are 6 possible test results besides green "Pass" (PASS) and red "Fail" (FAIL)...

https://github.com/AMWA-TV/nmos-testing/blob/eef5fabf26f2bc6af0054ac7327059284c305b20/nmostesting/TestResult.py#L22-L30

As far as I understand, the yellow "Not Implemented" (OPTIONAL) and "Warning" (WARNING) refer to unimplemented optional and recommended features in the thing under test. For tests that cannot be run because the thing under test (perhaps just temporarily) doesn't expose the feature (e.g. a transmit-only thing may have no Receiver resources), we have yellow "Could Not Test" (UNCLEAR). For test cases that do not apply to the version of API under test, we have grey "Not Applicable" (NA). For things that cannot be tested due to other testing tool config (e.g. secure/auth/DNS-SD options) we have yellow "Test Disabled" (DISABLED). For important tests that would be impossible or hard to automate we have blue "Manual" (MANUAL).

So, I think these should be UNCLEAR rather than NA?

