### PR TITLE
Fix "Passing coroutines is forbidden, use tasks explicitly" error

### DIFF
--- a/nmostesting/TestHelper.py
+++ b/nmostesting/TestHelper.py
@@ -469,7 +469,8 @@ class SubscriptionWebsocketWorker(threading.Thread):
         while True:
             message = await self._message_queue.get()
             # broadcast to all connected clients
-            await asyncio.wait([ws.send(message) for ws in self._connected_clients])
+            for ws in self._connected_clients:
+                await asyncio.create_task(ws.send(message))
 
     async def handler(self, websocket, path):
         consumer_task = asyncio.ensure_future(self.consumer_handler(websocket, path))

--- a/nmostesting/TestHelper.py
+++ b/nmostesting/TestHelper.py
@@ -469,8 +469,7 @@ class SubscriptionWebsocketWorker(threading.Thread):
         while True:
             message = await self._message_queue.get()
             # broadcast to all connected clients
-            for ws in self._connected_clients:
-                await asyncio.create_task(ws.send(message))
+            await asyncio.wait([asyncio.create_task(ws.send(message)) for ws in self._connected_clients])
 
     async def handler(self, websocket, path):
         consumer_task = asyncio.ensure_future(self.consumer_handler(websocket, path))


### PR DESCRIPTION
The explicit passing of coroutine objects to asyncio.wait() has been deprecated since Python 3.8, and has now been removed in Python 3.11.  