### PR TITLE
Fix failure with cpython/ssl

### DIFF
--- a/nmostesting/suites/BCP00301Test.py
+++ b/nmostesting/suites/BCP00301Test.py
@@ -264,7 +264,7 @@ class BCP00301Test(GenericTest):
         """Certificate is valid and matches the host under test"""
 
         try:
-            context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH, CONFIG.CERT_TRUST_ROOT_CA)
+            context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH, cafile=CONFIG.CERT_TRUST_ROOT_CA)
             hostname = self.apis[SECURE_API_KEY]["hostname"]
             sock = context.wrap_socket(socket.socket(), server_hostname=hostname.rstrip('.'))
             sock.settimeout(CONFIG.HTTP_TIMEOUT)


### PR DESCRIPTION
Follow up to #767.

Got error `create_default_context() takes from 0 to 1 positional arguments but 2 were given`.

Despite the documentation (https://docs.python.org/3.11/library/ssl.html#ssl.create_default_context) the cpython/ssl implementation makes most of the arguments keyword-only (https://github.com/python/cpython/blob/0f2ba6580565c3b51396c840406211ad81297735/Lib/ssl.py#L683-L684)

I.e. docs says
```python
def create_default_context(purpose=Purpose.SERVER_AUTH, cafile=None, capath=None, cadata=None)
```
but implementation is
```python
def create_default_context(purpose=Purpose.SERVER_AUTH, *, cafile=None,
                           capath=None, cadata=None):
```

That pesky `*` makes the following arguments keyword-only, which is well described at https://stackoverflow.com/a/57819001.
