### PR TITLE
Pass IP address of API under test to testssl.sh

### DIFF
--- a/nmostesting/suites/BCP00301Test.py
+++ b/nmostesting/suites/BCP00301Test.py
@@ -56,7 +56,9 @@ class BCP00301Test(GenericTest):
                                       "--openssl-timeout",
                                       str(CONFIG.HTTP_TIMEOUT),
                                       "--add-ca",
-                                      CONFIG.CERT_TRUST_ROOT_CA
+                                      CONFIG.CERT_TRUST_ROOT_CA,
+                                      "--ip",
+                                      self.apis[SECURE_API_KEY]["ip"]
                                       ] + args + ["{}:{}".format(self.apis[SECURE_API_KEY]["hostname"],
                                                                  self.apis[SECURE_API_KEY]["port"])]
                                      )


### PR DESCRIPTION
So that same one is used by Python tests and testssl.sh tests