### PR TITLE
Refactor Testing Facade out of Controller Tests into utility class

### DIFF
--- a/nmostesting/Config.py
+++ b/nmostesting/Config.py
@@ -397,7 +397,7 @@ SPECIFICATIONS = {
             }
         }
     },
-    "controller-tests": {
+    "testing-facade": {
         "repo": None,
         "versions": ["v1.0"],
         "default_version": "v1.0",

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -102,9 +102,6 @@ class ControllerTest(GenericTest):
 
         self.testing_facade_utils.reset()
 
-        # Reset the state of the Testing Façade
-        self.do_request("POST", self.apis[TESTING_FACADE_API_KEY]["url"], json={"clear": "True"})
-
         if self.dns_server:
             self.dns_server.reset()
 
@@ -451,7 +448,7 @@ class ControllerTest(GenericTest):
                    """)
 
         try:
-            self.testing_facade_utils.invoke_testing_facade(question, [], test_type="action", calling_test=self)
+            self.testing_facade_utils.invoke_testing_facade(question, [], test_type="action")
 
         except TestingFacadeException:
             # pre_test_introducton timed out
@@ -470,7 +467,7 @@ class ControllerTest(GenericTest):
                    """
 
         try:
-            self.testing_facade_utils.invoke_testing_facade(question, [], test_type="action", calling_test=self)
+            self.testing_facade_utils.invoke_testing_facade(question, [], test_type="action")
 
         except TestingFacadeException:
             # post_test_introducton timed out

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -12,17 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import time
 import json
 import uuid
-import inspect
 import random
 import textwrap
 from copy import deepcopy
 from urllib.parse import urlparse
 from dnslib import QTYPE
-from threading import Event
 
 from .GenericTest import GenericTest, NMOSTestException, NMOSInitException
 from . import Config as CONFIG
@@ -31,9 +28,7 @@ from .TestResult import Test
 from .NMOSUtils import NMOSUtils
 from .TestingFacadeUtils import TestingFacadeUtils, TestingFacadeException
 
-from flask import Flask, Blueprint, request
-
-CONTROLLER_TEST_API_KEY = "testquestion"
+TESTING_FACADE_API_KEY = "testquestion"
 QUERY_API_KEY = "query"
 CONN_API_KEY = "connection"
 REG_API_KEY = "registration"
@@ -45,7 +40,7 @@ class ControllerTest(GenericTest):
     """
     def __init__(self, apis, registries, node, dns_server, auths, disable_auto=True, **kwargs):
         # Remove the spec_path as there are no corresponding GitHub repos for Controller Tests
-        apis[CONTROLLER_TEST_API_KEY].pop("spec_path", None)
+        apis[TESTING_FACADE_API_KEY].pop("spec_path", None)
         # Ensure registration scope is added to JWT to allow authenticated
         # registration of mock resources with secure mock registry
         if CONFIG.ENABLE_AUTH:
@@ -108,7 +103,7 @@ class ControllerTest(GenericTest):
         self.testing_facade_utils.reset()
 
         # Reset the state of the Testing Façade
-        self.do_request("POST", self.apis[CONTROLLER_TEST_API_KEY]["url"], json={"clear": "True"})
+        self.do_request("POST", self.apis[TESTING_FACADE_API_KEY]["url"], json={"clear": "True"})
 
         if self.dns_server:
             self.dns_server.reset()

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -29,6 +29,7 @@ from . import Config as CONFIG
 from .TestHelper import get_default_ip, get_mocks_hostname
 from .TestResult import Test
 from .NMOSUtils import NMOSUtils
+from .TestingFacadeUtils import TestingFacadeUtils, TestingFacadeException
 
 from flask import Flask, Blueprint, request
 
@@ -36,41 +37,6 @@ CONTROLLER_TEST_API_KEY = "testquestion"
 QUERY_API_KEY = "query"
 CONN_API_KEY = "connection"
 REG_API_KEY = "registration"
-
-CALLBACK_ENDPOINT = "/x-nmos/testanswer/<version>"
-
-# asyncio queue for passing Testing Façade answer responses back to tests
-_event_loop = asyncio.new_event_loop()
-asyncio.set_event_loop(_event_loop)
-_answer_response_queue = asyncio.Queue()
-
-# use exit Event to quit tests early that involve waiting for senders/connections
-exitTestEvent = Event()
-
-app = Flask(__name__)
-TEST_API = Blueprint('test_api', __name__)
-
-
-class TestingFacadeException(Exception):
-    """Exception thrown due to comms or data errors between NMOS Testing and Testing Façade"""
-    pass
-
-
-@TEST_API.route(CALLBACK_ENDPOINT, methods=['POST'])
-def receive_answer(version):
-
-    if request.method == 'POST':
-        if 'question_id' not in request.json:
-            return 'Invalid JSON received', 400
-
-        answer_json = request.json
-        answer_json['time_received'] = time.time()
-        _event_loop.call_soon_threadsafe(_answer_response_queue.put_nowait, answer_json)
-
-        # Interrupt any 'sleeps' that are still active
-        exitTestEvent.set()
-
-    return '', 202
 
 
 class ControllerTest(GenericTest):
@@ -84,15 +50,8 @@ class ControllerTest(GenericTest):
         # registration of mock resources with secure mock registry
         if CONFIG.ENABLE_AUTH:
             apis[REG_API_KEY] = {}
-        if CONFIG.ENABLE_HTTPS:
-            # Comms with Testing Facade are http only
-            if apis[CONTROLLER_TEST_API_KEY]["base_url"] is not None:
-                apis[CONTROLLER_TEST_API_KEY]["base_url"] \
-                    = apis[CONTROLLER_TEST_API_KEY]["base_url"].replace("https", "http")
-            if apis[CONTROLLER_TEST_API_KEY]["url"] is not None:
-                apis[CONTROLLER_TEST_API_KEY]["url"] \
-                    = apis[CONTROLLER_TEST_API_KEY]["url"].replace("https", "http")
         GenericTest.__init__(self, apis, auths=auths, disable_auto=disable_auto, **kwargs)
+        self.testing_facade_utils = TestingFacadeUtils(apis)
         self.primary_registry = registries[1] if registries else None
         self.node = node
         self.dns_server = dns_server
@@ -109,10 +68,6 @@ class ControllerTest(GenericTest):
             if QUERY_API_KEY in apis and "version" in self.apis[QUERY_API_KEY] else "v1.3"
         self.connection_api_version = self.apis[CONN_API_KEY]["version"] \
             if CONN_API_KEY in apis and "version" in self.apis[CONN_API_KEY] else "v1.1"
-        self.qa_api_version = self.apis[CONTROLLER_TEST_API_KEY]["version"] \
-            if CONTROLLER_TEST_API_KEY in apis and "version" in self.apis[CONTROLLER_TEST_API_KEY] else "v1.0"
-        self.answer_uri = "http://" + get_default_ip() + ":" + str(CONFIG.PORT_BASE) + \
-            CALLBACK_ENDPOINT.replace('<version>', self.qa_api_version)
 
     def set_up_tests(self):
         test = Test("Test setup", "set_up_tests")
@@ -150,6 +105,8 @@ class ControllerTest(GenericTest):
         if self.primary_registry:
             self.primary_registry.disable()
 
+        self.testing_facade_utils.reset()
+
         # Reset the state of the Testing Façade
         self.do_request("POST", self.apis[CONTROLLER_TEST_API_KEY]["url"], json={"clear": "True"})
 
@@ -174,96 +131,7 @@ class ControllerTest(GenericTest):
 
         self.post_tests_message()
 
-    async def get_answer_response(self, timeout):
-        # Add API processing time to specified timeout
-        # Otherwise, if timeout is None then disable timeout mechanism
-        timeout = timeout + (2 * CONFIG.API_PROCESSING_TIMEOUT) if timeout is not None else None
-
-        return await asyncio.wait_for(_answer_response_queue.get(), timeout=timeout)
-
-    def _send_testing_facade_questions(
-            self,
-            test_method_name,
-            question,
-            answers,
-            test_type,
-            multipart_test=None,
-            metadata=None):
-        """
-        Send question and answers to Testing Façade
-        question:   text to be presented to Test User
-        answers:    list of all possible answers
-        test_type:  "single_choice" - one and only one answer
-                    "multi_choice" - multiple answers
-                    "action" - Test User asked to click button
-        multipart_test: indicates test uses multiple questions. Default None, should be increasing
-                    integers with each subsequent call within the same test
-        metadata: Test details to assist fully automated testing
-        """
-
-        method = getattr(self, test_method_name)
-
-        timeout = CONFIG.CONTROLLER_TESTING_TIMEOUT
-
-        question_id = test_method_name if not multipart_test else test_method_name + '_' + str(multipart_test)
-
-        json_out = {
-            "test_type": test_type,
-            "question_id": question_id,
-            "name": test_method_name,
-            "description": inspect.getdoc(method),
-            "question": question,
-            "answers": answers,
-            "timeout": timeout,
-            "answer_uri": self.answer_uri,
-            "metadata": metadata
-        }
-        # Send questions to Testing Façade API endpoint then wait
-        valid, response = self.do_request("POST", self.apis[CONTROLLER_TEST_API_KEY]["url"], json=json_out)
-
-        if not valid or response.status_code != 202:
-            raise TestingFacadeException("Problem contacting Testing Façade: " + response.text if valid else response)
-
-        return json_out
-
-    def _wait_for_testing_facade(self, question_id, test_type):
-
-        # Wait for answer response or question timeout in seconds. A timeout of None will wait indefinitely
-        timeout = CONFIG.CONTROLLER_TESTING_TIMEOUT
-
-        try:
-            answer_response = _event_loop.run_until_complete(self.get_answer_response(timeout))
-        except asyncio.TimeoutError:
-            raise TestingFacadeException("Test timed out")
-
-        # Basic integrity check for response json
-        if answer_response['question_id'] is None:
-            raise TestingFacadeException("Integrity check failed: result format error: "
-                                         + json.dump(answer_response))
-
-        if answer_response['question_id'] != question_id:
-            raise TestingFacadeException(
-                "Integrity check failed: cannot compare result of " + question_id +
-                " with expected result for " + answer_response['question_id'])
-
-        # Multi_choice question submitted without any answers should be an empty list
-        if test_type == 'multi_choice' and answer_response['answer_response'] is None:
-            answer_response['answer_response'] = []
-
-        return answer_response
-
-    def _invoke_testing_facade(self, question, answers, test_type,
-                               multipart_test=None, metadata=None, test_method_name=None):
-        # Get the name of the calling test method to use as an identifier
-        test_method_name = test_method_name if test_method_name \
-            else inspect.currentframe().f_back.f_code.co_name
-
-        json_out = self._send_testing_facade_questions(
-            test_method_name, question, answers, test_type, multipart_test, metadata)
-
-        return self._wait_for_testing_facade(json_out['question_id'], test_type)
-
-    def _generate_random_indices(self, index_range, min_index_count=2, max_index_count=4):
+    def generate_random_indices(self, index_range, min_index_count=2, max_index_count=4):
         """
         index_range: number of possible indices
         min_index_count, max_index_count: Minimum, maximum number of indices to be returned.
@@ -482,7 +350,7 @@ class ControllerTest(GenericTest):
         sender_data = self._create_sender_json(sender)
         self.post_resource(test, "sender", sender_data, codes=codes, fail=fail)
 
-    def _delete_sender(self, test, sender):
+    def delete_sender(self, test, sender):
         del_url = self.mock_registry_base_url + 'x-nmos/registration/v1.3/resource/senders/' + sender['id']
 
         valid, r = self.do_request("DELETE", del_url)
@@ -588,7 +456,7 @@ class ControllerTest(GenericTest):
                    """)
 
         try:
-            self._invoke_testing_facade(question, [], test_type="action")
+            self.testing_facade_utils.invoke_testing_facade(question, [], test_type="action", calling_test=self)
 
         except TestingFacadeException:
             # pre_test_introducton timed out
@@ -607,7 +475,7 @@ class ControllerTest(GenericTest):
                    """
 
         try:
-            self._invoke_testing_facade(question, [], test_type="action")
+            self.testing_facade_utils.invoke_testing_facade(question, [], test_type="action", calling_test=self)
 
         except TestingFacadeException:
             # post_test_introducton timed out

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -39,7 +39,7 @@ class ControllerTest(GenericTest):
     Testing initial set up of new test suite for controller testing
     """
     def __init__(self, apis, registries, node, dns_server, auths, disable_auto=True, **kwargs):
-        # Remove the spec_path as there are no corresponding GitHub repos for Controller Tests
+        # Remove the Testing Facade spec_path as there are no corresponding GitHub repos for the Testing Facade API
         apis[TESTING_FACADE_API_KEY].pop("spec_path", None)
         # Ensure registration scope is added to JWT to allow authenticated
         # registration of mock resources with secure mock registry

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -48,7 +48,7 @@ from requests.compat import json
 from . import Config as CONFIG
 from .DNS import DNS
 from .GenericTest import NMOSInitException
-from . import ControllerTest
+from . import TestingFacadeUtils
 from .TestResult import TestStates
 from .TestHelper import get_default_ip
 from .NMOSUtils import DEFAULT_ARGS
@@ -108,7 +108,7 @@ core_app.config['TEST_ACTIVE'] = False
 core_app.config['PORT'] = CONFIG.PORT_BASE
 core_app.config['SECURE'] = False
 core_app.register_blueprint(NODE_API)  # Dependency for IS0401Test
-core_app.register_blueprint(ControllerTest.TEST_API)
+core_app.register_blueprint(TestingFacadeUtils.TEST_API)
 FLASK_APPS.append(core_app)
 
 for instance in range(NUM_REGISTRIES):

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -48,7 +48,7 @@ from requests.compat import json
 from . import Config as CONFIG
 from .DNS import DNS
 from .GenericTest import NMOSInitException
-from . import TestingFacadeUtils
+from . import ControllerTest
 from .TestResult import TestStates
 from .TestHelper import get_default_ip
 from .NMOSUtils import DEFAULT_ARGS
@@ -108,7 +108,7 @@ core_app.config['TEST_ACTIVE'] = False
 core_app.config['PORT'] = CONFIG.PORT_BASE
 core_app.config['SECURE'] = False
 core_app.register_blueprint(NODE_API)  # Dependency for IS0401Test
-core_app.register_blueprint(TestingFacadeUtils.TEST_API)
+core_app.register_blueprint(ControllerTest.TEST_API)
 FLASK_APPS.append(core_app)
 
 for instance in range(NUM_REGISTRIES):
@@ -217,7 +217,7 @@ TEST_DEFINITIONS = {
     "IS-04-04": {
         "name": "IS-04 Controller",
         "specs": [{
-            "spec_key": "controller-tests",
+            "spec_key": "testing-facade",
             "api_key": "testquestion"
         }, {
             "spec_key": "is-04",
@@ -248,7 +248,7 @@ TEST_DEFINITIONS = {
     "IS-05-03": {
         "name": "IS-05 Controller",
         "specs": [{
-            "spec_key": "controller-tests",
+            "spec_key": "testing-facade",
             "api_key": "testquestion"
         }, {
             "spec_key": "is-04",
@@ -372,7 +372,7 @@ TEST_DEFINITIONS = {
             "api_key": "controlframework",
             "disable_fields": ["host", "port", "urlpath"]
         }, {
-            "spec_key": "controller-tests",
+            "spec_key": "testing-facade",
             "api_key": "testquestion",
             "disable_fields": ["urlpath"] if CONFIG.MS05_INTERACTIVE_TESTING else ["host", "port", "urlpath"]
         }],
@@ -417,7 +417,7 @@ TEST_DEFINITIONS = {
     "BCP-006-01-02": {
         "name": "BCP-006-01 Controller",
         "specs": [{
-            "spec_key": "controller-tests",
+            "spec_key": "testing-facade",
             "api_key": "testquestion"
         }, {
             "spec_key": "is-04",

--- a/nmostesting/TestingFacadeUtils.py
+++ b/nmostesting/TestingFacadeUtils.py
@@ -1,0 +1,184 @@
+# Copyright (C) 2025 Advanced Media Workflow Association
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import time
+import json
+import inspect
+from threading import Event
+
+from . import Config as CONFIG
+from .TestHelper import do_request, get_default_ip
+
+from flask import Flask, Blueprint, request
+
+CONTROLLER_TEST_API_KEY = "testquestion"
+QUERY_API_KEY = "query"
+CONN_API_KEY = "connection"
+REG_API_KEY = "registration"
+
+CALLBACK_ENDPOINT = "/x-nmos/testanswer/<version>"
+
+# asyncio queue for passing Testing Facade answer responses back to tests
+_event_loop = asyncio.new_event_loop()
+asyncio.set_event_loop(_event_loop)
+_answer_response_queue = asyncio.Queue()
+
+# use exit Event to quit tests early that involve waiting for senders/connections
+exitTestEvent = Event()
+
+app = Flask(__name__)
+TEST_API = Blueprint('test_api', __name__)
+
+
+class TestingFacadeException(Exception):
+    """Exception thrown due to comms or data errors between NMOS Testing and Testing Facade"""
+    pass
+
+
+@TEST_API.route(CALLBACK_ENDPOINT, methods=['POST'])
+def receive_answer(version):
+
+    if request.method == 'POST':
+        if 'question_id' not in request.json:
+            return 'Invalid JSON received', 400
+
+        answer_json = request.json
+        answer_json['time_received'] = time.time()
+        _event_loop.call_soon_threadsafe(_answer_response_queue.put_nowait, answer_json)
+
+        # Interrupt any 'sleeps' that are still active
+        exitTestEvent.set()
+
+    return '', 202
+
+
+class TestingFacadeUtils(object):
+    """
+    Testing initial set up of new test suite for controller testing
+    """
+    def __init__(self, apis):
+        self.apis = apis
+        if CONFIG.ENABLE_HTTPS:
+            # Comms with Testing Facade are http only
+            if apis[CONTROLLER_TEST_API_KEY]["base_url"] is not None:
+                apis[CONTROLLER_TEST_API_KEY]["base_url"] \
+                    = apis[CONTROLLER_TEST_API_KEY]["base_url"].replace("https", "http")
+            if apis[CONTROLLER_TEST_API_KEY]["url"] is not None:
+                apis[CONTROLLER_TEST_API_KEY]["url"] \
+                    = apis[CONTROLLER_TEST_API_KEY]["url"].replace("https", "http")
+        qa_api_version = self.apis[CONTROLLER_TEST_API_KEY]["version"] \
+            if CONTROLLER_TEST_API_KEY in apis and "version" in self.apis[CONTROLLER_TEST_API_KEY] else "v1.0"
+        self.answer_uri = "http://" + get_default_ip() + ":" + str(CONFIG.PORT_BASE) + \
+            CALLBACK_ENDPOINT.replace('<version>', qa_api_version)
+
+    def reset(self):
+        # Reset the state of the Testing Facade
+        do_request("POST", self.apis[CONTROLLER_TEST_API_KEY]["url"], json={"clear": "True"})
+
+    async def get_answer_response(self, timeout):
+        # Add API processing time to specified timeout
+        # Otherwise, if timeout is None then disable timeout mechanism
+        timeout = timeout + (2 * CONFIG.API_PROCESSING_TIMEOUT) if timeout is not None else None
+
+        return await asyncio.wait_for(_answer_response_queue.get(), timeout=timeout)
+
+    def send_testing_facade_questions(
+            self,
+            test_method_name,
+            question,
+            answers,
+            test_type,
+            calling_test,
+            multipart_test=None,
+            metadata=None):
+        """
+        Send question and answers to Testing Facade
+        question:   text to be presented to Test User
+        answers:    list of all possible answers
+        test_type:  "single_choice" - one and only one answer
+                    "multi_choice" - multiple answers
+                    "action" - Test User asked to click button
+        multipart_test: indicates test uses multiple questions. Default None, should be increasing
+                    integers with each subsequent call within the same test
+        metadata: Test details to assist fully automated testing
+        """
+
+        method = getattr(calling_test, test_method_name)
+
+        timeout = CONFIG.CONTROLLER_TESTING_TIMEOUT
+
+        question_id = test_method_name if not multipart_test else test_method_name + '_' + str(multipart_test)
+
+        json_out = {
+            "test_type": test_type,
+            "question_id": question_id,
+            "name": test_method_name,
+            "description": inspect.getdoc(method),
+            "question": question,
+            "answers": answers,
+            "timeout": timeout,
+            "answer_uri": self.answer_uri,
+            "metadata": metadata
+        }
+        # Send questions to Testing Facade API endpoint then wait
+        valid, response = do_request("POST", self.apis[CONTROLLER_TEST_API_KEY]["url"], json=json_out)
+
+        if not valid or response.status_code != 202:
+            raise TestingFacadeException("Problem contacting Testing Facade: " + response.text if valid else response)
+
+        return json_out
+
+    def wait_for_testing_facade(self, question_id, test_type):
+
+        # Wait for answer response or question timeout in seconds. A timeout of None will wait indefinitely
+        timeout = CONFIG.CONTROLLER_TESTING_TIMEOUT
+
+        try:
+            answer_response = _event_loop.run_until_complete(self.get_answer_response(timeout))
+        except asyncio.TimeoutError:
+            raise TestingFacadeException("Test timed out")
+
+        # Basic integrity check for response json
+        if answer_response['question_id'] is None:
+            raise TestingFacadeException("Integrity check failed: result format error: "
+                                         + json.dump(answer_response))
+
+        if answer_response['question_id'] != question_id:
+            raise TestingFacadeException(
+                "Integrity check failed: cannot compare result of " + question_id +
+                " with expected result for " + answer_response['question_id'])
+
+        # Multi_choice question submitted without any answers should be an empty list
+        if test_type == 'multi_choice' and answer_response['answer_response'] is None:
+            answer_response['answer_response'] = []
+
+        return answer_response
+
+    def invoke_testing_facade(self, question, answers, test_type, calling_test,
+                               multipart_test=None, metadata=None, test_method_name=None):
+        # Get the name of the calling test method to use as an identifier
+        test_method_name = test_method_name if test_method_name \
+            else inspect.currentframe().f_back.f_code.co_name
+
+        json_out = self.send_testing_facade_questions(
+            test_method_name, question, answers, test_type, calling_test, multipart_test, metadata)
+
+        return self.wait_for_testing_facade(json_out['question_id'], test_type)
+
+    def exit_test_event_clear(self):
+        exitTestEvent.clear()
+
+    def exit_test_event_wait(self, time_delay):
+        exitTestEvent.wait(time_delay)

--- a/nmostesting/suites/BCP0060102Test.py
+++ b/nmostesting/suites/BCP0060102Test.py
@@ -715,8 +715,8 @@ class BCP0060102Test(ControllerTest):
             expected_answers = ['answer_'+str(i) for i, r in enumerate(candidate_senders)
                                 if 'video/jxsv' == r['sdp_params']['media_type']]
 
-            actual_answers = self._invoke_testing_facade(
-                question, possible_answers, test_type='multi_choice')['answer_response']
+            actual_answers = self.testing_facade_utils.invoke_testing_facade(
+                question, possible_answers, test_type='multi_choice', calling_test=self)['answer_response']
 
             actual = set(actual_answers)
             expected = set(expected_answers)
@@ -773,8 +773,8 @@ class BCP0060102Test(ControllerTest):
             expected_answers = ['answer_'+str(i) for i, r in enumerate(candidate_receivers)
                                 if 'video/jxsv' in r['caps']['media_types']]
 
-            actual_answers = self._invoke_testing_facade(
-                question, possible_answers, test_type='multi_choice')['answer_response']
+            actual_answers = self.testing_facade_utils.invoke_testing_facade(
+                question, possible_answers, test_type='multi_choice', calling_test=self)['answer_response']
 
             actual = set(actual_answers)
             expected = set(expected_answers)
@@ -845,8 +845,8 @@ class BCP0060102Test(ControllerTest):
                 expected_answers = ['answer_'+str(i) for i, r in enumerate(candidate_receivers)
                                     if self._is_compatible(sender, r)]
 
-                actual_answers = self._invoke_testing_facade(
-                    question, possible_answers, test_type='multi_choice', multipart_test=i)['answer_response']
+                actual_answers = self.testing_facade_utils.invoke_testing_facade(
+                    question, possible_answers, test_type='multi_choice', calling_test=self, multipart_test=i)['answer_response']
 
                 actual = set(actual_answers)
                 expected = set(expected_answers)
@@ -921,8 +921,8 @@ class BCP0060102Test(ControllerTest):
                 expected_answers = ['answer_'+str(i) for i, s in enumerate(candidate_senders)
                                     if self._is_compatible(s, receiver)]
 
-                actual_answers = self._invoke_testing_facade(
-                    question, possible_answers, test_type='multi_choice', multipart_test=i)['answer_response']
+                actual_answers = self.testing_facade_utils.invoke_testing_facade(
+                    question, possible_answers, test_type='multi_choice', calling_test=self, multipart_test=i)['answer_response']
 
                 actual = set(actual_answers)
                 expected = set(expected_answers)
@@ -998,7 +998,7 @@ class BCP0060102Test(ControllerTest):
                              'label': receiver['label'],
                              'description': receiver['description']}}
 
-                self._invoke_testing_facade(question, possible_answers, test_type='action', metadata=metadata)
+                self.testing_facade_utils.invoke_testing_facade(question, possible_answers, test_type='action', calling_test=self, metadata=metadata)
 
                 # Check the staged API endpoint received the correct PATCH request
                 patch_requests = [r for r in self.node.staged_requests

--- a/nmostesting/suites/BCP0060102Test.py
+++ b/nmostesting/suites/BCP0060102Test.py
@@ -27,7 +27,7 @@ class BCP0060102Test(ControllerTest):
     Runs Controller Tests covering BCP-006-01
     """
     def __init__(self, apis, registries, node, dns_server, **kwargs):
-        ControllerTest.__init__(self, apis, registries, node, dns_server)
+        ControllerTest.__init__(self, apis, registries, node, dns_server, **kwargs)
 
     def _create_interop_point(self, sdp_base, override_params):
         interop_point = {**sdp_base, **override_params}
@@ -846,7 +846,8 @@ class BCP0060102Test(ControllerTest):
                                     if self._is_compatible(sender, r)]
 
                 actual_answers = self.testing_facade_utils.invoke_testing_facade(
-                    question, possible_answers, test_type='multi_choice', calling_test=self, multipart_test=i)['answer_response']
+                    question, possible_answers, test_type='multi_choice',
+                    calling_test=self, multipart_test=i)['answer_response']
 
                 actual = set(actual_answers)
                 expected = set(expected_answers)
