### PR TITLE
Fix type hinting for backwards compatibility with Python 3.8

### DIFF
--- a/nmostesting/MS05Utils.py
+++ b/nmostesting/MS05Utils.py
@@ -21,7 +21,7 @@ from copy import deepcopy
 from enum import IntEnum, Enum
 from itertools import takewhile, dropwhile
 from jsonschema import FormatChecker, SchemaError, validate, ValidationError
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 from .GenericTest import NMOSTestException, GenericTest
 from .TestResult import Test
@@ -504,7 +504,7 @@ class NcPropertyChangedEventData():
 
 
 class NcObject():
-    def __init__(self, class_id: list, oid: int, owner: Optional[int], role: str, role_path: list,
+    def __init__(self, class_id: List[int], oid: int, owner: Optional[int], role: str, role_path: List[str],
                  runtime_constraints: Optional[NcPropertyConstraints],
                  member_descriptor: NcBlockMemberDescriptor):
         self.class_id = class_id
@@ -517,7 +517,7 @@ class NcObject():
 
 
 class NcBlock(NcObject):
-    def __init__(self, class_id: list, oid: int, owner: Optional[int], role: str, role_path: list,
+    def __init__(self, class_id: List[int], oid: int, owner: Optional[int], role: str, role_path: List[str],
                  runtime_constraints: Optional[NcPropertyConstraints],
                  member_descriptor: NcBlockMemberDescriptor):
         NcObject.__init__(self, class_id, oid, owner, role, role_path, runtime_constraints, member_descriptor)
@@ -527,7 +527,7 @@ class NcBlock(NcObject):
     def add_child_object(self, nc_object):
         self.child_objects.append(nc_object)
 
-    def get_role_paths(self) -> list[list[str]]:
+    def get_role_paths(self) -> List[List[str]]:
         role_paths = []
         for child_object in self.child_objects:
             role_paths.append([child_object.role])
@@ -539,7 +539,7 @@ class NcBlock(NcObject):
                     role_paths.append(role_path)
         return role_paths
 
-    def get_oids(self, root=True) -> list[int]:
+    def get_oids(self, root=True) -> List[int]:
         oids = [self.oid] if root else []
         for child_object in self.child_objects:
             oids.append(child_object.oid)
@@ -562,7 +562,7 @@ class NcBlock(NcObject):
         return ret_val
 
     # NcBlock Methods
-    def get_member_descriptors(self, recurse=False) -> list[NcBlockMemberDescriptor]:
+    def get_member_descriptors(self, recurse=False) -> List[NcBlockMemberDescriptor]:
         query_results = []
         for child_object in self.child_objects:
             query_results.append(child_object.member_descriptor)
@@ -570,7 +570,7 @@ class NcBlock(NcObject):
                 query_results += child_object.get_member_descriptors(recurse)
         return query_results
 
-    def find_members_by_path(self, role_path) -> list[NcBlockMemberDescriptor]:
+    def find_members_by_path(self, role_path) -> List[NcBlockMemberDescriptor]:
         query_results = []
         query_role = role_path[0]
         for child_object in self.child_objects:
@@ -585,7 +585,7 @@ class NcBlock(NcObject):
                              role,
                              case_sensitive=False,
                              match_whole_string=False,
-                             recurse=False) -> list[NcBlockMemberDescriptor]:
+                             recurse=False) -> List[NcBlockMemberDescriptor]:
         def match(query_role, role, case_sensitive, match_whole_string):
             if case_sensitive:
                 return query_role == role if match_whole_string else query_role in role
@@ -606,7 +606,7 @@ class NcBlock(NcObject):
                                  class_id,
                                  include_derived=False,
                                  recurse=False,
-                                 get_objects=False) -> Union[list[NcBlockMemberDescriptor], list[NcObject]]:
+                                 get_objects=False) -> Union[List[NcBlockMemberDescriptor], List[NcObject]]:
         def match(query_class_id, class_id, include_derived):
             if query_class_id == (class_id[:len(query_class_id)] if include_derived else class_id):
                 return True
@@ -626,16 +626,16 @@ class NcBlock(NcObject):
 
 
 class NcManager(NcObject):
