### PR TITLE
Check IS-11 control advertisement like other test suites do

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The following test suites are currently supported.
 | BCP-003-01 | BCP-003-01 Secure Communication | X | X | | See [Testing TLS](docs/2.2.%20Usage%20-%20Testing%20BCP-003-01%20TLS.md) |
 | - | BCP-003-02 Authorization | X | X | | See [Testing Authorization](docs/2.3.%20Usage%20-%20Testing%20IS-10%20Authorization.md) |
 | - | BCP-004-01 Receiver Capabilities | X | | | Included in IS-04 Node API and IS-05 Interaction with IS-04 suites |
+| BCP-006-01-01 | BCP-006-01 NMOS With JPEG XS | X | | | |
+| BCP-006-01-02 | BCP-006-01 Controller | | | X | See [Testing Controllers](docs/2.8.%20Usage%20-%20Testing%20Controllers.md) |
 
 When testing any of the above APIs it is important that they contain representative data. The test results will generate 'Could Not Test' results if no testable entities can be located. In addition, if devices support many modes of operation (including multiple video/audio formats) it is strongly recommended to re-test them in multiple modes.
 

--- a/nmostesting/NMOSUtils.py
+++ b/nmostesting/NMOSUtils.py
@@ -183,32 +183,32 @@ class NMOSUtils(object):
         return sorted(versions_list, key=functools.cmp_to_key(NMOSUtils.compare_api_version))
 
     @staticmethod
-    def test_device_control_advertisement(test, node_url, type, href, authorization):
+    def do_test_device_control(test, node_url, type, href, authorization):
         """At least one Device is showing the given control advertisement matching the API under test"""
 
         valid, devices = TestHelper.do_request("GET", node_url + "devices")
         if not valid:
             return test.FAIL("Node API did not respond as expected: {}".format(devices))
 
-        compat_devices = []
-        found_api_match = False
+        found_type = False
+        found_api = False
         try:
             for device in devices.json():
                 controls = device["controls"]
                 for control in controls:
                     if control["type"] == type:
-                        compat_devices.append(control["href"])
+                        found_type = True
                         if NMOSUtils.compare_urls(href, control["href"]) and \
                                 authorization is control.get("authorization", False):
-                            found_api_match = True
+                            found_api = True
         except json.JSONDecodeError:
             return test.FAIL("Non-JSON response returned from Node API")
         except KeyError:
             return test.FAIL("One or more Devices were missing the 'controls' attribute")
 
-        if len(compat_devices) > 0 and found_api_match:
+        if found_api:
             return test.PASS()
-        elif len(compat_devices) > 0:
+        elif found_type:
             return test.FAIL("Found one or more Device controls, but no href and authorization mode matched the "
                              "API under test")
         else:

--- a/nmostesting/NMOSUtils.py
+++ b/nmostesting/NMOSUtils.py
@@ -16,9 +16,11 @@ import time
 import functools
 import random
 from urllib.parse import urlparse
+from requests.compat import json
 
 
 from . import Config as CONFIG
+from . import TestHelper
 
 # The UTC leap seconds table below was extracted from the information provided at
 # http://www.ietf.org/timezones/data/leap-seconds.list
@@ -179,3 +181,35 @@ class NMOSUtils(object):
     @staticmethod
     def sort_versions(versions_list):
         return sorted(versions_list, key=functools.cmp_to_key(NMOSUtils.compare_api_version))
+
+    @staticmethod
+    def test_device_control_advertisement(test, node_url, api_under_test_url, control_type, authorization):
+        """At least one Device is showing the given control advertisement matching the API under test"""
+
+        valid, devices = TestHelper.do_request("GET", node_url + "devices")
+        if not valid:
+            return test.FAIL("Node API did not respond as expected: {}".format(devices))
+
+        compat_devices = []
+        found_api_match = False
+        try:
+            for device in devices.json():
+                controls = device["controls"]
+                for control in controls:
+                    if control["type"] == control_type:
+                        compat_devices.append(control["href"])
+                        if NMOSUtils.compare_urls(api_under_test_url, control["href"]) and \
+                                authorization is control.get("authorization", False):
+                            found_api_match = True
+        except json.JSONDecodeError:
+            return test.FAIL("Non-JSON response returned from Node API")
+        except KeyError:
+            return test.FAIL("One or more Devices were missing the 'controls' attribute")
+
+        if len(compat_devices) > 0 and found_api_match:
+            return test.PASS()
+        elif len(compat_devices) > 0:
+            return test.FAIL("Found one or more Device controls, but no href and authorization mode matched the "
+                             "API under test")
+        else:
+            return test.FAIL("Unable to find any Devices which expose the control type '{}'".format(control_type))