@@ -922,7 +923,8 @@ class BCP0060102Test(ControllerTest):
                                     if self._is_compatible(s, receiver)]
 
                 actual_answers = self.testing_facade_utils.invoke_testing_facade(
-                    question, possible_answers, test_type='multi_choice', calling_test=self, multipart_test=i)['answer_response']
+                    question, possible_answers, test_type='multi_choice',
+                    calling_test=self, multipart_test=i)['answer_response']
 
                 actual = set(actual_answers)
                 expected = set(expected_answers)
@@ -998,7 +1000,8 @@ class BCP0060102Test(ControllerTest):
                              'label': receiver['label'],
                              'description': receiver['description']}}
 
-                self.testing_facade_utils.invoke_testing_facade(question, possible_answers, test_type='action', calling_test=self, metadata=metadata)
+                self.testing_facade_utils.invoke_testing_facade(question, possible_answers, test_type='action',
+                                                                calling_test=self, metadata=metadata)
 
                 # Check the staged API endpoint received the correct PATCH request
                 patch_requests = [r for r in self.node.staged_requests

--- a/nmostesting/suites/BCP0060102Test.py
+++ b/nmostesting/suites/BCP0060102Test.py
@@ -716,7 +716,7 @@ class BCP0060102Test(ControllerTest):
                                 if 'video/jxsv' == r['sdp_params']['media_type']]
 
             actual_answers = self.testing_facade_utils.invoke_testing_facade(
-                question, possible_answers, test_type='multi_choice', calling_test=self)['answer_response']
+                question, possible_answers, test_type='multi_choice')['answer_response']
 
             actual = set(actual_answers)
             expected = set(expected_answers)
