### PR TITLE
Clear resource IDs cache before autotesting each API

### DIFF
--- a/nmostesting/GenericTest.py
+++ b/nmostesting/GenericTest.py
@@ -433,6 +433,9 @@ class GenericTest(object):
             # Test that the API responds with a 401 or 503 followed by 200 when no matching public keys for the token
             results.append(self.do_test_no_matching_public_key_authorization(api))
 
+            # Clear saved entities before switching the API
+            self.saved_entities.clear()
+
         return results
 
     def do_test_404_path(self, api_name):


### PR DESCRIPTION
`auto_*` tests collect cache while going through resources in each API. The issue is that API lexicographic order matters: if an API has less resources than any of previous APIs, `auto_*` take resource IDs from the cache and fail, although the API itself doesn't even list these IDs.

The fix clears the cache after going though each API.