### PR TITLE
Address authorization issues with mock resources

### DIFF
--- a/nmostesting/IS10Utils.py
+++ b/nmostesting/IS10Utils.py
@@ -161,7 +161,7 @@ class IS10Utils(NMOSUtils):
         return False
 
     @staticmethod
-    def check_authorization(auth, path, scopes=["x-nmos-registration"], write=False):
+    def check_authorization(auth, path, scope="x-nmos-registration", write=False):
         def _check_path_match(path, path_wildcards):
             path_match = False
             for path_wildcard in path_wildcards:
@@ -183,11 +183,10 @@ class IS10Utils(NMOSUtils):
                 if claims["iss"] != auth.make_issuer():
                     return 401, f"Unexpected issuer, expected: {auth.make_issuer()}, actual: {claims['iss']}"
                 # TODO: Check 'aud' claim matches 'mocks.<domain>'
-                for scope in scopes:
-                    if not _check_path_match(path, claims[scope]["read"]):
-                        return 403, f"Paths mismatch for {scope} read claims"
-                    if write and not _check_path_match(path, claims[scope]["write"]):
-                        return 403, f"Paths mismatch for {scope} write claims"
+                if not _check_path_match(path, claims[scope]["read"]):
+                    return 403, f"Paths mismatch for {scope} read claims"
+                if write and not _check_path_match(path, claims[scope]["write"]):
+                    return 403, f"Paths mismatch for {scope} write claims"
             except KeyError as err:
                 return 400, f"KeyError: {err}"
             except Exception as err:

--- a/nmostesting/IS10Utils.py
+++ b/nmostesting/IS10Utils.py
@@ -15,6 +15,7 @@
 from Crypto.PublicKey import RSA
 from authlib.jose import jwt, JsonWebKey
 
+import re
 import time
 import uuid
 
@@ -22,6 +23,7 @@ from .NMOSUtils import NMOSUtils
 from OpenSSL import crypto
 from cryptography.hazmat.primitives import serialization
 from cryptography import x509
+from flask import request
 from .TestHelper import get_default_ip, get_mocks_hostname
 
 from . import Config as CONFIG
@@ -157,3 +159,37 @@ class IS10Utils(NMOSUtils):
             if item in [e.name for e in enum]:
                 return True
         return False
+
+    @staticmethod
+    def check_authorization(auth, path, scopes=["x-nmos-registration"], write=False):
+        def _check_path_match(path, path_wildcards):
+            path_match = False
+            for path_wildcard in path_wildcards:
+                pattern = path_wildcard.replace("*", ".*")
+                if re.search(pattern, path):
+                    path_match = True
+                    break
+            return path_match
+
+        if CONFIG.ENABLE_AUTH:
+            try:
+                if "Authorization" not in request.headers:
+                    return 400, "Authorization header not found"
+                if not request.headers["Authorization"].startswith("Bearer "):
+                    return 400, "Bearer not found in Authorization header"
+                token = request.headers["Authorization"].split(" ")[1]
+                claims = jwt.decode(token, auth.generate_jwk())
+                claims.validate()
+                if claims["iss"] != auth.make_issuer():
+                    return 401, f"Unexpected issuer, expected: {auth.make_issuer()}, actual: {claims['iss']}"
+                # TODO: Check 'aud' claim matches 'mocks.<domain>'
+                for scope in scopes:
+                    if not _check_path_match(path, claims[scope]["read"]):
+                        return 403, f"Paths mismatch for {scope} read claims"
+                    if write and not _check_path_match(path, claims[scope]["write"]):
+                        return 403, f"Paths mismatch for {scope} write claims"
+            except KeyError as err:
+                return 400, f"KeyError: {err}"
+            except Exception as err:
+                return 400, f"Exception: {err}"
+        return True, ""

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -169,6 +169,7 @@ FLASK_APPS.append(ocsp_app)
 # Primary Authorization server
 if CONFIG.ENABLE_AUTH:
     auth_app = Flask(__name__)
+    CORS(auth_app)
     auth_app.debug = False
     auth_app.config['AUTH_INSTANCE'] = 0
     auth_app.config['PORT'] = PRIMARY_AUTH.port

--- a/nmostesting/mocks/Node.py
+++ b/nmostesting/mocks/Node.py
@@ -24,6 +24,8 @@ from jinja2 import Template
 from .. import Config as CONFIG
 from ..TestHelper import get_default_ip, do_request
 from ..IS04Utils import IS04Utils
+from ..IS10Utils import IS10Utils
+from .Auth import PRIMARY_AUTH
 
 
 class Node(object):