@@ -774,7 +774,7 @@ class BCP0060102Test(ControllerTest):
                                 if 'video/jxsv' in r['caps']['media_types']]
 
             actual_answers = self.testing_facade_utils.invoke_testing_facade(
-                question, possible_answers, test_type='multi_choice', calling_test=self)['answer_response']
+                question, possible_answers, test_type='multi_choice')['answer_response']
 
             actual = set(actual_answers)
             expected = set(expected_answers)
@@ -846,8 +846,7 @@ class BCP0060102Test(ControllerTest):
                                     if self._is_compatible(sender, r)]
 
                 actual_answers = self.testing_facade_utils.invoke_testing_facade(
-                    question, possible_answers, test_type='multi_choice',
-                    calling_test=self, multipart_test=i)['answer_response']
+                    question, possible_answers, test_type='multi_choice', multipart_test=i)['answer_response']
 
                 actual = set(actual_answers)
                 expected = set(expected_answers)
@@ -923,8 +922,7 @@ class BCP0060102Test(ControllerTest):
                                     if self._is_compatible(s, receiver)]
 
                 actual_answers = self.testing_facade_utils.invoke_testing_facade(
-                    question, possible_answers, test_type='multi_choice',
-                    calling_test=self, multipart_test=i)['answer_response']
+                    question, possible_answers, test_type='multi_choice', multipart_test=i)['answer_response']
 
                 actual = set(actual_answers)
                 expected = set(expected_answers)
