### PR TITLE
[IS-11] Independent tests for Senders

### DIFF
--- a/nmostesting/IS11Utils.py
+++ b/nmostesting/IS11Utils.py
@@ -97,10 +97,17 @@ class IS11Utils(NMOSUtils, GenericTest):
             toReturn = r.text
         return toReturn
 
-    def get_flows(self, url, sender_id):
+    def get_flow(self, url, sender_id):
         """Get the flow for a given Sender"""
         toReturn = None
         valid, r = TestHelper.do_request("GET", url + "flows/" + sender_id)
+        if valid and r.status_code == 200:
+            toReturn = r.json()
+        return toReturn
+
+    def get_source(self, url, id):
+        toReturn = None
+        valid, r = TestHelper.do_request("GET", url + "sources/" + id)
         if valid and r.status_code == 200:
             toReturn = r.json()
         return toReturn

--- a/nmostesting/suites/IS1101Test.py
+++ b/nmostesting/suites/IS1101Test.py
@@ -225,7 +225,7 @@ class IS1101Test(GenericTest):
     def test_01_02(self, test):
         """Inputs with Base EDID support handle PUTting and DELETing the Base EDID"""
         def is_edid_equal_to_effective_edid(self, test, inputId, edid):
-            return self.get_effective_edid(test, inputId) == edid
+            return self.get_effective_edid(test, inputId) == edid, ""
 
         if len(self.base_edid_inputs) == 0:
             return test.UNCLEAR("Not tested. No inputs with Base EDID support found.")
@@ -454,10 +454,10 @@ class IS1101Test(GenericTest):
         """Effective EDID updates if Base EDID changes with 'adjust_to_caps'"""
 
         def is_edid_equal_to_effective_edid(self, test, inputId, edid):
-            return self.get_effective_edid(test, inputId) == edid
+            return self.get_effective_edid(test, inputId) == edid, ""
 
         def is_edid_inequal_to_effective_edid(self, test, inputId, edid):
-            return self.get_effective_edid(test, inputId) != edid
+            return self.get_effective_edid(test, inputId) != edid, ""
 
         if len(self.adjust_to_caps_inputs) == 0:
             return test.UNCLEAR("Not tested. No inputs with 'adjust_to_caps' support found.")
@@ -2469,11 +2469,13 @@ class IS1101Test(GenericTest):
         return response.content
 
     def wait_until_true(self, predicate):
+        err = ""
         for i in range(0, CONFIG.STABLE_STATE_ATTEMPTS):
-            if predicate():
+            result, err = predicate()
+            if result:
                 return True
             time.sleep(CONFIG.STABLE_STATE_DELAY)
-        return False
+        return False, err
 
     def has_sender_flow_format(self, sender_id, format):
         assert format in ["video", "audio"]
@@ -2664,7 +2666,8 @@ class IS1101Test(GenericTest):
                 "The streamcompatibility request for sender {} status has failed: {}"
                 .format(sender_id, response.json())
             )
-        return response.json()["state"] == expected
+        actual_state = response.json()["state"]
+        return actual_state == expected, actual_state
 
     def apply_nop_active_constraints(self, test, senders, make_active_constraints, source_attrs, flow_attrs):
         if len(senders) == 0:


### PR DESCRIPTION
test 2.0 -> `delete_active_constraints` called in `set_up_tests`
test 2.1 has been removed
test 2.1.1 has been refactored
test 2.2 has been removed
test 2.2.1 has been refactored
test 2.2.3 -> filling `{video,audio}_senders` in `set_up_tests`
tests 2.2.3.1, 2.2.3.2, 2.2.4.1, 2.2.4.2, 2.2.5.1, 2.2.5.2, 2.2.6.1, 2.2.6.2, 2.2.7.1, 2.2.7.2  have been refactored
test 2.3 -> filling `senders_with_inputs` in `set_up_tests`
test 2.3.1 stays as is
test 2.3.2 has been removed (duplicates tests 1.4 and 1.5)
test 2.3.3 has been removed (duplicates test 2.2.1)
test 2.3.4 has been removed (duplicates test 1.5)
tests 2.3.5.1, 2.3.5.2 were fixed (see code review suggestions in https://github.com/AMWA-TV/nmos-testing/pull/728)
test 2.4 has been removed (partially duplicates test 2.2.1)