--- a/nmostesting/NMOSUtils.py
+++ b/nmostesting/NMOSUtils.py
@@ -183,7 +183,7 @@ class NMOSUtils(object):
         return sorted(versions_list, key=functools.cmp_to_key(NMOSUtils.compare_api_version))
 
     @staticmethod
-    def test_device_control_advertisement(test, node_url, api_under_test_url, control_type, authorization):
+    def test_device_control_advertisement(test, node_url, type, href, authorization):
         """At least one Device is showing the given control advertisement matching the API under test"""
 
         valid, devices = TestHelper.do_request("GET", node_url + "devices")
@@ -196,9 +196,9 @@ class NMOSUtils(object):
             for device in devices.json():
                 controls = device["controls"]
                 for control in controls:
-                    if control["type"] == control_type:
+                    if control["type"] == type:
                         compat_devices.append(control["href"])
-                        if NMOSUtils.compare_urls(api_under_test_url, control["href"]) and \
+                        if NMOSUtils.compare_urls(href, control["href"]) and \
                                 authorization is control.get("authorization", False):
                             found_api_match = True
         except json.JSONDecodeError:
@@ -212,4 +212,4 @@ class NMOSUtils(object):
             return test.FAIL("Found one or more Device controls, but no href and authorization mode matched the "
                              "API under test")
         else:
-            return test.FAIL("Unable to find any Devices which expose the control type '{}'".format(control_type))
+            return test.FAIL("Unable to find any Devices which expose the control type '{}'".format(type))

--- a/nmostesting/suites/IS0502Test.py
+++ b/nmostesting/suites/IS0502Test.py
@@ -309,8 +309,8 @@ class IS0502Test(GenericTest):
         return self.is05_utils.test_device_control_advertisement(
             test,
             self.node_url,
-            self.connection_url,
             control_type,
+            self.connection_url,
             self.authorization
         )
 

--- a/nmostesting/suites/IS0502Test.py
+++ b/nmostesting/suites/IS0502Test.py
@@ -305,34 +305,14 @@ class IS0502Test(GenericTest):
     def test_02(self, test):
         """At least one Device is showing an IS-05 control advertisement matching the API under test"""
 
-        valid, devices = self.do_request("GET", self.node_url + "devices")
-        if not valid:
-            return test.FAIL("Node API did not respond as expected: {}".format(devices))
-
-        is05_devices = []
-        found_api_match = False
-        try:
-            device_type = "urn:x-nmos:control:sr-ctrl/" + self.apis[CONN_API_KEY]["version"]
-            for device in devices.json():
-                controls = device["controls"]
-                for control in controls:
-                    if control["type"] == device_type:
-                        is05_devices.append(control["href"])
-                        if self.is05_utils.compare_urls(self.connection_url, control["href"]) and \
-                                self.authorization is control.get("authorization", False):
-                            found_api_match = True
-        except json.JSONDecodeError:
-            return test.FAIL("Non-JSON response returned from Node API")
-        except KeyError:
-            return test.FAIL("One or more Devices were missing the 'controls' attribute")
-
-        if len(is05_devices) > 0 and found_api_match:
-            return test.PASS()
-        elif len(is05_devices) > 0:
-            return test.FAIL("Found one or more Device controls, but no href and authorization mode matched the "
-                             "Connection API under test")
-        else:
-            return test.FAIL("Unable to find any Devices which expose the control type '{}'".format(device_type))
+        control_type = "urn:x-nmos:control:sr-ctrl/" + self.apis[CONN_API_KEY]["version"]
+        return self.is05_utils.test_device_control_advertisement(
+            test,
+            self.node_url,
+            self.connection_url,
+            control_type,
+            self.authorization
+        )
 
     def test_03(self, test):
         """Receivers shown in Connection API matches those shown in Node API"""

--- a/nmostesting/suites/IS0502Test.py
+++ b/nmostesting/suites/IS0502Test.py
@@ -306,7 +306,7 @@ class IS0502Test(GenericTest):
         """At least one Device is showing an IS-05 control advertisement matching the API under test"""
 
         control_type = "urn:x-nmos:control:sr-ctrl/" + self.apis[CONN_API_KEY]["version"]