@@ -1000,8 +998,8 @@ class BCP0060102Test(ControllerTest):
                              'label': receiver['label'],
                              'description': receiver['description']}}
 
-                self.testing_facade_utils.invoke_testing_facade(question, possible_answers, test_type='action',
-                                                                calling_test=self, metadata=metadata)
+                self.testing_facade_utils.invoke_testing_facade(question, possible_answers,
+                                                                test_type='action', metadata=metadata)
 
                 # Check the staged API endpoint received the correct PATCH request
                 patch_requests = [r for r in self.node.staged_requests

--- a/nmostesting/suites/IS0404Test.py
+++ b/nmostesting/suites/IS0404Test.py
@@ -104,7 +104,7 @@ class IS0404Test(ControllerTest):
 
                        Successful browsing of the Registry will be automatically logged by the test framework.
                        """
-            self.testing_facade_utils.invoke_testing_facade(question, [], test_type="action", calling_test=self)
+            self.testing_facade_utils.invoke_testing_facade(question, [], test_type="action")
 
             # Fail if the REST Query API was not called, and no query subscriptions were made
             # The registry will log calls to the Query API endpoints
@@ -148,7 +148,7 @@ class IS0404Test(ControllerTest):
             expected_answers = ['answer_'+str(i) for i, s in enumerate(self.senders) if s['registered']]
 
             actual_answers = self.testing_facade_utils.invoke_testing_facade(
-                question, possible_answers, test_type="multi_choice", calling_test=self)['answer_response']
+                question, possible_answers, test_type="multi_choice")['answer_response']
 
             if len(actual_answers) != len(expected_answers):
                 return test.FAIL('Incorrect sender identified')
@@ -195,7 +195,7 @@ class IS0404Test(ControllerTest):
             expected_answers = ['answer_'+str(i) for i, r in enumerate(self.receivers) if r['registered']]
 
             actual_answers = self.testing_facade_utils.invoke_testing_facade(
-                question, possible_answers, test_type="multi_choice", calling_test=self)['answer_response']
+                question, possible_answers, test_type="multi_choice")['answer_response']
 
             if len(actual_answers) != len(expected_answers):
                 return test.FAIL('Incorrect receiver identified')
@@ -240,8 +240,7 @@ class IS0404Test(ControllerTest):
                        """
             possible_answers = []
 
-            self.testing_facade_utils.invoke_testing_facade(question, possible_answers,
-                                                            test_type="action", calling_test=self)
+            self.testing_facade_utils.invoke_testing_facade(question, possible_answers, test_type="action")
 
             # Take one of the senders offline
             possible_answers = [{'answer_id': 'answer_'+str(i), 'display_answer': s['display_answer'],
@@ -261,8 +260,7 @@ class IS0404Test(ControllerTest):
             question = 'Please refresh your NCuT and select the sender which has been put \'offline\'.'
 
             actual_answer = self.testing_facade_utils.invoke_testing_facade(
-                question, possible_answers, test_type="single_choice",
-                calling_test=self, multipart_test=1)['answer_response']
+                question, possible_answers, test_type="single_choice", multipart_test=1)['answer_response']
 
             if actual_answer != expected_answer:
                 return test.FAIL('Offline/online sender not handled: Incorrect sender identified')
@@ -282,13 +280,16 @@ class IS0404Test(ControllerTest):
                        """)
             possible_answers = []
 
-            # Get the name of the calling test method to use as an identifier
+            # Get the name and the description of this test method to use as an identifier
             test_method_name = inspect.currentframe().f_code.co_name
+            method = getattr(self, test_method_name)
+            test_method_description = inspect.getdoc(method)
 
             # Send the question to the Testing Façade
             # and then put sender online before waiting for the Testing Façade response
             sent_json = self.testing_facade_utils.send_testing_facade_questions(
-                test_method_name, question, possible_answers, test_type="action", calling_test=self, multipart_test=2)
+                test_method_name, test_method_description, question, possible_answers,
+                test_type="action", multipart_test=2)
 
             # Wait a random amount of time before bringing sender back online
             self.testing_facade_utils.exit_test_event_clear()

--- a/nmostesting/suites/IS0404Test.py
+++ b/nmostesting/suites/IS0404Test.py
@@ -24,6 +24,7 @@ import textwrap
 from .. import Config as CONFIG
 from ..ControllerTest import ControllerTest, TestingFacadeException
 
+
 class IS0404Test(ControllerTest):
     """
     Testing initial set up of new test suite for controller testing
@@ -239,7 +240,8 @@ class IS0404Test(ControllerTest):
                        """
             possible_answers = []
 
-            self.testing_facade_utils.invoke_testing_facade(question, possible_answers, test_type="action", calling_test=self)
+            self.testing_facade_utils.invoke_testing_facade(question, possible_answers,
+                                                            test_type="action", calling_test=self)
 
             # Take one of the senders offline
             possible_answers = [{'answer_id': 'answer_'+str(i), 'display_answer': s['display_answer'],
@@ -259,7 +261,8 @@ class IS0404Test(ControllerTest):
             question = 'Please refresh your NCuT and select the sender which has been put \'offline\'.'
 
             actual_answer = self.testing_facade_utils.invoke_testing_facade(
-                question, possible_answers, test_type="single_choice", calling_test=self, multipart_test=1)['answer_response']
+                question, possible_answers, test_type="single_choice",
+                calling_test=self, multipart_test=1)['answer_response']
 
             if actual_answer != expected_answer:
                 return test.FAIL('Offline/online sender not handled: Incorrect sender identified')

--- a/nmostesting/suites/IS0503Test.py
+++ b/nmostesting/suites/IS0503Test.py
@@ -24,6 +24,7 @@ import textwrap
 from ..ControllerTest import ControllerTest, TestingFacadeException
 from ..TestingFacadeUtils import exitTestEvent
 
+
 class IS0503Test(ControllerTest):
     """
     Testing initial set up of new test suite for controller testing
@@ -163,7 +164,8 @@ class IS0503Test(ControllerTest):
                          'label': receiver['label'],
                          'description': receiver['description']}}
 