-    def __init__(self, class_id: list, oid: int, owner: Optional[int], role: list, role_path: str,
+    def __init__(self, class_id: List[int], oid: int, owner: Optional[int], role: List[str], role_path: str,
                  runtime_constraints: Optional[NcPropertyConstraints],
                  member_descriptor: NcBlockMemberDescriptor):
         NcObject.__init__(self, class_id, oid, owner, role, role_path, runtime_constraints, member_descriptor)
 
 
 class NcClassManager(NcManager):
-    def __init__(self, class_id: list, oid: int, owner: Optional[int], role: list, role_path: str,
-                 class_descriptors: list[NcClassDescriptor],
-                 datatype_descriptors: list[NcDatatypeDescriptor],
+    def __init__(self, class_id: List[int], oid: int, owner: Optional[int], role: List[str], role_path: str,
+                 class_descriptors: List[NcClassDescriptor],
+                 datatype_descriptors: List[NcDatatypeDescriptor],
                  runtime_constraints: Optional[NcPropertyConstraints],
                  member_descriptor: NcBlockMemberDescriptor):
         NcObject.__init__(self, class_id, oid, owner, role, role_path, runtime_constraints, member_descriptor)
@@ -1470,7 +1470,7 @@ class MS05Utils(NMOSUtils):
                        block: NcBlock,
                        get_constraints=False,
                        get_sequences=False,
-                       get_readonly=False) -> list[MS05PropertyMetadata]:
+                       get_readonly=False) -> List[MS05PropertyMetadata]:
 
         def is_read_only(class_id, property_descriptor):
             """Account for Worker enabled property cludge in the BCP-008 specs"""

--- a/nmostesting/suites/IS1401Test.py
+++ b/nmostesting/suites/IS1401Test.py
@@ -16,7 +16,7 @@
 from copy import copy, deepcopy
 from enum import IntEnum
 from functools import cmp_to_key
-from typing import Union
+from typing import Dict, List, Union
 import random
 import string
 from ..Config import MS05_INVASIVE_TESTING
@@ -133,7 +133,7 @@ class IS1401Test(MS0501Test):
         self.is14_utils.device_model = None
         self.oid_cache = []
 
-    def _do_request_json(self, test: GenericTest, method: str, url: str, **kwargs):
+    def _do_request_json(self, test: GenericTest, method: str, url: str, **kwargs) -> any:
         """Perform an HTTP request and return JSON response"""
         valid, response = self.do_request(method, url, **kwargs)
 
@@ -151,7 +151,7 @@ class IS1401Test(MS0501Test):
 
         return response.json()
 
-    def _compare_property_ids(self, a: NcPropertyId, b: NcPropertyId):
+    def _compare_property_ids(self, a: NcPropertyId, b: NcPropertyId) -> int:
         """Compare level and index of an NcPropertyId"""
         if a.level > b.level:
             return 1
@@ -166,7 +166,7 @@ class IS1401Test(MS0501Test):
 
     def _compare_property_objects(self,
                                   a: Union[NcPropertyDescriptor, NcPropertyHolder],
-                                  b: Union[NcPropertyDescriptor, NcPropertyHolder]):
+                                  b: Union[NcPropertyDescriptor, NcPropertyHolder]) -> int:
         """Compare NcPropertyIds of NcPropertyDescriptors or NcPropertyHolders"""
         return self._compare_property_ids(a.id, b.id)
 
@@ -187,7 +187,7 @@ class IS1401Test(MS0501Test):
         else:
             return obj
 
-    def _get_bulk_properties_holder(self, test: GenericTest, endpoint: str):
+    def _get_bulk_properties_holder(self, test: GenericTest, endpoint: str) -> NcBulkPropertiesHolder:
         """Get backup dataset from endpoint"""
         method_result_json = self._do_request_json(test, "GET", endpoint)
 
@@ -213,7 +213,7 @@ class IS1401Test(MS0501Test):
                                       endpoint: str,
                                       bulk_properties_holder: NcBulkPropertiesHolder,
                                       restoreMode: NcRestoreMode,
-                                      recurse: bool):
+                                      recurse: bool) -> List[NcObjectPropertiesSetValidation]:
         """Apply a backup dataset to the endpoint"""
         backup_dataset = {
             "arguments": {
@@ -253,7 +253,7 @@ class IS1401Test(MS0501Test):
                                         endpoint: str,
                                         bulk_properties_holder: NcBulkPropertiesHolder,
                                         restoreMode=NcRestoreMode.Modify,
-                                        recurse=True):
+                                        recurse=True) -> List[NcObjectPropertiesSetValidation]:
         """Perform an HTTP PUT of the backup dataset to the endpoint"""
         return self._apply_bulk_properties_holder(test,
                                                   test_metadata,
@@ -265,7 +265,7 @@ class IS1401Test(MS0501Test):
                                          endpoint: str,
                                          bulk_properties_holder: NcBulkPropertiesHolder,
                                          restoreMode=NcRestoreMode.Modify,
-                                         recurse=True):
+                                         recurse=True) -> List[NcObjectPropertiesSetValidation]:
         """Perform an HTTP PATCH of the backup dataset to the endpoint"""
         return self._apply_bulk_properties_holder(test,
                                                   test_metadata,
@@ -297,7 +297,7 @@ class IS1401Test(MS0501Test):
                           + "/docs/API_requests.html#url-and-usage")
         return test.PASS()
 
