### PR TITLE
Fix linting error due to upgrade of flake8

### DIFF
--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -464,7 +464,6 @@ class DataForm(Form):
 # Index page
 @core_app.route('/', methods=["GET", "POST"])
 def index_page():
-    global CMD_ARGS
     form = DataForm(request.form)
     if request.method == "POST" and not core_app.config['TEST_ACTIVE']:
         if form.validate():


### PR DESCRIPTION
- This linting error has been trapped by the upgrade of flake8 from 7.1.2 -> 7.2.0
- This error has been extant for 5+ years and has only trapped by the upgrade to flake8.
- Remove `global CMD_ARGS` statement as it is unused: name is never assigned in scope.
- This error will fail the linting of all current pull requests that are in flight.