### PR TITLE
Fix IS-05 transport constraints mismatch diagnostic

### DIFF
--- a/nmostesting/IS05Utils.py
+++ b/nmostesting/IS05Utils.py
@@ -440,10 +440,12 @@ class IS05Utils(NMOSUtils):
                 except TypeError:
                     return False, "Expected a dict to be returned from {}, got a {}: {}".format(url, type(staged),
                                                                                                 staged)
-                count = 0
                 try:
-                    for item in stagedParams:
-                        expected = paramValues[count]
+                    if len(stagedParams) != len(paramValues):
+                        return False, "Number of transport_params in response from {} ({}) does not match " \
+                                      "the advertised constraints ({})".format(url, len(stagedParams),
+                                                                               len(paramValues))
+                    for expected, item in zip(paramValues, stagedParams):
                         actual = item[paramName]
                         msg = "Could not change {} parameter at {}, expected {}, got {}".format(paramName, url,
                                                                                                 expected,
@@ -452,7 +454,6 @@ class IS05Utils(NMOSUtils):
                             pass
                         else:
                             return False, msg
-                        count = count + 1
                 except TypeError:
                     return False, "Expected a dict to be returned from {}, got a {}: {}".format(url,
                                                                                                 type(stagedParams),

--- a/tests/test_is05_transport_params.py
+++ b/tests/test_is05_transport_params.py
@@ -1,0 +1,69 @@
+import unittest
+from unittest.mock import MagicMock
+
+from nmostesting.IS05Utils import IS05Utils
+
+
+class TransportParamTests(unittest.TestCase):
+    def make_utils(self, staged):
+        utils = IS05Utils("http://node.example/x-nmos/connection/v1.1/")
+        utils.get_num_paths = MagicMock(return_value=2)
+        utils.checkCleanRequestJSON = MagicMock(side_effect=[
+            (True, {}),
+            (True, {"transport_params": staged}),
+        ])
+        return utils
+
+    def test_accepts_one_matching_value_per_constraint(self):
+        utils = self.make_utils([
+            {"destination_port": 5004},
+            {"destination_port": 5006},
+        ])
+
+        valid, message = utils.check_change_transport_param(
+            "sender", [], "destination_port", [5004, 5006], "sender-id")
+
+        self.assertTrue(valid)
+        self.assertEqual(message, "")
+
+    def test_reports_missing_transport_param_leg(self):
+        utils = self.make_utils([{"destination_port": 5004}])
+
+        valid, message = utils.check_change_transport_param(
+            "sender", [], "destination_port", [5004, 5006], "sender-id")
+
+        self.assertFalse(valid)
+        self.assertIn("does not match the advertised constraints", message)
+        self.assertIn("(1)", message)
+        self.assertIn("(2)", message)
+
+    def test_reports_extra_transport_param_leg(self):
+        utils = self.make_utils([
+            {"destination_port": 5004},
+            {"destination_port": 5006},
+            {"destination_port": 5008},
+        ])
+
+        valid, message = utils.check_change_transport_param(
+            "sender", [], "destination_port", [5004, 5006], "sender-id")
+
+        self.assertFalse(valid)
+        self.assertIn("does not match the advertised constraints", message)
+
+    def test_empty_constraints_do_not_raise_index_error(self):
+        utils = IS05Utils("http://node.example/x-nmos/connection/v1.1/")
+        utils.get_num_paths = MagicMock(return_value=0)
+        utils.checkCleanRequestJSON = MagicMock(side_effect=[
+            (True, {}),
+            (True, {"transport_params": []}),
+        ])
+
+        valid, message = utils.check_change_transport_param(
+            "sender", [], "destination_port", [], "sender-id")
+
+        self.assertTrue(valid)
+        self.assertEqual(message, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- return a clear test failure when the number of `transport_params` in `/staged` does not match the advertised constraints
- avoid an `IndexError` when a Node returns an empty constraints array
- cover matching, missing, extra, and empty transport-parameter legs with focused tests

## Validation

At signed commit `f9e0fc875cefb6e2097d70219f50fa41affc4653`:

- `.venv/bin/python -m unittest discover -s tests -v` — 4 tests pass
- `.venv/bin/flake8 nmostesting/IS05Utils.py tests/test_is05_transport_params.py`
- Python bytecode compilation for changed Python files
- `git diff --check`

Closes #843