-    def _check_block_member_role_syntax(self, test: GenericTest, role_path: list[str]):
+    def _check_block_member_role_syntax(self, test: GenericTest, role_path: List[str]):
         """Check syntax of roles in this block"""
         method_result = self.is14_utils.get_property(test, NcBlockProperties.MEMBERS.value, role_path=role_path)
 
@@ -725,11 +725,12 @@ class IS1401Test(MS0501Test):
 
         return test.PASS()
 
-    def _create_notices_list(self, set_validations: list[NcObjectPropertiesSetValidation]):
+    def _create_notices_list(self, set_validations: List[NcObjectPropertiesSetValidation]) -> List[str]:
         """Create list of validation notices"""
         return [".".join(v.path) + str(n.id) for v in set_validations for n in v.notices]
 
-    def _create_object_properties_dict(self, bulk_properties_holder: NcBulkPropertiesHolder):
+    def _create_object_properties_dict(self, bulk_properties_holder: NcBulkPropertiesHolder) \
+            -> Dict[str, NcObjectPropertiesHolder]:
         """Creates a dict keyed on formatted role path and property id"""
         return {".".join(o.path) + str(v.id): v for o in bulk_properties_holder.values for v in o.values}
 
@@ -738,8 +739,8 @@ class IS1401Test(MS0501Test):
                                  original_bulk_properties_holder: NcBulkPropertiesHolder,
                                  applied_bulk_properties_holder: NcBulkPropertiesHolder,
                                  updated_bulk_properties_holder: NcBulkPropertiesHolder,
-                                 target_role_path: list[str],
-                                 set_validations: list[NcObjectPropertiesSetValidation],
+                                 target_role_path: List[str],
+                                 set_validations: List[NcObjectPropertiesSetValidation],
                                  recurse: bool, validate=False):
         """Compare the original backup dataset to the updated, given the applied dataset"""
         # original_bulk_properties_holder is the state before dataset applied
@@ -805,8 +806,8 @@ class IS1401Test(MS0501Test):
     def _check_object_properties_set_validations(self,
                                                  test_metadata: TestMetadata,
                                                  bulk_properties_holder: NcBulkPropertiesHolder,
-                                                 validations: list[NcObjectPropertiesSetValidation],
-                                                 target_role_path: list[str],
+                                                 validations: List[NcObjectPropertiesSetValidation],
+                                                 target_role_path: List[str],
                                                  recurse: bool):
         """Check that the NcObjectPropertiesSetValidations have no errors"""
         # Check there is one validation per object changed
@@ -851,7 +852,7 @@ class IS1401Test(MS0501Test):
 
     def _check_validate_restore_properties(self,
                                            test: GenericTest,
-                                           target_role_path: list[str],
+                                           target_role_path: List[str],
                                            restoreMode: NcRestoreMode,
                                            recurse: bool):
         """Perform a validate and restore on the target role path"""
@@ -1041,7 +1042,7 @@ class IS1401Test(MS0501Test):
 
     # Invasive testing
 
-    def _generate_property_value(self, test: GenericTest, type_name: str, value: any):
+    def _generate_property_value(self, test: GenericTest, type_name: str, value: any) -> any:
         """Generate a new value based on the existing value"""
 
         # If this is a null property then not sure how to manipulate it
@@ -1125,8 +1126,8 @@ class IS1401Test(MS0501Test):
 
     def _filter_property_holders(self,
                                  bulk_properties_holder: NcBulkPropertiesHolder,
-                                 filter_list: list[str],
-                                 include=False):
+                                 filter_list: List[str],
+                                 include=False) -> NcBulkPropertiesHolder:
         """Either include or exclude the filter_list property keys from the bulk properties holder"""
         # if include = True then properties with keys found in filter_list are kept (all others removed)
         # if include = False then properties with keys found in filter_list are removed
@@ -1147,7 +1148,7 @@ class IS1401Test(MS0501Test):
     def _perform_restore(self,
                          test: GenericTest,
                          test_metadata: TestMetadata,
-                         target_role_path: list[str],
+                         target_role_path: List[str],
                          bulk_properties_holder: NcBulkPropertiesHolder,
                          original_bulk_properties_holder: NcBulkPropertiesHolder,
                          restoreMode: NcRestoreMode,


### PR DESCRIPTION
`list` and `dict` can only be used as type hint from Python 3.9 onwards.  
Use `List` and `Dict` imported from `typing` instead for compatibility with Python 3.8