### PR TITLE
Fix IS-05 SDP session-level connection handling

### DIFF
--- a/nmostesting/IS05Utils.py
+++ b/nmostesting/IS05Utils.py
@@ -581,6 +581,10 @@ class IS05Utils(NMOSUtils):
                         return False, "SDP destination port {} does not match transport_params: {}" \
                                       .format(media_line.group(2), transport_params["destination_port"])
                     connection_line = re.search(r"c=IN IP[4,6] ([^/\r\n]*)(?:/[0-9]+){0,2}", sdp_data)
+                    if connection_line is None:
+                        connection_line = re.search(r"c=IN IP[4,6] ([^/\r\n]*)(?:/[0-9]+){0,2}", sdp_global)
+                    if connection_line is None:
+                        return False, "SDP does not contain a connection line"
                     if connection_line.group(1) != transport_params["destination_ip"]:
                         return False, "SDP destination IP {} does not match transport_params: {}" \
                                       .format(connection_line.group(1), transport_params["destination_ip"])


### PR DESCRIPTION
## Summary

- fall back to the session-level `c=` line when a media description does not override it
- report a missing connection line as a test failure instead of raising `AttributeError`

## Rationale

[RFC 8866 section 5.7](https://www.rfc-editor.org/rfc/rfc8866.html#section-5.7) permits a single `c=` field at session level. The SDP attached to #876 follows that form, but `check_sdp_matches_params` currently searches only the selected media section and dereferences a missing match.

## Validation

- reproduced the `AttributeError` on `master` with the SDP from #876
- verified session-level `c=` is accepted
- verified existing media-level `c=` remains accepted
- verified an SDP with no `c=` returns a clear failure
- ran `flake8 .`

Closes #876