-        return self.is05_utils.test_device_control_advertisement(
+        return self.is05_utils.do_test_device_control(
             test,
             self.node_url,
             control_type,

--- a/nmostesting/suites/IS0702Test.py
+++ b/nmostesting/suites/IS0702Test.py
@@ -637,6 +637,18 @@ class IS0702Test(GenericTest):
         else:
             return test.UNCLEAR("Not tested. No resources found.")
 
+    def test_07(self, test):
+        """At least one Device is showing an IS-07 control advertisement matching the API under test"""
+
+        control_type = "urn:x-nmos:control:events/" + self.apis[EVENTS_API_KEY]["version"]
+        return self.is04_utils.do_test_device_control(
+            test,
+            self.node_url,
+            control_type,
+            self.events_url,
+            self.authorization
+        )
+
     def get_websocket_connection_sources(self, test):
         """Returns a dictionary of WebSocket sources available for connection"""
         connection_sources = {}

--- a/nmostesting/suites/IS0802Test.py
+++ b/nmostesting/suites/IS0802Test.py
@@ -160,6 +160,7 @@ class IS0802Test(GenericTest):
 
         return self.get_is04_resources(resource_type)
 
+    # hm, see NMOSUtils.do_test_device_control
     def find_device_advertisement(self):
         test = globalConfig.test
 

--- a/nmostesting/suites/IS1101Test.py
+++ b/nmostesting/suites/IS1101Test.py
@@ -95,7 +95,7 @@ class IS1101Test(GenericTest):
         """At least one Device is showing an IS-11 control advertisement matching the API under test"""
 
         control_type = "urn:x-nmos:control:stream-compat/" + self.apis[COMPAT_API_KEY]["version"]
-        return NMOSUtils.test_device_control_advertisement(
+        return NMOSUtils.do_test_device_control(
             test,
             self.node_url,
             control_type,

--- a/nmostesting/suites/IS1101Test.py
+++ b/nmostesting/suites/IS1101Test.py
@@ -98,8 +98,8 @@ class IS1101Test(GenericTest):
         return NMOSUtils.test_device_control_advertisement(
             test,
             self.node_url,
-            self.compat_url,
             control_type,
+            self.compat_url,
             self.authorization
         )
 

--- a/nmostesting/suites/IS1101Test.py
+++ b/nmostesting/suites/IS1101Test.py
@@ -124,7 +124,6 @@ class IS1101Test(GenericTest):
         else:
             return test.FAIL("Unable to find any Devices which expose the control type '{}'".format(device_type))
 
-
     def test_00_02(self, test):
         "Put all senders into inactive state"
         senders_url = self.conn_url + "single/senders/"


### PR DESCRIPTION
Fixes the test that searches for IS-11 control advertisement in IS-04 APIs. For instance, this test fails with the following `controls`:
```
"controls": [
    {
        "href": "http://192.168.228.40:3215/x-nmos/connection/v1.0",
        "type": "urn:x-nmos:control:sr-ctrl/v1.0"
    },
    {
        "href": "http://192.168.100.40:3215/x-nmos/connection/v1.0",
        "type": "urn:x-nmos:control:sr-ctrl/v1.0"
    },
    {
        "href": "http://192.168.228.40:3215/x-nmos/connection/v1.1",
        "type": "urn:x-nmos:control:sr-ctrl/v1.1"
    },
    {
        "href": "http://192.168.100.40:3215/x-nmos/connection/v1.1",
        "type": "urn:x-nmos:control:sr-ctrl/v1.1"
    },
    {
        "href": "http://192.168.228.40:3216/x-nmos/events/v1.0",
        "type": "urn:x-nmos:control:events/v1.0"
    },
    {
        "href": "http://192.168.100.40:3216/x-nmos/events/v1.0",
        "type": "urn:x-nmos:control:events/v1.0"
    },
    {
        "href": "http://192.168.228.40:3215/x-nmos/channelmapping/v1.0",
        "type": "urn:x-nmos:control:cm-ctrl/v1.0"
    },
    {
        "href": "http://192.168.100.40:3215/x-nmos/channelmapping/v1.0",
        "type": "urn:x-nmos:control:cm-ctrl/v1.0"
    },
    {
        "href": "http://192.168.228.40:3218/x-nmos/streamcompatibility/v1.0",
        "type": "urn:x-nmos:control:stream-compat/v1.0"
    },
    {
        "href": "http://192.168.100.40:3218/x-nmos/streamcompatibility/v1.0",
        "type": "urn:x-nmos:control:stream-compat/v1.0"
    },
    {
        "href": "http://192.168.228.40:3212/x-manifest/",
        "type": "urn:x-nmos:control:manifest-base/v1.0"
    },
    {
        "href": "http://192.168.100.40:3212/x-manifest/",
        "type": "urn:x-nmos:control:manifest-base/v1.0"
    }

]
```