### PR TITLE
python-zeroconf 0.75.0 strict=False for _nmos-registration._tcp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 WORKDIR /home/nmos-testing
 ADD . .
@@ -7,9 +7,9 @@ ADD .git .git
 RUN apt-get update \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y wget \
-    && wget https://deb.nodesource.com/setup_14.x \
-    && chmod 755 setup_14.x \
-    && /home/nmos-testing/setup_14.x \
+    && wget https://deb.nodesource.com/setup_16.x \
+    && chmod 755 setup_16.x \
+    && /home/nmos-testing/setup_16.x \
     && apt-get install -y --no-install-recommends \
     gcc openssl libssl-dev wget ca-certificates avahi-daemon avahi-utils libnss-mdns libavahi-compat-libdnssd-dev \
     python3 python3-pip python3-dev nodejs \
@@ -26,7 +26,7 @@ RUN apt-get update \
     && rm v3.0.7.tar.gz \
     && npm config set unsafe-perm true \
     && npm install -g AMWA-TV/sdpoker#v0.3.0 \
-    && rm /home/nmos-testing/setup_14.x \
+    && rm /home/nmos-testing/setup_16.x \
     && apt-get remove -y wget \
     && apt-get clean -y --no-install-recommends \
     && apt-get autoclean -y --no-install-recommends \

--- a/docs/1.1. Installation - Local.md
+++ b/docs/1.1. Installation - Local.md
@@ -4,7 +4,7 @@
 
 Please ensure that the following dependencies are installed on your system first.
 
-- Python 3.6 or higher, including the 'pip' package manager
+- Python 3.8 or higher, including the 'pip' package manager
 - Git
 - [testssl.sh](https://testssl.sh) (required for BCP-003-01 testing, see our [README](../testssl/README.md) for instructions)
 - [OpenSSL](https://www.openssl.org/) (required for BCP-003-01 OCSP testing)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 flask>=2.0.0
 wtforms
 jsonschema
-zeroconf>=0.32.0
+zeroconf>=0.75.0
 requests
 netifaces
 gitpython


### PR DESCRIPTION
Resolve #828.

Could have just put `strict=False` on all the `register_service` calls that advertise the Registration API, but figured might as well pass `False` only when we believe that's necessary: for `_nmos-registration._tcp` and not for `_nmos-register._tcp`.