### PR TITLE
BCP-008-01/02: Make test suite names consistent

### DIFF
--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -459,7 +459,7 @@ TEST_DEFINITIONS = {
         }],
         "class": BCP0060102Test.BCP0060102Test
     },
-    "BCP-008-01": {
+    "BCP-008-01-01": {
         "name": "BCP-008-01 Receiver Status Monitoring",
         "specs": [{
             "spec_key": "is-04",
@@ -489,7 +489,7 @@ TEST_DEFINITIONS = {
         "class": BCP0080101Test.BCP0080101Test,
         "urlpath": True
     },
-    "BCP-008-02": {
+    "BCP-008-02-01": {
         "name": "BCP-008-02 Sender Status Monitoring",
         "specs": [{
             "spec_key": "is-04",


### PR DESCRIPTION
Correct test specification names for BCP-008-01-01 and BCP-008-02-01