### PR TITLE
IS-14: Change spec_key from controller-test to testing-facade

### DIFF
--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -399,7 +399,7 @@ TEST_DEFINITIONS = {
             "api_key": "controlframework",
             "disable_fields": ["host", "port", "selector"]
         }, {
-            "spec_key": "controller-tests",
+            "spec_key": "testing-facade",
             "api_key": "testquestion",
             "disable_fields": ["selector"] if CONFIG.MS05_INTERACTIVE_TESTING else ["host", "port", "selector"]
         }],


### PR DESCRIPTION
* controller-test is the old spec_key
* the testing-facade refactoring changed the name to "testing-facade"
* update the IS-14 test definition accordingly