### PR TITLE
[IS-04-01] Much smaller zeroconf monkey patch

### DIFF
--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -58,7 +58,7 @@ from .mocks.Node import NODE, NODE_API
 from .mocks.Registry import NUM_REGISTRIES, REGISTRIES, REGISTRY_API
 from .mocks.System import NUM_SYSTEMS, SYSTEMS, SYSTEM_API
 from .mocks.Auth import AUTH_API, PRIMARY_AUTH, SECONDARY_AUTH
-from zeroconf_monkey import Zeroconf
+from zeroconf import Zeroconf
 
 # Make ANSI escape character sequences (for producing coloured terminal text) work under Windows
 try:

--- a/nmostesting/mocks/Auth.py
+++ b/nmostesting/mocks/Auth.py
@@ -29,7 +29,7 @@ from urllib.parse import parse_qs
 from ..Config import PORT_BASE, KEYS_MOCKS, ENABLE_HTTPS, CERT_TRUST_ROOT_CA, JWKS_URI, REDIRECT_URI, SCOPE, CACHE_PATH
 from ..TestHelper import get_default_ip, get_mocks_hostname, load_resolved_schema, check_content_type
 from ..IS10Utils import IS10Utils
-from zeroconf_monkey import ServiceInfo
+from zeroconf import ServiceInfo
 from enum import Enum
 from werkzeug.serving import make_server
 from http import HTTPStatus

--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -24,13 +24,17 @@ from dnslib import QTYPE
 from copy import deepcopy
 from collections import defaultdict
 from pathlib import Path
-from zeroconf_monkey import ServiceBrowser, ServiceInfo, Zeroconf
+from zeroconf import ServiceBrowser, ServiceInfo, Zeroconf
 
 from .. import Config as CONFIG
 from ..MdnsListener import MdnsListener
 from ..GenericTest import GenericTest, NMOSTestException, NMOS_WIKI_URL
 from ..IS04Utils import IS04Utils
 from ..TestHelper import get_default_ip, is_ip_address, load_resolved_schema, check_content_type
+
+# monkey patch zeroconf to allow us to advertise "_nmos-registration._tcp"
+from zeroconf import service_type_name
+service_type_name.__kwdefaults__['strict'] = False
 
 NODE_API_KEY = "node"
 RECEIVER_CAPS_KEY = "receiver-caps"

--- a/nmostesting/suites/IS0402Test.py
+++ b/nmostesting/suites/IS0402Test.py
@@ -22,7 +22,7 @@ from copy import deepcopy
 from time import sleep
 from jsonschema import ValidationError
 from urllib.parse import urlparse
-from zeroconf_monkey import ServiceBrowser, Zeroconf
+from zeroconf import ServiceBrowser, Zeroconf
 
 from .. import Config as CONFIG
 from ..MdnsListener import MdnsListener

--- a/nmostesting/suites/IS0403Test.py
+++ b/nmostesting/suites/IS0403Test.py
@@ -15,7 +15,7 @@
 import time
 import socket
 
-from zeroconf_monkey import ServiceBrowser, Zeroconf
+from zeroconf import ServiceBrowser, Zeroconf
 from ..MdnsListener import MdnsListener
 from ..GenericTest import GenericTest, NMOS_WIKI_URL
 from ..IS04Utils import IS04Utils

--- a/nmostesting/suites/IS0902Test.py
+++ b/nmostesting/suites/IS0902Test.py
@@ -14,7 +14,7 @@
 
 import time
 import socket
-from zeroconf_monkey import ServiceInfo, Zeroconf
+from zeroconf import ServiceInfo, Zeroconf
 
 from .. import Config as CONFIG
 from ..MdnsListener import MdnsListener

--- a/nmostesting/suites/IS1001Test.py
+++ b/nmostesting/suites/IS1001Test.py
@@ -21,7 +21,7 @@ from OpenSSL import crypto
 
 from ..GenericTest import GenericTest, NMOSTestException, NMOSInitException
 from .. import Config as CONFIG
-from zeroconf_monkey import ServiceBrowser, Zeroconf
+from zeroconf import ServiceBrowser, Zeroconf
 from ..MdnsListener import MdnsListener
 from ..TestHelper import check_content_type
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 flask>=2.0.0
 wtforms
 jsonschema
-zeroconf-monkey>=1.0.0
+zeroconf>=0.32.0
 requests
 netifaces
 gitpython


### PR DESCRIPTION
We can avoid zeroconf-monkey and adopt latest jstasiak/zeroconf, with a single-line monkey patch to be able to advertise the overlong service type "_nmos-registration._tcp".

![Marmoset](https://media.giphy.com/media/d7MZouissJKow/giphy.gif)
