### PR TITLE
Use `ensure_future` rather than `create_task`

### DIFF
--- a/nmostesting/TestHelper.py
+++ b/nmostesting/TestHelper.py
@@ -469,7 +469,7 @@ class SubscriptionWebsocketWorker(threading.Thread):
         while True:
             message = await self._message_queue.get()
             # broadcast to all connected clients
-            await asyncio.wait([asyncio.create_task(ws.send(message)) for ws in self._connected_clients])
+            await asyncio.wait([asyncio.ensure_future(ws.send(message)) for ws in self._connected_clients])
 
     async def handler(self, websocket, path):
         consumer_task = asyncio.ensure_future(self.consumer_handler(websocket, path))


### PR DESCRIPTION
Use `ensure_future` rather than `create_task` for better backwards Python compatibility