### PR TITLE
Fix for version display in Docker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,32 +4,51 @@ on:
 
   push:
     branches:
-        - main
-        - master
-        - deploy-action
+      - main
+      - master
+      - dev
+      - deploy-action
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ secrets.DOCKER_USERNAME }}/nmos-testing
+          tags: |
+            # Tag all builds with branch name and sha
+            type=sha,prefix=${{ github.ref_name }}-
+            # Tag each non-default branch with branch name and latest
+            type=raw,value=latest,prefix=${{ github.ref_name }}-,enable=${{ github.ref_name != 'master' }}
+            # Tag default branch with latest (no branch name prefix)
+            type=raw,value=latest,enable={{is_default_branch}}
+
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2.1.0
         with:
           platforms: all
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2.5.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4.0.0
         with:
+          context: .
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/nmos-testing:latest
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,10 +4,8 @@ on:
 
   push:
     branches:
-      - main
       - master
       - dev
-      - deploy-action
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,10 +22,10 @@ jobs:
           tags: |
             # Tag all builds with branch name and sha
             type=sha,prefix=${{ github.ref_name }}-
-            # Tag each non-default branch with branch name and latest
+            # Tag if non-master branch with branch name and latest
             type=raw,value=latest,prefix=${{ github.ref_name }}-,enable=${{ github.ref_name != 'master' }}
-            # Tag default branch with latest (no branch name prefix)
-            type=raw,value=latest,enable={{is_default_branch}}
+            # Tag if master branch with latest (no branch name prefix)
+            type=raw,value=latest,enable=${{ github.ref_name == 'master' }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:bionic
 
 WORKDIR /home/nmos-testing
 ADD . .
+ADD .git .git
 
 RUN apt-get update \
     && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Changes :

- Add a shallow clone of the git repo (image size goes from 256.8MB to 257.97MB. This allows the Python code that displays the version of the test suite to work the same for a local repo and a docker container.
- Add tags for branches using commit SHA.  
- Updated the versions of the GitHub actions to be the latest versions.
- Tested on NMOS Testbed.