### PR TITLE
Allow multiple URL parameters in auto tests endpoints.

### DIFF
--- a/nmostesting/GenericTest.py
+++ b/nmostesting/GenericTest.py
@@ -630,7 +630,8 @@ class GenericTest(object):
                 return test.WARNING("Warning for {}: {}".format(param_values, entity_message)
                                     if param_values else entity_message)
         if len(endpoints) == 0:
-            return test.UNCLEAR("Unable to test endpoint.")
+            # There were no saved entities found, so we can't test this parameterised URL
+            return test.UNCLEAR("No resources found to perform this test")
         return test.PASS()
 
     def check_api_resource(self, test, resource, response_code, api, path):


### PR DESCRIPTION
- This removes the current limitation of a single URL parameter in an endpoint URL when running auto tests.
- This is a problem for the emerging IS-14 API as this has endpoints with two URL parameters.
- This code is generalized to allow any number of URL parameters, simplifying the existing implementation.