### PR TITLE
IS0501Test.py: remove trailing slash from /staged endpoint for PATCH

### DIFF
--- a/nmostesting/suites/IS0501Test.py
+++ b/nmostesting/suites/IS0501Test.py
@@ -1210,7 +1210,7 @@ class IS0501Test(GenericTest):
         """
         if len(resources) > 0:
             for resource in resources:
-                dest_staged = "single/" + resourceType + "/" + resource + "/staged/"
+                dest_staged = "single/" + resourceType + "/" + resource + "/staged"
                 dest_active = "single/" + resourceType + "/" + resource + "/active/"
 
                 valid, response = self.is05_utils.checkCleanRequestJSON("GET", dest_staged)


### PR DESCRIPTION
per https://specs.amwa.tv/is-05/releases/v1.1.2/docs/Controllers.html

Controllers performing requests other than GET or HEAD (i.e PUT, POST, DELETE, OPTIONS etc.) MUST use URLs with no trailing slash present.

Currently, test_11_02 and test_12_02 will fail on a node that returns 405: method not allowed for a PATCH on the /staged/ endpoint