### PR TITLE
Add description to JSON results output

### DIFF
--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -890,7 +890,8 @@ def format_test_results(results, endpoints, format, args):
                 "name": test_result.name,
                 "state": str(TestStates.DISABLED if test_result.name in ignored_tests else test_result.state),
                 "detail": test_result.detail,
-                "duration": test_result.elapsed_time
+                "duration": test_result.elapsed_time,
+                "description": test_result.description
             })
         formatted = json.dumps(formatted, sort_keys=True, indent=4)
     elif format == "junit":


### PR DESCRIPTION
Currently the JSON output file omits the description, making it difficult to determine which endpoint might be failing an auto test:
<img width="479" height="137" alt="image" src="https://github.com/user-attachments/assets/fe8d1330-de40-4c3b-bf9a-29c46e0e8e12" />

This PR adds the description field to make the results more understandable:
<img width="526" height="153" alt="image" src="https://github.com/user-attachments/assets/f65d8d9e-8b53-49c6-8b23-b85323271939" />