-            self.testing_facade_utils.invoke_testing_facade(question, possible_answers, test_type="action", calling_test=self, metadata=metadata)
+            self.testing_facade_utils.invoke_testing_facade(question, possible_answers, test_type="action",
+                                                            calling_test=self, metadata=metadata)
 
             # Check the staged API endpoint received the correct PATCH request
             patch_requests = [r for r in self.node.staged_requests
@@ -266,7 +268,8 @@ class IS0503Test(ControllerTest):
                          'label': receiver['label'],
                          'description': receiver['description']}}
 
-            self.testing_facade_utils.invoke_testing_facade(question, possible_answers, test_type="action", calling_test=self, metadata=metadata)
+            self.testing_facade_utils.invoke_testing_facade(question, possible_answers, test_type="action",
+                                                            calling_test=self, metadata=metadata)
 
             # Check the staged API endpoint received a PATCH request
             patch_requests = [r for r in self.node.staged_requests
@@ -403,7 +406,8 @@ class IS0503Test(ControllerTest):
 
             # Send the question to the Testing Façade
             sent_json = self.testing_facade_utils.send_testing_facade_questions(
-                test_method_name, question, possible_answers, self, test_type="action", multipart_test=2, metadata=metadata)
+                test_method_name, question, possible_answers, test_type="action", calling_test=self,
+                multipart_test=2, metadata=metadata)
 
             # Wait a random amount of time before disconnecting
             exitTestEvent.clear()

