### PR TITLE
Fix mock servers with ENABLE_HTTPS = True on Windows

### DIFF
--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -905,7 +905,7 @@ def start_web_servers():
     ctx = None
     if CONFIG.ENABLE_HTTPS:
         # ssl.create_default_context() provides options that broadly correspond to the requirements of BCP-003-01
-        ctx = ssl.create_default_context()
+        ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
         for cert, key in zip(CONFIG.CERTS_MOCKS, CONFIG.KEYS_MOCKS):
             ctx.load_cert_chain(cert, key)
         # additionally disable TLS v1.0 and v1.1

--- a/nmostesting/TestHelper.py
+++ b/nmostesting/TestHelper.py
@@ -499,7 +499,7 @@ class SubscriptionWebsocketWorker(threading.Thread):
 
         ctx = None
         if secure:
-            ctx = ssl.create_default_context()
+            ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
             for cert, key in zip(CONFIG.CERTS_MOCKS, CONFIG.KEYS_MOCKS):
                 ctx.load_cert_chain(cert, key)
             # additionally disable TLS v1.0 and v1.1

--- a/nmostesting/mocks/Auth.py
+++ b/nmostesting/mocks/Auth.py
@@ -71,7 +71,7 @@ class AuthServer(object):
             if ENABLE_HTTPS:
                 # ssl.create_default_context() provides options that broadly correspond to
                 # the requirements of BCP-003-01
-                ctx = ssl.create_default_context()
+                ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
                 ctx.load_cert_chain(cert_file, key_file)
                 # additionally disable TLS v1.0 and v1.1
                 ctx.options &= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1

--- a/nmostesting/suites/BCP00301Test.py
+++ b/nmostesting/suites/BCP00301Test.py
@@ -264,7 +264,7 @@ class BCP00301Test(GenericTest):
         """Certificate is valid and matches the host under test"""
 
         try:
-            context = ssl.create_default_context(cafile=CONFIG.CERT_TRUST_ROOT_CA)
+            context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH, CONFIG.CERT_TRUST_ROOT_CA)
             hostname = self.apis[SECURE_API_KEY]["hostname"]
             sock = context.wrap_socket(socket.socket(), server_hostname=hostname.rstrip('.'))
             sock.settimeout(CONFIG.HTTP_TIMEOUT)


### PR DESCRIPTION
@lo-simon worked out what was up with the mock servers rejecting TLS connections with `ENABLE_HTTPS = True`. The `ssl.create_default_context()` function is by default only appropriate for client-side, authenticating connections to servers. So our mocks need to explicitly specify `purpose=ssl.Purpose.CLIENT_AUTH`.

I conjecture but haven't proven that this may only be a problem since 3.10, per this note in the docs:

> _Changed in version 3.10:_ The context now uses `PROTOCOL_TLS_CLIENT` or `PROTOCOL_TLS_SERVER` protocol instead of generic `PROTOCOL_TLS`.
