### PR TITLE
Added customization for Unicast DNS server IP and Port

### DIFF
--- a/docs/2.1. Usage - Testing Unicast Discovery.md
+++ b/docs/2.1. Usage - Testing Unicast Discovery.md
@@ -5,6 +5,7 @@ In order to test unicast discovery, the testing tool launches its own mock DNS s
 *   Ensure the `DNS_SD_MODE` in the testing tool's `nmostesting/UserConfig.py` file is set to `'unicast'` before running the tool.
 *   Configure the DNS search domain for your Node to be `testsuite.nmos.tv` (either manually or by providing this to your Node via DHCP).
 *   Configure the DNS server IP address for your Node to be the IP address of the host which is running the testing tool (either manually or by providing this to your Node via DHCP).
+*   Additionally, IP address and Port number of DNS mock server can be overridden (file `nmostesting/UserConfig.py`, parameters `CONFIG.DNS_IP` and `CONFIG.DNS_PORT`). This allows for easier testing of client code without requiring elevated permissions for nmos-testing-tool and without interference with existing DNS servers.
 
 Unicast DNS advertisements for registries only become available once tests are running. As a result the unit under test may need prompting to re-scan the DNS server for records at this point. The `DNS_SD_ADVERT_TIMEOUT` config parameter may be used to increase the period which the test suite waits for in this situation.
 

--- a/nmostesting/Config.py
+++ b/nmostesting/Config.py
@@ -136,6 +136,12 @@ SCOPE = None
 # This must match the domain name used for certificates in HTTPS mode
 DNS_DOMAIN = "testsuite.nmos.tv"
 
+# IP address for Unicast DNS server (to use instead of default one)
+DNS_IP = None
+
+# Port number for Unicast DNS server (to use instead of default one)
+DNS_PORT = None
+
 # The testing tool uses multiple ports to run mock services. This sets the lowest of these, which also runs the GUI
 # Note that changing this from the default of 5000 also requires changes to supporting files such as
 # test_data/BCP00301/ca/intermediate/openssl.cnf and any generated certificates.

--- a/nmostesting/DNS.py
+++ b/nmostesting/DNS.py
@@ -98,6 +98,8 @@ class WatchingResolver(ForwardingZoneResolver):
 class DNS(object):
     def __init__(self):
         self.default_ip = get_default_ip()
+        self.dns_ip = CONFIG.DNS_IP if CONFIG.DNS_IP else self.default_ip
+        self.dns_port = CONFIG.DNS_PORT if CONFIG.DNS_PORT else 53
         self.resolver = None
         self.server = None
         self.base_zone_data = None
@@ -153,15 +155,15 @@ class DNS(object):
 
     def start(self):
         if not self.server:
-            print(" * Starting DNS server on {}:53".format(self.default_ip))
+            print(" * Starting DNS server on {}:{}".format(self.dns_ip, self.dns_port))
             try:
-                self.server = DNSServer(self.resolver, port=53, address=self.default_ip)
+                self.server = DNSServer(self.resolver, port=self.dns_port, address=self.dns_ip)
                 self.server.start_thread()
             except Exception as e:
-                print(" * ERROR: Unable to bind to port 53. DNS server could not start: {}".format(e))
+                print(" * ERROR: Unable to bind to {}:{}. DNS server could not start: {}".format(self.dns_ip, self.dns_port, e))
 
     def stop(self):
         if self.server:
-            print(" * Stopping DNS server on {}:53".format(self.default_ip))
+            print(" * Stopping DNS server on {}:{}".format(self.dns_ip, self.dns_port))
             self.server.stop()
             self.server = None

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -1282,8 +1282,10 @@ def run_api_tests(args, data_format):
 
 def main(args):
     global CMD_ARGS, DNS_SERVER, TOOL_VERSION
-    # Check if we're testing unicast DNS discovery, and if so ensure we have elevated privileges
-    if CONFIG.ENABLE_DNS_SD and CONFIG.DNS_SD_MODE == "unicast":
+    # Check if we're testing unicast DNS discovery with default port number,
+    #  and if so ensure we have elevated privileges
+    if CONFIG.ENABLE_DNS_SD and CONFIG.DNS_SD_MODE == "unicast" \
+       and CONFIG.DNS_PORT == None:
         is_admin = False
         if platform.system() == "Windows":
             from ctypes import windll
@@ -1292,7 +1294,7 @@ def main(args):
         elif os.geteuid() == 0:
             is_admin = True
         if not is_admin:
-            print(" * ERROR: In order to test DNS-SD in unicast mode, the test suite must be run "
+            print(" * ERROR: In order to test DNS-SD in unicast mode with default port number, the test suite must be run "
                   "with elevated permissions")
             sys.exit(ExitCodes.ERROR)
 


### PR DESCRIPTION
Here I add an option to customize IP address and Port number for mock Unicast DNS server of nmos-testing-tool.
This allows for easier use of this mock:
- no need to do elevated permissions when use privileged port (53). 
- no conflicts with already present DNS services in system. 
- no conflicts with DHCP services which might already provide DNS server addresses.

Configure custom IP:Port for mock DNS server and use it in Your client code. 

What is done:
- added 'None' values for CONFIG.DNS_IP and CONFIG.DNS_PORT variables (Config.py)
- elevated permissions check in NMOSTesting.py modified to not start when DNS_PORT is initialized to any value
- DNS.Py: modified code for DNS server start/stop and logging
- configuration options are mentioned in docs