--- a/nmostesting/suites/IS0503Test.py
+++ b/nmostesting/suites/IS0503Test.py
@@ -109,7 +109,7 @@ class IS0503Test(ControllerTest):
                                 if r['registered'] and r['connectable']]
 
             actual_answers = self.testing_facade_utils.invoke_testing_facade(
-                question, possible_answers, test_type="multi_choice", calling_test=self)['answer_response']
+                question, possible_answers, test_type="multi_choice")['answer_response']
 
             if len(actual_answers) != len(expected_answers):
                 return test.FAIL('Incorrect Receiver identified')
@@ -164,8 +164,8 @@ class IS0503Test(ControllerTest):
                          'label': receiver['label'],
                          'description': receiver['description']}}
 
-            self.testing_facade_utils.invoke_testing_facade(question, possible_answers, test_type="action",
-                                                            calling_test=self, metadata=metadata)
+            self.testing_facade_utils.invoke_testing_facade(question, possible_answers,
+                                                            test_type="action", metadata=metadata)
 
             # Check the staged API endpoint received the correct PATCH request
             patch_requests = [r for r in self.node.staged_requests
@@ -268,8 +268,8 @@ class IS0503Test(ControllerTest):
                          'label': receiver['label'],
                          'description': receiver['description']}}
 
