### PR TITLE
Fix flake8/pycodestyle E721 do not compare types

### DIFF
--- a/utilities/dut-data-exporter/dutDataExporter.py
+++ b/utilities/dut-data-exporter/dutDataExporter.py
@@ -54,9 +54,9 @@ if __name__ == "__main__":
     response = requests.get(url)
     mac_addresses = response.json()["interfaces"]
     for address in mac_addresses:
-        if type(address["port_id"]) == str:
+        if isinstance(address["port_id"], str):
             address["port_id"] = address["port_id"].replace("-", ":")
-        if type(address["chassis_id"]) == str:
+        if isinstance(address["chassis_id"], str):
             address["chassis_id"] = address["chassis_id"].replace("-", ":")
     node_id = response.json()["id"]
     print("Host: {}".format(response.json()["description"]))


### PR DESCRIPTION
The lint action has just switched from flake8 6.0.0 (pycodestyle 2.10) to flake8 6.1.0 (pycodestyle 2.11) and that seems to mean it's reporting [E721](https://www.flake8rules.com/rules/E721.html) where it wasn't before.

Ah yes, it's in the changelog for pycodestyle:
> * E721: adjust handling of type comparison.  Allowed forms are now
>  ``isinstance(x, t)`` or ``type(x) is t``.  PR #1086, #1167.

https://github.com/PyCQA/pycodestyle/blob/abe69bb9e1f358d0f1ba71034bc66a43725d28c7/CHANGES.txt#L12-L13