@@ -376,12 +378,24 @@ def x_nmos_root():
 def connection_root():
     base_data = ['v1.0/', 'v1.1/']
 
+    authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
+                                                              request.path,
+                                                              scopes=["x-nmos-connection"])
+    if authorized is not True:
+        abort(authorized, description=error_message)
+
     return make_response(Response(json.dumps(base_data), mimetype='application/json'))
 
 
 @NODE_API.route('/x-nmos/connection/<version>', methods=['GET'], strict_slashes=False)
 def version(version):
     base_data = ['bulk/', 'single/']
+
+    authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
+                                                              request.path,
+                                                              scopes=["x-nmos-connection"])
+    if authorized is not True:
+        abort(authorized, description=error_message)
 
     return make_response(Response(json.dumps(base_data), mimetype='application/json'))
 
@@ -390,11 +404,23 @@ def version(version):
 def single(version):
     base_data = ['senders/', 'receivers/']
 
+    authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
+                                                              request.path,
+                                                              scopes=["x-nmos-connection"])
+    if authorized is not True:
+        abort(authorized, description=error_message)
+
     return make_response(Response(json.dumps(base_data), mimetype='application/json'))
 
 
 @NODE_API.route('/x-nmos/connection/<version>/single/<resource>/', methods=["GET"], strict_slashes=False)
 def resources(version, resource):
+    authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
+                                                              request.path,
+                                                              scopes=["x-nmos-connection"])
+    if authorized is not True:
+        abort(authorized, description=error_message)
+
     if resource == 'senders':
         base_data = [r + '/' for r in [*NODE.senders]]
     elif resource == 'receivers':
@@ -405,6 +431,12 @@ def resources(version, resource):
 
 @NODE_API.route('/x-nmos/connection/<version>/single/<resource>/<resource_id>', methods=["GET"], strict_slashes=False)
 def connection(version, resource, resource_id):
+    authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
+                                                              request.path,
+                                                              scopes=["x-nmos-connection"])
+    if authorized is not True:
+        abort(authorized, description=error_message)
+
     if resource != 'senders' and resource != 'receivers':
         abort(404)
 
@@ -441,6 +473,12 @@ def _get_constraints(resource):
 @NODE_API.route('/x-nmos/connection/<version>/single/<resource>/<resource_id>/constraints',
                 methods=["GET"], strict_slashes=False)
 def constraints(version, resource, resource_id):
+    authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
+                                                              request.path,
+                                                              scopes=["x-nmos-connection"])
+    if authorized is not True:
+        abort(authorized, description=error_message)
+
     base_data = [_get_constraints(resource)]
 
     return make_response(Response(json.dumps(base_data), mimetype='application/json'))