-            self.testing_facade_utils.invoke_testing_facade(question, possible_answers, test_type="action",
-                                                            calling_test=self, metadata=metadata)
+            self.testing_facade_utils.invoke_testing_facade(question, possible_answers,
+                                                            test_type="action", metadata=metadata)
 
             # Check the staged API endpoint received a PATCH request
             patch_requests = [r for r in self.node.staged_requests
@@ -353,7 +353,7 @@ class IS0503Test(ControllerTest):
                                if r['display_answer'] == receiver['display_answer']][0]
 
             actual_answer = self.testing_facade_utils.invoke_testing_facade(
-                question, possible_answers, test_type="single_choice", calling_test=self)['answer_response']
+                question, possible_answers, test_type="single_choice")['answer_response']
 
             if actual_answer != expected_answer:
                 return test.FAIL('Incorrect receiver identified')
@@ -377,8 +377,8 @@ class IS0503Test(ControllerTest):
                          'description': receiver['description']}}
 
             actual_answer = self.testing_facade_utils.invoke_testing_facade(
-                question, possible_answers, test_type="single_choice", calling_test=self,
-                multipart_test=1, metadata=metadata)['answer_response']
+                question, possible_answers, test_type="single_choice", multipart_test=1,
+                metadata=metadata)['answer_response']
 
             if actual_answer != expected_answer:
                 return test.FAIL('Incorrect sender identified')
