### PR TITLE
IS-04 and IS-05 Tests: Accommodate new MXL transport 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Node.js
         uses: actions/setup-node@v1
         with:

--- a/nmostesting/IS04Utils.py
+++ b/nmostesting/IS04Utils.py
@@ -72,6 +72,14 @@ class IS04Utils(NMOSUtils):
         return toReturn
 
     @staticmethod
+    def transport_uses_interface_bindings(transport):
+        """Determine whether a transport expects populated interface_bindings."""
+        return not any(
+            transport.startswith(transport_prefix)
+            for transport_prefix in ("urn:x-nmos:transport:mxl",)
+        )
+
+    @staticmethod
     def comparable_parameter_constraint_value(value):
         if isinstance(value, dict):
             return Fraction(value["numerator"], value.get("denominator", 1))

--- a/nmostesting/IS05Utils.py
+++ b/nmostesting/IS05Utils.py
@@ -40,6 +40,8 @@ class IS05Utils(NMOSUtils):
         if self.compare_api_version(api_version, "v1.1") >= 0 and include_transports_without_transport_file:
             valid_transports.append("urn:x-nmos:transport:websocket")
             valid_transports.append("urn:x-nmos:transport:mqtt")
+        if self.compare_api_version(api_version, "v1.2") >= 0 and include_transports_without_transport_file:
+            valid_transports.append("urn:x-nmos:transport:mxl")
         return valid_transports
 
     def check_num_legs(self, url, res_type, uuid):

--- a/nmostesting/IS05Utils.py
+++ b/nmostesting/IS05Utils.py
@@ -16,6 +16,7 @@
 
 import re
 import time
+import uuid
 
 from random import randint
 from . import TestHelper
@@ -306,6 +307,8 @@ class IS05Utils(NMOSUtils):
             return self.generate_connection_uris(port, portId)
         elif transportType == "urn:x-nmos:transport:mqtt":
             return self.generate_broker_topics(port, portId)
+        elif transportType == "urn:x-nmos:transport:mxl":
+            return self.generate_mxl_flow_ids(port, portId)
         else:
             return self.generate_destination_ports(port, portId)
 
@@ -315,6 +318,8 @@ class IS05Utils(NMOSUtils):
             return "connection_uri"
         elif transportType == "urn:x-nmos:transport:mqtt":
             return "broker_topic"
+        elif transportType == "urn:x-nmos:transport:mxl":
+            return "mxl_flow_id"
         else:
             return "destination_port"
 
@@ -385,6 +390,27 @@ class IS05Utils(NMOSUtils):
                         toReturn.append(values[randint(0, len(values) - 1)])
                     else:
                         toReturn.append("test_broker_topic")
+                return True, toReturn
+            except (TypeError, ValueError):
+                return False, "Invalid response from {}, got: {}".format(url, constraints)
+            except KeyError as e:
+                return False, "Expected key '{}' not found in response from {}".format(str(e), url)
+        else:
+            return False, constraints
+
+    def generate_mxl_flow_ids(self, port, portId):
+        """Uses a port's constraints to generate allowable mxl_flow_id values for it"""
+        url = "single/" + port + "s/" + portId + "/constraints/"
+        valid, constraints = self.checkCleanRequestJSON("GET", url)
+        if valid:
+            toReturn = []
+            try:
+                for entry in constraints:
+                    if "enum" in entry['mxl_flow_id']:
+                        values = entry['mxl_flow_id']['enum']
+                        toReturn.append(values[randint(0, len(values) - 1)])
+                    else:
+                        toReturn.append(str(uuid.uuid4()))
                 return True, toReturn
             except (TypeError, ValueError):
                 return False, "Invalid response from {}, got: {}".format(url, constraints)

--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -1192,7 +1192,7 @@ class IS0401Test(GenericTest):
                 return test.FAIL("Unexpected response from the Node API: {}".format(response))
             try:
                 for binder in response.json():
-                    if binder["transport"].startswith("urn:x-nmos:transport:mxl"):
+                    if not IS04Utils.transport_uses_interface_bindings(binder["transport"]):
                         continue
                     interface_bindings = binder["interface_bindings"]
                     if len(interface_bindings) == 0:

--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -1192,6 +1192,8 @@ class IS0401Test(GenericTest):
                 return test.FAIL("Unexpected response from the Node API: {}".format(response))
             try:
                 for binder in response.json():
+                    if binder["transport"].startswith("urn:x-nmos:transport:mxl"):
+                        continue
                     interface_bindings = binder["interface_bindings"]
                     if len(interface_bindings) == 0:
                         return test.FAIL("{} '{}' does not list any interface_bindings"

--- a/nmostesting/suites/IS0502Test.py
+++ b/nmostesting/suites/IS0502Test.py
@@ -547,7 +547,9 @@ class IS0502Test(GenericTest):
         try:
             for resource_type in ["senders", "receivers"]:
                 for resource in self.is04_resources[resource_type]:
-                    valid_transports = self.is05_utils.get_valid_transports(self.apis[CONN_API_KEY]["version"])
+                    valid_transports = self.is05_utils.get_valid_transports(
+                        self.apis[CONN_API_KEY]["version"],
+                        include_transports_without_transport_file=False)
                     if resource["transport"] not in valid_transports:
                         continue
 


### PR DESCRIPTION
Problem:

- Currently the IS-04 schema requires an `interface_bindings` array but does not enforce a minimum number of entries but does recommend at least one entry.
- However `test_19` enforces at least one entry, making the test stronger than the specification.
- This means for MXL transport senders and receivers, this test fails, due to empty `interface_bindings`.

Solution:

- `interface_bindings` checks in `test_19` are now ignored when the transport is MXL.
- This is in preference to weaking the tests for other transports, or restricting the check to only RTP transports.

Edit:
- As well as excluding MXL transports from interface bindings checks, this PR also ensures valid constraints for MXL senders and receivers 