### PR TITLE
Mocks warm up

### DIFF
--- a/nmostesting/Config.py
+++ b/nmostesting/Config.py
@@ -19,6 +19,9 @@ import sys
 # Please consult the documentation for instructions on how to adjust these values for common testing setups including
 # unicast DNS-SD and HTTPS testing.
 
+# Number of seconds to wait after starting the mock DNS server, authorization server, etc. before running tests.
+# This gives the API or client under test a chance to use these services before any test case is run.
+MOCK_SERVICES_WARM_UP_DELAY = 0
 
 # Enable or disable DNS-SD advertisements. Browsing is always permitted.
 # The IS-04 Node tests create a mock registry on the network unless the `ENABLE_DNS_SD` parameter is set to `False`.

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -1142,7 +1142,7 @@ def main(args):
     # Give an API or client that is already running a chance to use the mock services
     # before running any test cases
     if CONFIG.MOCK_SERVICES_WARM_UP_DELAY:
-        print(" * Warm up your engines, testing begins in {} seconds..."
+        print(" * Waiting for {} seconds to allow discovery of mock services"
               .format(CONFIG.MOCK_SERVICES_WARM_UP_DELAY))
         time.sleep(CONFIG.MOCK_SERVICES_WARM_UP_DELAY)
 

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -1139,6 +1139,13 @@ def main(args):
     print(" * Testing tool running on 'http://{}:{}'. Version '{}'"
           .format(get_default_ip(), core_app.config['PORT'], TOOL_VERSION))
 
+    # Give an API or client that is already running a chance to use the mock services
+    # before running any test cases
+    if CONFIG.MOCK_SERVICES_WARM_UP_DELAY:
+        print(" * Warm up your engines, testing begins in {} seconds..."
+              .format(CONFIG.MOCK_SERVICES_WARM_UP_DELAY))
+        time.sleep(CONFIG.MOCK_SERVICES_WARM_UP_DELAY)
+
     exit_code = 0
     if "suite" not in vars(CMD_ARGS):
         # Interactive testing mode. Await user input.


### PR DESCRIPTION
This gives the API or client under test a chance to use the mock services before any test case is run.