@@ -401,13 +401,15 @@ class IS0503Test(ControllerTest):
                        """)
             possible_answers = []
 
-            # Get the name of the calling test method to use as an identifier
+            # Get the name and the description of this test method to use as an identifier
             test_method_name = inspect.currentframe().f_code.co_name
+            method = getattr(self, test_method_name)
+            test_method_description = inspect.getdoc(method)
 
             # Send the question to the Testing Façade
             sent_json = self.testing_facade_utils.send_testing_facade_questions(
-                test_method_name, question, possible_answers, test_type="action", calling_test=self,
-                multipart_test=2, metadata=metadata)
+                test_method_name, test_method_description, question, possible_answers,
+                test_type="action", multipart_test=2, metadata=metadata)
 
             # Wait a random amount of time before disconnecting
             exitTestEvent.clear()

--- a/nmostesting/suites/MS0501Test.py
+++ b/nmostesting/suites/MS0501Test.py
@@ -72,9 +72,9 @@ class MS0501Test(GenericTest):
             self.descriptor = descriptor
 
     def __init__(self, apis, utils, **kwargs):
-        # Remove the RAML key to prevent this test suite from auto-testing IS-04 API
+        # Remove the Node API RAML key to prevent this test suite from auto-testing IS-04 API
         apis[NODE_API_KEY].pop("raml", None)
-        # Remove the controller test spec_path as there are no corresponding GitHub repos for Controller Tests
+        # Remove the Testing Facade spec_path as there are no corresponding GitHub repos for the Testing Facade API
         apis[TESTING_FACADE_API_KEY].pop("spec_path", None)
 
         GenericTest.__init__(self, apis, disable_auto=False, **kwargs)

--- a/nmostesting/suites/MS0501Test.py
+++ b/nmostesting/suites/MS0501Test.py
@@ -157,7 +157,7 @@ class MS0501Test(GenericTest):
                    """
 
         try:
-            self.testing_facade_utils.invoke_testing_facade(question, [], test_type="action", calling_test=self)
+            self.testing_facade_utils.invoke_testing_facade(question, [], test_type="action")
 
         except TestingFacadeException:
             # pre_test_introducton timed out
@@ -178,7 +178,7 @@ class MS0501Test(GenericTest):
                    """
 
         try:
-            self.testing_facade_utils.invoke_testing_facade(question, [], test_type="action", calling_test=self)
+            self.testing_facade_utils.invoke_testing_facade(question, [], test_type="action")
 
         except TestingFacadeException:
             # post_test_introducton timed out
@@ -1703,7 +1703,7 @@ class MS0501Test(GenericTest):
         for p in filtered:
             p.pop("resource", None)
         return self.testing_facade_utils.invoke_testing_facade(question, filtered,
-                                                               test_type="multi_choice", calling_test=self,
+                                                               test_type="multi_choice",
                                                                test_method_name=test_method_name)["answer_response"]
 
     def _get_constraints(self, test, class_property, datatype_descriptors, object_runtime_constraints):

--- a/nmostesting/suites/MS0501Test.py
+++ b/nmostesting/suites/MS0501Test.py
@@ -36,6 +36,7 @@ NODE_API_KEY = "node"
 CONTROL_API_KEY = "ncp"
 MS05_API_KEY = "controlframework"
 FEATURE_SETS_KEY = "featuresets"
+TESTING_FACADE_API_KEY = "testquestion"
 
 
 # Note: this test suite is a base class for the IS1202Test and IS1402Test test suites
@@ -73,6 +74,9 @@ class MS0501Test(GenericTest):
     def __init__(self, apis, utils, **kwargs):
         # Remove the RAML key to prevent this test suite from auto-testing IS-04 API
         apis[NODE_API_KEY].pop("raml", None)
+        # Remove the controller test spec_path as there are no corresponding GitHub repos for Controller Tests
+        apis[TESTING_FACADE_API_KEY].pop("spec_path", None)
+
         GenericTest.__init__(self, apis, disable_auto=False, **kwargs)
         self.ms05_utils = utils
         self.testing_facade_utils = TestingFacadeUtils(apis)
@@ -179,6 +183,15 @@ class MS0501Test(GenericTest):
         except TestingFacadeException:
             # post_test_introducton timed out
             pass
+
+    def execute_tests(self, test_names):
+        """Perform tests defined within this class"""
+
+        self.pre_tests_message()
+
+        super().execute_tests(test_names)
+
+        self.post_tests_message()
 
     def test_ms05_01(self, test):
         """Device Model: Root Block exists with correct oid and role"""
@@ -1690,8 +1703,8 @@ class MS0501Test(GenericTest):
         for p in filtered:
             p.pop("resource", None)
         return self.testing_facade_utils.invoke_testing_facade(question, filtered,
-                                           test_type="multi_choice", calling_test=self,
-                                           test_method_name=test_method_name)["answer_response"]
+                                                               test_type="multi_choice", calling_test=self,
+                                                               test_method_name=test_method_name)["answer_response"]
 
     def _get_constraints(self, test, class_property, datatype_descriptors, object_runtime_constraints):
         datatype_constraints = None


### PR DESCRIPTION
- The Testing Facade was developed to allow user interactive testing of Controllers with the `ControllerTest` class.
- However, applications of the Testing Facade have extended beyond Controller testing.
- For instance, it is now used in the MS-05/IS-12 test suite to guide invasive testing of MS-05 Device Models.
- To decouple the MS-05/IS-12 test suite from the `ControllerTest` class, the Testing Facade functionality has been refactored into a `TestingFacadeUtils` class.
- Associated API keys have been renamed from `CONTROLLER_TEST_API_KEY` to `TESTING_FACADE_API_KEY`.
- Associated spec keys have been renamed from `controller-tests` to `testing-facade`.
- All affected test suites have been tested, namely:
    - IS-04-04
    - IS-05-03
    - BCP-006-01-02
    - IS-12