### PR TITLE
Validate requested time after immediate activation

### DIFF
--- a/nmostesting/IS05Utils.py
+++ b/nmostesting/IS05Utils.py
@@ -32,6 +32,17 @@ class IS05Utils(NMOSUtils):
     def __init__(self, url):
         NMOSUtils.__init__(self, url)
 
+    @staticmethod
+    def check_requested_time(activate_mode, active_requested, activate_time, active_activation):
+        """Validate requested_time values reported by the active endpoint."""
+        if activate_mode == IMMEDIATE_ACTIVATION:
+            if not isinstance(active_requested, str) or not isinstance(active_activation, str):
+                return False
+            if re.match("^[0-9]+:[0-9]+$", active_requested) is None:
+                return False
+            return NMOSUtils.compare_resource_version(active_activation, active_requested) >= 0
+        return active_requested == activate_time
+
     def get_valid_transports(self, api_version, include_transports_without_transport_file=True):
         """Identify the valid transport types for a given version of IS-05"""
         valid_transports = ["urn:x-nmos:transport:rtp",
@@ -227,8 +238,10 @@ class IS05Utils(NMOSUtils):
                             return False, "Expected a dict to be returned from {}, " \
                                           "got a {}: {}".format(activeUrl, type(active), active)
 
-                        if activeMode == activateMode and activeActivation \
-                                and (activateMode == IMMEDIATE_ACTIVATION or activeRequested == activateTime) \
+                        requestedTimeValid = self.check_requested_time(
+                            activateMode, activeRequested, activateTime, activeActivation)
+
+                        if activeMode == activateMode and activeActivation and requestedTimeValid \
                                 and self.compare_resource_version(activeActivation, stageActivation) >= 0:
                             if tries > 1:
                                 # True with a message means WARNING!

--- a/nmostesting/mocks/Node.py
+++ b/nmostesting/mocks/Node.py
@@ -647,9 +647,14 @@ class Node(object):
             valid, response = do_request('POST', self.registry_url + 'x-nmos/registration/' + self.registry_version +
                                          '/resource', json={'type': resource_type, 'data': subscription_update})
 
-            # Update active data with new data
-            activations['active'] = response_data
-            activations['transport_params'] = response_data['transport_params']
+            # Update active data with new data. For immediate activations the
+            # PATCH response has a null requested_time, but /active reports a
+            # non-null requested_time. The mock uses activation_time.
+            active_data = deepcopy(response_data)
+            if active_data['activation']['mode'] == 'activate_immediate':
+                active_data['activation']['requested_time'] = active_data['activation']['activation_time']
+            activations['active'] = active_data
+            activations['transport_params'] = active_data['transport_params']
 
         # Update staged data with new data
         staged_data = deepcopy(response_data)

--- a/tests/test_is05_utils.py
+++ b/tests/test_is05_utils.py
@@ -1,0 +1,35 @@
+import unittest
+
+from nmostesting.IS05Utils import IMMEDIATE_ACTIVATION, IS05Utils, SCHEDULED_ABSOLUTE_ACTIVATION
+
+
+class RequestedTimeTests(unittest.TestCase):
+    def test_immediate_activation_accepts_requested_time_at_or_before_activation(self):
+        self.assertTrue(IS05Utils.check_requested_time(IMMEDIATE_ACTIVATION,
+                                                       "100:50", None, "100:50"))
+        self.assertTrue(IS05Utils.check_requested_time(IMMEDIATE_ACTIVATION,
+                                                       "100:49", None, "100:50"))
+
+    def test_immediate_activation_rejects_missing_or_malformed_requested_time(self):
+        for requested_time in (None, "", "100", "100:not-nanoseconds"):
+            with self.subTest(requested_time=requested_time):
+                self.assertFalse(IS05Utils.check_requested_time(IMMEDIATE_ACTIVATION,
+                                                                requested_time, None, "100:50"))
+
+    def test_immediate_activation_rejects_requested_time_after_activation(self):
+        self.assertFalse(IS05Utils.check_requested_time(IMMEDIATE_ACTIVATION,
+                                                        "100:51", None, "100:50"))
+
+    def test_immediate_activation_rejects_missing_activation_time(self):
+        self.assertFalse(IS05Utils.check_requested_time(IMMEDIATE_ACTIVATION,
+                                                        "100:50", None, None))
+
+    def test_scheduled_activation_requires_the_requested_time(self):
+        self.assertTrue(IS05Utils.check_requested_time(SCHEDULED_ABSOLUTE_ACTIVATION,
+                                                       "100:50", "100:50", "100:51"))
+        self.assertFalse(IS05Utils.check_requested_time(SCHEDULED_ABSOLUTE_ACTIVATION,
+                                                        "100:49", "100:50", "100:51"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- validate that `/active` reports a non-null TAI `requested_time` after an immediate activation
- require `requested_time` to be no later than `activation_time`
- reject missing or malformed activation timestamps without raising an exception
- update the mock Node so PATCH `/staged` retains its null `requested_time`, while GET `/active` reports an activation timestamp
- add focused regression tests for immediate and scheduled activation semantics

## Validation

At signed commit `1aed76331be399119fbe2a221fcedd94a1db7ac6`:

- `.venv/bin/python -m unittest discover -s tests -v` — 5 tests pass
- `.venv/bin/flake8 nmostesting/IS05Utils.py nmostesting/mocks/Node.py tests/test_is05_utils.py`
- Python bytecode compilation for all changed Python files
- `git diff --check`

Closes #840