@@ -479,6 +517,13 @@ def staged(version, resource, resource_id):
     activating a connection without staging or deactivating an active connection
     Updates data then POSTs updated resource to registry
     """
+    authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
+                                                              request.path,
+                                                              scopes=["x-nmos-connection"],
+                                                              write=request.method == 'PATCH')
+    if authorized is not True:
+        abort(authorized, description=error_message)
+
     # Track requests
     NODE.staged_requests.append({'method': request.method, 'resource': resource, 'resource_id': resource_id,
                                  'data': request.get_json(silent=True)})
@@ -516,6 +561,11 @@ def staged(version, resource, resource_id):
 @NODE_API.route('/x-nmos/connection/<version>/single/<resource>/<resource_id>/active',
                 methods=["GET"], strict_slashes=False)
 def active(version, resource, resource_id):
+    authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
+                                                              request.path,
+                                                              scopes=["x-nmos-connection"])
+    if authorized is not True:
+        abort(authorized, description=error_message)
     try:
         if resource == 'senders':
             base_data = NODE.senders[resource_id]['activations']['active']
@@ -530,6 +580,11 @@ def active(version, resource, resource_id):
 @NODE_API.route('/x-nmos/connection/<version>/single/<resource>/<resource_id>/transporttype',
                 methods=["GET"], strict_slashes=False)
 def transport_type(version, resource, resource_id):
+    authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
+                                                              request.path,
+                                                              scopes=["x-nmos-connection"])
+    if authorized is not True:
+        abort(authorized, description=error_message)
     # TODO fetch from resource info
     base_data = "urn:x-nmos:transport:rtp"
 
@@ -584,6 +639,11 @@ def node_sdp(media_type, media_subtype):
 @NODE_API.route('/x-nmos/connection/<version>/single/<resource>/<resource_id>/transportfile',
                 methods=["GET"], strict_slashes=False)
 def transport_file(version, resource, resource_id):
+    authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
+                                                              request.path,
+                                                              scopes=["x-nmos-connection"])
+    if authorized is not True:
+        abort(authorized, description=error_message)
     # GET should either redirect to the location of the transport file or return it directly
     try:
         if resource == 'senders':

--- a/nmostesting/mocks/Node.py
+++ b/nmostesting/mocks/Node.py
@@ -380,7 +380,7 @@ def connection_root():
 
     authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
                                                               request.path,
-                                                              scopes=["x-nmos-connection"])
+                                                              scope="x-nmos-connection")
     if authorized is not True:
         abort(authorized, description=error_message)
 
@@ -393,7 +393,7 @@ def version(version):
 
     authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
                                                               request.path,
-                                                              scopes=["x-nmos-connection"])
+                                                              scope="x-nmos-connection")
     if authorized is not True:
         abort(authorized, description=error_message)
 
@@ -406,7 +406,7 @@ def single(version):
 
     authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
                                                               request.path,
-                                                              scopes=["x-nmos-connection"])
+                                                              scope="x-nmos-connection")
     if authorized is not True:
         abort(authorized, description=error_message)
 
@@ -417,7 +417,7 @@ def single(version):
 def resources(version, resource):
     authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
                                                               request.path,
-                                                              scopes=["x-nmos-connection"])
+                                                              scope="x-nmos-connection")
     if authorized is not True:
         abort(authorized, description=error_message)
 
@@ -433,7 +433,7 @@ def resources(version, resource):
 def connection(version, resource, resource_id):
     authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
                                                               request.path,
-                                                              scopes=["x-nmos-connection"])
+                                                              scope="x-nmos-connection")
     if authorized is not True:
         abort(authorized, description=error_message)
 
@@ -475,7 +475,7 @@ def _get_constraints(resource):
 def constraints(version, resource, resource_id):
     authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
                                                               request.path,
-                                                              scopes=["x-nmos-connection"])
+                                                              scope="x-nmos-connection")
     if authorized is not True:
         abort(authorized, description=error_message)
 
@@ -517,10 +517,11 @@ def staged(version, resource, resource_id):
     activating a connection without staging or deactivating an active connection
     Updates data then POSTs updated resource to registry
     """
+    write = (request.method == 'PATCH')
     authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
                                                               request.path,
-                                                              scopes=["x-nmos-connection"],
-                                                              write=request.method == 'PATCH')
+                                                              scope="x-nmos-connection",
+                                                              write=write)
     if authorized is not True:
         abort(authorized, description=error_message)
 
@@ -563,7 +564,7 @@ def staged(version, resource, resource_id):
 def active(version, resource, resource_id):
     authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
                                                               request.path,
-                                                              scopes=["x-nmos-connection"])
+                                                              scope="x-nmos-connection")
     if authorized is not True:
         abort(authorized, description=error_message)
     try:
@@ -582,7 +583,7 @@ def active(version, resource, resource_id):
 def transport_type(version, resource, resource_id):
     authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
                                                               request.path,
-                                                              scopes=["x-nmos-connection"])
+                                                              scope="x-nmos-connection")
     if authorized is not True:
         abort(authorized, description=error_message)
     # TODO fetch from resource info
@@ -641,7 +642,7 @@ def node_sdp(media_type, media_subtype):
 def transport_file(version, resource, resource_id):
     authorized, error_message = IS10Utils.check_authorization(PRIMARY_AUTH,
                                                               request.path,
-                                                              scopes=["x-nmos-connection"])
+                                                              scope="x-nmos-connection")
     if authorized is not True:
         abort(authorized, description=error_message)
     # GET should either redirect to the location of the transport file or return it directly


### PR DESCRIPTION
After doing some controller testing of nmos-js using authorization the following issues were identified:
* The Auth server causes cross origin errors in browsers when using authorization code flow authentication
* The mock Auth required the use of private key JWT - however, this is optional
* The mock Auth required scopes to be supplied on token refresh - however, this is optional
* The mock Node was not authenticating its API
* Both mock Registry and Node had poor responsiveness when using authentication mainly due to the token evaluation process being expensive

The following fixes were introduced:
* Wrap the mock Auth server in a CORS wrapper
* Make use of private key JWT optional
* Cache scopes on authentication to use on token refresh if scopes not supplied.
* Factor the authentication checking into a utility function
* Add authentication to the mock Node
* Introduce auth caching on Registry and Node so decoding of tokens only happens once for each scope