### PR TITLE
Use github DOCKER_USERNAME secret for docker image name

### DIFF
--- a/.deploy/docker-compose.yml
+++ b/.deploy/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3"
 services:
   nmos-testing:
-    image: rbgodwin/nmos-testing:latest
+    image: ${{ secrets.DOCKER_USERNAME }}/nmos-testing:latest
     ports:
       - "5000:5000"

--- a/.deploy/docker-compose.yml
+++ b/.deploy/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3"
 services:
   nmos-testing:
-    image: amwa/nmos-testing:latest
+    image: rbgodwin/nmos-testing:latest
     ports:
       - "5000:5000"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,4 +32,4 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/nmos-testing:latest
+          tags: rbgodwin/nmos-testing:latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,4 +32,4 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: amwa/nmos-testing:latest
+          tags: ${{ secrets.DOCKER_USERNAME }}/nmos-testing:latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,4 +32,4 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: rbgodwin/nmos-testing:latest
+          tags: ${{ secrets.DOCKER_USERNAME }}/nmos-testing:latest


### PR DESCRIPTION
When forking the repo and running the Actions, using GitHub DOCKER_USERNAME for the docker image is handy.  Since a docker account is needed to run the Action, there should not be a case where we need a default value.